### PR TITLE
Replace old repository links with new ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ One-click deployment script for sing-box proxy server with VLESS-REALITY support
 
 **Install (Reality mode, no domain required)**
 ```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/Joe-oss9527/sbx-lite/main/install_multi.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/xrf9268-hue/sbx/main/install_multi.sh)
 ```
 
 **Install with domain (enables WS-TLS + Hysteria2)**
 ```bash
-DOMAIN=your.domain.com bash <(curl -fsSL https://raw.githubusercontent.com/Joe-oss9527/sbx-lite/main/install_multi.sh)
+DOMAIN=your.domain.com bash <(curl -fsSL https://raw.githubusercontent.com/xrf9268-hue/sbx/main/install_multi.sh)
 ```
 
 After installation, connection URIs are displayed automatically. Copy them to your client.
@@ -63,7 +63,7 @@ sbx log           # View error messages
 **Installation issues - Enable debug logging**
 ```bash
 # Run with detailed debug output and timestamps
-DEBUG=1 LOG_TIMESTAMPS=1 bash <(curl -fsSL https://raw.githubusercontent.com/Joe-oss9527/sbx-lite/main/install_multi.sh)
+DEBUG=1 LOG_TIMESTAMPS=1 bash <(curl -fsSL https://raw.githubusercontent.com/xrf9268-hue/sbx/main/install_multi.sh)
 
 # Save debug log to file for sharing
 DEBUG=1 LOG_FILE=/tmp/install-debug.log bash <(curl -fsSL ...)

--- a/docs/improvements/README.md
+++ b/docs/improvements/README.md
@@ -192,7 +192,7 @@ Phase 4: ⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 0% (0/4)
 ## 📞 联系与支持
 
 ### 问题反馈
-- GitHub Issues: [Create Issue](https://github.com/Joe-oss9527/sbx-lite/issues)
+- GitHub Issues: [Create Issue](https://github.com/xrf9268-hue/sbx/issues)
 - 计划问题: 在改进计划文档中记录
 
 ### 审查请求

--- a/install_multi.sh
+++ b/install_multi.sh
@@ -242,7 +242,7 @@ _show_download_error_help() {
     echo "Troubleshooting:"
     echo "  • Test connectivity: curl -I https://github.com"
     echo "  • Use git clone instead:"
-    echo "    git clone https://github.com/Joe-oss9527/sbx-lite.git"
+    echo "    git clone https://github.com/xrf9268-hue/sbx.git"
     echo "    cd sbx-lite && bash install_multi.sh"
     echo ""
 }
@@ -298,7 +298,7 @@ _show_syntax_error() {
 
 # Smart module loader: downloads modules if not present (for one-liner install)
 _load_modules() {
-    local github_repo="https://raw.githubusercontent.com/Joe-oss9527/sbx-lite/main"
+    local github_repo="https://raw.githubusercontent.com/xrf9268-hue/sbx/main"
     # Module loading order: common loads logging and generators, tools after common
     local modules=(common logging generators tools retry download network validation checksum version certificate caddy config config_validator service ui backup export messages)
     local temp_lib_dir=""
@@ -500,7 +500,7 @@ _verify_module_apis() {
         echo "  3. Corrupted module files"
         echo ""
         echo "Please try:"
-        echo "  git clone https://github.com/Joe-oss9527/sbx-lite.git"
+        echo "  git clone https://github.com/xrf9268-hue/sbx.git"
         echo "  cd sbx-lite && bash install_multi.sh"
         echo ""
         exit 1
@@ -1030,7 +1030,7 @@ EOF
         warn "     - 'sbx export' and 'sbx backup' commands not available"
         warn ""
         warn "  To get full functionality, please reinstall or manually download:"
-        warn "  curl -fsSL https://raw.githubusercontent.com/Joe-oss9527/sbx-lite/main/bin/sbx-manager.sh \\"
+        warn "  curl -fsSL https://raw.githubusercontent.com/xrf9268-hue/sbx/main/bin/sbx-manager.sh \\"
         warn "    -o /usr/local/bin/sbx-manager && chmod 755 /usr/local/bin/sbx-manager"
     fi
 }

--- a/tests/unit/test_tools.sh
+++ b/tests/unit/test_tools.sh
@@ -156,7 +156,7 @@ test_http_operations() {
     echo "Testing HTTP operations..."
 
     # Test 1: http_download creates output file
-    local test_url="https://raw.githubusercontent.com/Joe-oss9527/sbx-lite/main/README.md"
+    local test_url="https://raw.githubusercontent.com/xrf9268-hue/sbx/main/README.md"
     local output_file="/tmp/test_http_download_$$"
 
     if http_download "$test_url" "$output_file" 10 2>/dev/null; then
@@ -180,7 +180,7 @@ test_http_operations() {
 
     # Test 3: http_fetch returns content
     local content
-    content=$(http_fetch "https://raw.githubusercontent.com/Joe-oss9527/sbx-lite/main/README.md" 10 2>/dev/null | head -1) || true
+    content=$(http_fetch "https://raw.githubusercontent.com/xrf9268-hue/sbx/main/README.md" 10 2>/dev/null | head -1) || true
     if [[ -n "$content" ]]; then
         test_result "http_fetch returns content" "pass"
     else


### PR DESCRIPTION
…ue/sbx

Updated all repository references across the codebase:
- README.md: 3 occurrences in installation commands
- install_multi.sh: 4 occurrences in module download URLs and error messages
- docs/improvements/README.md: 1 occurrence in GitHub Issues link
- tests/unit/test_tools.sh: 2 occurrences in test URLs

All links now point to the new repository location.