### PR TITLE
Fix sing-box installation script IP detection error

### DIFF
--- a/install_multi.sh
+++ b/install_multi.sh
@@ -24,6 +24,9 @@ readonly HTTP_DOWNLOAD_TIMEOUT_SEC=30  # For safe_http_get() during bootstrap
 readonly MIN_MODULE_FILE_SIZE_BYTES=100
 readonly MIN_MANAGER_FILE_SIZE_BYTES=5000  # Manager script validation (~15KB expected)
 
+# Network configuration
+readonly NETWORK_TIMEOUT_SEC=5  # Used by get_public_ip() during bootstrap
+
 # File permissions (octal)
 readonly SECURE_DIR_PERMISSIONS=700
 readonly SECURE_FILE_PERMISSIONS=600

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -44,7 +44,8 @@ declare -r CERT_DIR_BASE="${CERT_DIR_BASE:-/etc/ssl/sbx}"
 declare -r LOG_LEVEL="${LOG_LEVEL:-warn}"
 
 # Operation timeouts and retry limits
-declare -r NETWORK_TIMEOUT_SEC=5
+# NETWORK_TIMEOUT_SEC defined in install_multi.sh early constants for bootstrap
+[[ -z "${NETWORK_TIMEOUT_SEC:-}" ]] && declare -r NETWORK_TIMEOUT_SEC=5
 declare -r SERVICE_STARTUP_MAX_WAIT_SEC=10
 declare -r SERVICE_PORT_VALIDATION_MAX_RETRIES=5
 declare -r PORT_ALLOCATION_MAX_RETRIES=3


### PR DESCRIPTION
**Problem:**
Installation failed with "NETWORK_TIMEOUT_SEC: unbound variable" error when get_public_ip() was called during bootstrap phase. This occurred during one-liner installations where modules are downloaded to temp directory before being sourced.

**Root Cause:**
NETWORK_TIMEOUT_SEC was defined only in lib/common.sh, but get_public_ip() in lib/network.sh needs this constant available during early bootstrap before all modules are fully loaded. The strict mode (set -u) caused immediate failure on undefined variable access.

**Solution:**
Following the bootstrap pattern documented in CLAUDE.md:
1. Added NETWORK_TIMEOUT_SEC=5 to install_multi.sh early constants section
2. Made lib/common.sh declaration conditional to avoid conflicts: [[ -z "${NETWORK_TIMEOUT_SEC:-}" ]] && declare -r NETWORK_TIMEOUT_SEC=5

This matches the pattern used for HTTP_DOWNLOAD_TIMEOUT_SEC and other bootstrap-phase constants.

**Testing:**
- Syntax validation: bash -n (passed)
- Installation flow: IP detection now works during bootstrap
- No breaking changes to existing functionality

**References:**
- CLAUDE.md "Bootstrapping Fixes" section
- Similar fix: HTTP_DOWNLOAD_TIMEOUT_SEC (commit a078273)
- Error pattern: Same as previous unbound variable bugs (commits 49e4b91, a078273)