### PR TITLE
Fix unbound variable error in sbx script

### DIFF
--- a/bin/sbx-manager.sh
+++ b/bin/sbx-manager.sh
@@ -85,7 +85,7 @@ ${B}Examples:${N}
 EOF
 }
 
-case "$1" in
+case "${1:-}" in
     status)
         echo -e "${B}=== Service Status ===${N}"
         echo "[sing-box]"


### PR DESCRIPTION
Fix strict mode (-u) compatibility issue where `sbx` command fails with "$1: unbound variable" error when invoked without arguments.

Changes:
- bin/sbx-manager.sh:88: Change `case "$1"` to `case "${1:-}"`
- Use safe parameter expansion to provide empty string default
- Maintains existing error handling via wildcard case block

Impact:
- No more crashes when running `sbx` without arguments
- Proper error message "Unknown command: " now displayed
- All valid commands (help, status, etc.) continue to work correctly

Tested:
- sbx (no args) → Shows usage help with exit code 1 ✓
- sbx help → Shows usage help with exit code 0 ✓