### PR TITLE
Code review for quality and security

### DIFF
--- a/.claude/scripts/format-shell.sh
+++ b/.claude/scripts/format-shell.sh
@@ -16,6 +16,23 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m'
 
+# Check if jq is available (required to parse hook input)
+if ! command -v jq >/dev/null 2>&1; then
+  cat >&2 <<'EOF'
+┌─────────────────────────────────────────────────────────────┐
+│ ⚠️  jq Not Installed (Required for Claude Hooks)            │
+├─────────────────────────────────────────────────────────────┤
+│ Install jq to enable automatic shell script hooks:          │
+│                                                              │
+│   Debian/Ubuntu:  sudo apt install jq                       │
+│   macOS:          brew install jq                           │
+│                                                              │
+│ The SessionStart hook normally installs this automatically. │
+└─────────────────────────────────────────────────────────────┘
+EOF
+  exit 1
+fi
+
 # Read hook input from stdin
 INPUT=$(cat)
 
@@ -92,7 +109,7 @@ EOF
     exit 0
 else
     # Formatting failed - likely syntax error
-    echo -e "${RED}✗${NC} Failed to format $FILE_PATH - syntax error?" >&2
+    echo -e "${RED}✗${NC} Failed to format \"$FILE_PATH\" - syntax error?" >&2
     echo "  Run: shfmt -d \"$FILE_PATH\"" >&2
     # Non-blocking error
     exit 1

--- a/.claude/scripts/lint-shell.sh
+++ b/.claude/scripts/lint-shell.sh
@@ -16,6 +16,23 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m'
 
+# Check if jq is available (required to parse hook input)
+if ! command -v jq >/dev/null 2>&1; then
+  cat >&2 <<'EOF'
+┌─────────────────────────────────────────────────────────────┐
+│ ⚠️  jq Not Installed (Required for Claude Hooks)            │
+├─────────────────────────────────────────────────────────────┤
+│ Install jq to enable automatic shell script hooks:          │
+│                                                              │
+│   Debian/Ubuntu:  sudo apt install jq                       │
+│   macOS:          brew install jq                           │
+│                                                              │
+│ The SessionStart hook normally installs this automatically. │
+└─────────────────────────────────────────────────────────────┘
+EOF
+  exit 1
+fi
+
 # Read hook input from stdin
 INPUT=$(cat)
 


### PR DESCRIPTION
Code review follow-up fixes for PostToolUse hooks:

- Add jq availability check to both format-shell.sh and lint-shell.sh to prevent cryptic errors if jq is missing (edge case race condition)
- Fix variable quoting consistency in format-shell.sh error message (line 112: $FILE_PATH -> "$FILE_PATH")
- Provide helpful installation instructions when jq is not found

All changes maintain backward compatibility and follow project coding standards (CLAUDE.md, CODING_STANDARDS.md).