### PR TITLE
Rename install_multi.sh to install.sh

### DIFF
--- a/.claude/ARCHITECTURE.md
+++ b/.claude/ARCHITECTURE.md
@@ -4,7 +4,7 @@ Technical architecture and module organization for sbx-lite.
 
 ## Modular Structure (v2.2.0)
 
-**Main:** `install_multi.sh` (~583 lines) - Orchestrates installation
+**Main:** `install.sh` (~583 lines) - Orchestrates installation
 **Library:** `lib/` directory (11 modules, 3,523 lines total)
 
 ## Key Modules

--- a/.claude/CODING_STANDARDS.md
+++ b/.claude/CODING_STANDARDS.md
@@ -77,7 +77,7 @@ fi
 ```
 
 **Real production bugs caused by this:**
-1. `url` variable (install_multi.sh:836) - Installation failed on 90% of systems
+1. `url` variable (install.sh:836) - Installation failed on 90% of systems
 2. `HTTP_DOWNLOAD_TIMEOUT_SEC` - GitHub API completely broken
 3. `get_file_size()` - Bootstrap failures preventing installation
 
@@ -117,11 +117,11 @@ fi
 **MANDATORY: Test before committing**
 ```bash
 # Test with strict mode to catch unbound variables
-bash -u install_multi.sh  # Must NOT show "unbound variable" errors
+bash -u install.sh  # Must NOT show "unbound variable" errors
 bash -u lib/your_module.sh  # Test individual modules
 
 # Syntax validation
-bash -n install_multi.sh
+bash -n install.sh
 bash -n lib/your_module.sh
 ```
 

--- a/.claude/CONSTANTS_REFERENCE.md
+++ b/.claude/CONSTANTS_REFERENCE.md
@@ -66,7 +66,7 @@ All constants defined in `lib/common.sh` and available globally after module loa
 
 **Where to define:**
 - `lib/common.sh` - Global constants used across modules
-- `install_multi.sh (early)` - Boot-time constants before module loading
+- `install.sh (early)` - Boot-time constants before module loading
 - Module-specific - Only if truly module-internal
 
 **Naming conventions:**

--- a/.claude/HOOKS_GUIDE.md
+++ b/.claude/HOOKS_GUIDE.md
@@ -53,7 +53,7 @@ sbx-lite uses two types of hooks to maintain code quality:
 **Triggered by:** Edit or Write operations on `.sh` files
 
 **What it does:**
-1. Detects shell script edits (`.sh` files, `install_multi.sh`)
+1. Detects shell script edits (`.sh` files, `install.sh`)
 2. **Step 1:** Formats code with `shfmt` (if installed)
 3. **Step 2:** Lints the **formatted** result with `shellcheck` (if installed)
 4. Provides install instructions if tools missing
@@ -324,8 +324,8 @@ shfmt -w -i 4 -bn -ci "$FILE_PATH"
 Edit the pattern matching in `format-and-lint-shell.sh`:
 
 ```bash
-# Current: Only .sh files and install_multi.sh
-if [[ ! "$FILE_PATH" =~ \.(sh)$ ]] && [[ ! "$FILE_PATH" != "install_multi.sh" ]]; then
+# Current: Only .sh files and install.sh
+if [[ ! "$FILE_PATH" =~ \.(sh)$ ]] && [[ ! "$FILE_PATH" != "install.sh" ]]; then
     exit 0
 fi
 
@@ -393,7 +393,7 @@ claude --debug
 
 **Issue 1: Hook not running**
 - Check `/hooks` to verify registration
-- Ensure file has `.sh` extension or is `install_multi.sh`
+- Ensure file has `.sh` extension or is `install.sh`
 - Verify `.claude/scripts/format-and-lint-shell.sh` is executable: `ls -la .claude/scripts/`
 
 **Issue 2: "shfmt: command not found"**
@@ -441,7 +441,7 @@ claude --debug
 |------|-------|-------------|-----------|-------|
 | lib/common.sh | 253 | ~100ms | ~150ms | ~250ms |
 | lib/network.sh | 300+ | ~150ms | ~200ms | ~350ms |
-| install_multi.sh | 600+ | ~300ms | ~400ms | ~700ms |
+| install.sh | 600+ | ~300ms | ~400ms | ~700ms |
 
 ### Impact on Workflow
 

--- a/.claude/REALITY_CONFIG.md
+++ b/.claude/REALITY_CONFIG.md
@@ -66,11 +66,11 @@ systemctl is-active sing-box || die "Service failed"
 
 ```bash
 # Enable full debug logging
-DEBUG=1 LOG_TIMESTAMPS=1 LOG_FILE=/tmp/debug.log bash install_multi.sh
+DEBUG=1 LOG_TIMESTAMPS=1 LOG_FILE=/tmp/debug.log bash install.sh
 
 # Check for errors
 grep -i error /tmp/debug.log
 
 # Test in strict mode (like CI)
-bash -e install_multi.sh
+bash -e install.sh
 ```

--- a/.claude/WORKFLOWS.md
+++ b/.claude/WORKFLOWS.md
@@ -205,7 +205,7 @@ make check
 bash tests/integration/test_reality_connection.sh
 
 # 4. Actual installation works
-bash install_multi.sh
+bash install.sh
 ```
 
 ### Independent Verification (Critical Features)

--- a/.claude/scripts/format-and-lint-shell.sh
+++ b/.claude/scripts/format-and-lint-shell.sh
@@ -50,7 +50,7 @@ if [[ -z "$FILE_PATH" ]]; then
 fi
 
 # Only process shell script files
-if [[ ! "$FILE_PATH" =~ \.(sh)$ ]] && [[ ! "$FILE_PATH" != "install_multi.sh" ]]; then
+if [[ ! "$FILE_PATH" =~ \.(sh)$ ]] && [[ ! "$FILE_PATH" != "install.sh" ]]; then
     exit 0
 fi
 

--- a/.claude/scripts/session-start.sh
+++ b/.claude/scripts/session-start.sh
@@ -208,7 +208,7 @@ echo "  Quick Commands:"
 echo "    bash tests/test-runner.sh unit    # Run all unit tests"
 echo "    bash tests/unit/test_bootstrap_constants.sh    # Validate bootstrap"
 echo "    bash hooks/install-hooks.sh       # Reinstall git hooks"
-echo "    bash install_multi.sh --help      # Installation help"
+echo "    bash install.sh --help      # Installation help"
 echo ""
 
 # Documentation links

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -59,7 +59,7 @@ jobs:
           count=0
           failed_files=()
 
-          for script in install_multi.sh lib/*.sh bin/*.sh; do
+          for script in install.sh lib/*.sh bin/*.sh; do
             [[ -f "$script" ]] || continue
             count=$((count + 1))
             echo "[$count] Checking $script..."
@@ -107,7 +107,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
 
           error_count=0
-          for script in install_multi.sh lib/*.sh bin/*.sh; do
+          for script in install.sh lib/*.sh bin/*.sh; do
             [[ -f "$script" ]] || continue
             if bash -n "$script" 2>&1; then
               echo "✓ $script" >> $GITHUB_STEP_SUMMARY
@@ -163,7 +163,7 @@ jobs:
           echo "## Shebang Compliance" >> $GITHUB_STEP_SUMMARY
 
           error_count=0
-          for script in install_multi.sh lib/*.sh bin/*.sh; do
+          for script in install.sh lib/*.sh bin/*.sh; do
             [[ -f "$script" ]] || continue
             if ! head -1 "$script" | grep -q '^#!/'; then
               echo "❌ Missing shebang: $script" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,7 +91,7 @@ jobs:
 
           # Test syntax with unbound variable detection (bash -nu)
           # This validates early constants without executing the script
-          if bash -nu install_multi.sh 2>&1 | tee /tmp/strict-test.log; then
+          if bash -nu install.sh 2>&1 | tee /tmp/strict-test.log; then
             echo "✅ Syntax valid, no unbound variables in early initialization" >> $GITHUB_STEP_SUMMARY
           else
             echo "❌ Syntax errors or unbound variables found" >> $GITHUB_STEP_SUMMARY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -277,10 +277,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ♻️ Refactored
 #### Integrated Tool Abstraction in Checksum Module
-- **Files**: `lib/checksum.sh`, `install_multi.sh`
+- **Files**: `lib/checksum.sh`, `install.sh`
 - **Changes**:
   - Updated `lib/checksum.sh` to use `crypto_sha256()` from `lib/tools.sh`
-  - Added `tools` module to loading sequence in `install_multi.sh`
+  - Added `tools` module to loading sequence in `install.sh`
   - Replaced direct sha256sum/shasum calls
   - Reduced checksum calculation from 10 lines to 5
 - **Benefits**:
@@ -314,7 +314,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Created `lib/generators.sh` (238 lines) - UUID, Reality keypair, hex string, QR code generation
   - Reduced `lib/common.sh` to core utilities only (253 lines)
   - Automatic module sourcing in `lib/common.sh` for backward compatibility
-  - Updated `install_multi.sh` to include new modules in loading sequence
+  - Updated `install.sh` to include new modules in loading sequence
 - **Benefits**:
   - 59% reduction in common.sh size (359 lines moved out)
   - Better separation of concerns (Single Responsibility Principle)
@@ -430,11 +430,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Ref**: Phase 1 Task 1.2 (HIGH priority)
 
 #### Extracted File Size Utility Function (MEDIUM)
-- **Files**: `lib/common.sh`, `install_multi.sh`
+- **Files**: `lib/common.sh`, `install.sh`
 - **Changes**:
   - Created `get_file_size()` function in lib/common.sh
   - Supports both Linux (`stat -c%s`) and BSD/macOS (`stat -f%z`)
-  - Replaced 3 duplicated implementations in install_multi.sh (lines 80, 205, 394)
+  - Replaced 3 duplicated implementations in install.sh (lines 80, 205, 394)
   - Added comprehensive documentation
   - Exported function for module use
 - **Benefits**:
@@ -499,7 +499,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Testing**: Created `tests/unit/test_strict_mode.sh` with 14 validation tests (all passing)
 
 #### Extracted Magic Numbers to Named Constants (MEDIUM PRIORITY)
-- **Scope**: `lib/common.sh`, `install_multi.sh`, `lib/validation.sh`, `lib/service.sh`
+- **Scope**: `lib/common.sh`, `install.sh`, `lib/validation.sh`, `lib/service.sh`
 - **New Constants Defined**:
   - **Download**: `DOWNLOAD_CONNECT_TIMEOUT_SEC=10`, `DOWNLOAD_MAX_TIMEOUT_SEC=30`
   - **File Sizes**: `MIN_MODULE_FILE_SIZE_BYTES=100`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ fi
 
 **How to prevent:**
 1. Initialize all local variables: `local var="" other="" more=""`
-2. Test with strict mode: `bash -u install_multi.sh`
+2. Test with strict mode: `bash -u install.sh`
 3. Check the pre-commit checklist in "Bootstrapping Fixes" section below
 
 **2. Reality Protocol Configuration Errors**
@@ -114,8 +114,8 @@ See @.claude/REALITY_CONFIG.md for full details:
 Always run after ANY configuration or code change:
 ```bash
 sing-box check -c /etc/sing-box/config.json
-bash -u install_multi.sh  # Test for unbound variables
-bash -n install_multi.sh  # Syntax check
+bash -u install.sh  # Test for unbound variables
+bash -n install.sh  # Syntax check
 ```
 
 **4. Claude Code Hooks - Parallel Execution Race Conditions** 🔴 **CRITICAL**
@@ -178,8 +178,8 @@ systemctl restart sing-box && sleep 3 && systemctl status sing-box
 journalctl -u sing-box -f  # Monitor for 10-15 seconds
 
 # Test installation
-bash install_multi.sh  # Reality-only (auto-detect IP)
-DOMAIN=test.domain.com bash install_multi.sh  # Full setup
+bash install.sh  # Reality-only (auto-detect IP)
+DOMAIN=test.domain.com bash install.sh  # Full setup
 
 # Unit tests
 bash tests/test_reality.sh
@@ -271,7 +271,7 @@ When adding constants or functions that are:
 3. Called from sourced modules during initialization
 
 **Apply this pattern:**
-1. Add to `install_multi.sh` early constants section (lines 16-29)
+1. Add to `install.sh` early constants section (lines 16-29)
 2. Make module declaration conditional: `if [[ -z "${VAR:-}" ]]; then declare -r VAR=value; fi`
 3. Document in commit message and CLAUDE.md
 4. Test bootstrap scenario: one-liner installation without git clone
@@ -279,7 +279,7 @@ When adding constants or functions that are:
 **Implemented Fixes:**
 - Fix 1: `get_file_size()` function - Available before module loading
 - Fix 2: `HTTP_DOWNLOAD_TIMEOUT_SEC` constant - Available for safe_http_get() (commit a078273)
-- Fix 3: `url` variable initialization - Prevent unbound variable in conditional flow (install_multi.sh:836)
+- Fix 3: `url` variable initialization - Prevent unbound variable in conditional flow (install.sh:836)
 
 ### Variable Initialization Pattern (CRITICAL - DO NOT SKIP)
 
@@ -301,7 +301,7 @@ fi
 ```
 
 **Real-world failures this pattern has caused:**
-- `url` variable (install_multi.sh:836) - Installation failed on glibc systems
+- `url` variable (install.sh:836) - Installation failed on glibc systems
 - `HTTP_DOWNLOAD_TIMEOUT_SEC` - GitHub API fetches failed
 - Multiple other instances caught during audits
 
@@ -356,8 +356,8 @@ Before committing code with local variables:
 **Manual testing (if needed):**
 ```bash
 # Test your changes with strict mode (hooks run this automatically)
-bash -u install_multi.sh  # Should NOT show "unbound variable" errors
-bash -n install_multi.sh  # Should pass syntax check
+bash -u install.sh  # Should NOT show "unbound variable" errors
+bash -n install.sh  # Should pass syntax check
 ```
 
 **Error Signatures:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,7 +165,7 @@ All bash scripts MUST:
 
 When adding constants used during bootstrap (before module loading):
 
-1. **Add to `install_multi.sh` early section (lines 16-44):**
+1. **Add to `install.sh` early section (lines 16-44):**
    ```bash
    readonly MY_NEW_CONSTANT=value
    ```
@@ -207,7 +207,7 @@ bash tests/test-runner.sh unit
 bash tests/unit/test_bootstrap_constants.sh
 
 # Test with strict mode
-bash -u install_multi.sh --help
+bash -u install.sh --help
 ```
 
 ### Test-Driven Development (TDD)
@@ -283,7 +283,7 @@ Fixes bootstrap failure when REALITY_SHORT_ID_MIN_LENGTH was
 accessed before module loading completed.
 
 Changes:
-- Added constant to install_multi.sh early section
+- Added constant to install.sh early section
 - Updated lib/common.sh to use conditional declaration
 - Added test coverage in test_bootstrap_constants.sh
 
@@ -308,7 +308,7 @@ Root cause: lib/config.sh referenced REALITY_FLOW_VISION during
 configuration generation, but the constant wasn't defined until
 lib/common.sh loaded (after bootstrap).
 
-Solution: Added REALITY_FLOW_VISION to install_multi.sh early
+Solution: Added REALITY_FLOW_VISION to install.sh early
 constants section following the established bootstrap pattern
 documented in CLAUDE.md.
 
@@ -316,7 +316,7 @@ This prevents installation failures on systems without pre-existing
 sing-box installations.
 
 Testing:
-- bash -u install_multi.sh (no unbound variable errors)
+- bash -u install.sh (no unbound variable errors)
 - tests/unit/test_bootstrap_constants.sh (10/10 pass)
 
 Related: Similar fix for REALITY_SHORT_ID_MIN_LENGTH in commit abc123
@@ -345,7 +345,7 @@ Related: Similar fix for REALITY_SHORT_ID_MIN_LENGTH in commit abc123
 Missing constants: MY_NEW_CONSTANT
 
 Remediation:
-  1. Add missing constant to install_multi.sh early section (lines 16-44)
+  1. Add missing constant to install.sh early section (lines 16-44)
   2. Update lib/common.sh with conditional declaration
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -37,14 +37,14 @@ lint:
 		echo "Error: shellcheck not installed. Install with: apt install shellcheck"; \
 		exit 1; \
 	}
-	@shellcheck -x -S warning install_multi.sh lib/*.sh 2>/dev/null || \
+	@shellcheck -x -S warning install.sh lib/*.sh 2>/dev/null || \
 		(echo "✗ ShellCheck found issues"; exit 1)
 	@echo "✓ ShellCheck passed"
 
 # Syntax validation
 syntax:
 	@echo "→ Checking syntax..."
-	@for script in install_multi.sh lib/*.sh; do \
+	@for script in install.sh lib/*.sh; do \
 		[ -f "$$script" ] || continue; \
 		echo "  Checking $$script..."; \
 		bash -n "$$script" || exit 1; \

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 ### Basic Installation (Reality-only, no domain required)
 
 ```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/xrf9268-hue/sbx/main/install_multi.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/xrf9268-hue/sbx/main/install.sh)
 ```
 
 After installation, connection URIs are displayed automatically. Copy and paste them into your client.
@@ -28,7 +28,7 @@ After installation, connection URIs are displayed automatically. Copy and paste 
 ### Advanced Installation (with domain for multi-protocol)
 
 ```bash
-DOMAIN=your.domain.com bash <(curl -fsSL https://raw.githubusercontent.com/xrf9268-hue/sbx/main/install_multi.sh)
+DOMAIN=your.domain.com bash <(curl -fsSL https://raw.githubusercontent.com/xrf9268-hue/sbx/main/install.sh)
 ```
 
 This enables VLESS-WS-TLS and Hysteria2 in addition to VLESS-REALITY.
@@ -111,10 +111,10 @@ Enable debug logging to diagnose problems:
 
 ```bash
 # Debug mode with timestamps
-DEBUG=1 LOG_TIMESTAMPS=1 bash <(curl -fsSL https://raw.githubusercontent.com/xrf9268-hue/sbx/main/install_multi.sh)
+DEBUG=1 LOG_TIMESTAMPS=1 bash <(curl -fsSL https://raw.githubusercontent.com/xrf9268-hue/sbx/main/install.sh)
 
 # Save debug log to file
-DEBUG=1 LOG_FILE=/tmp/install-debug.log bash <(curl -fsSL https://raw.githubusercontent.com/xrf9268-hue/sbx/main/install_multi.sh)
+DEBUG=1 LOG_FILE=/tmp/install-debug.log bash <(curl -fsSL https://raw.githubusercontent.com/xrf9268-hue/sbx/main/install.sh)
 ```
 
 ### Common Problems
@@ -164,13 +164,13 @@ LOG_LEVEL_FILTER=ERROR               # Filter by severity
 
 ```bash
 # Install latest stable version (default)
-bash <(curl -fsSL https://raw.githubusercontent.com/xrf9268-hue/sbx/main/install_multi.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/xrf9268-hue/sbx/main/install.sh)
 
 # Install specific version
-SINGBOX_VERSION=v1.10.7 bash <(curl -fsSL https://raw.githubusercontent.com/xrf9268-hue/sbx/main/install_multi.sh)
+SINGBOX_VERSION=v1.10.7 bash <(curl -fsSL https://raw.githubusercontent.com/xrf9268-hue/sbx/main/install.sh)
 
 # Install latest including pre-releases
-SINGBOX_VERSION=latest bash <(curl -fsSL https://raw.githubusercontent.com/xrf9268-hue/sbx/main/install_multi.sh)
+SINGBOX_VERSION=latest bash <(curl -fsSL https://raw.githubusercontent.com/xrf9268-hue/sbx/main/install.sh)
 ```
 
 ## System Requirements

--- a/bin/sbx-manager.sh
+++ b/bin/sbx-manager.sh
@@ -127,7 +127,7 @@ case "${1:-}" in
             done
             echo
             echo -e "${Y}[INFO]${N} Generated URIs may be invalid or incomplete."
-            echo -e "${Y}[INFO]${N} Please run: ${B}bash install_multi.sh${N} to reinstall."
+            echo -e "${Y}[INFO]${N} Please run: ${B}bash install.sh${N} to reinstall."
             echo
         fi
 

--- a/docs/REALITY_BEST_PRACTICES.md
+++ b/docs/REALITY_BEST_PRACTICES.md
@@ -360,7 +360,7 @@ sudo sysctl -p
 **Deployment:**
 ```bash
 # Using sbx-lite
-bash <(curl -fsSL https://raw.githubusercontent.com/xrf9268-hue/sbx/main/install_multi.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/xrf9268-hue/sbx/main/install.sh)
 ```
 
 ---

--- a/docs/SING_BOX_VS_XRAY.md
+++ b/docs/SING_BOX_VS_XRAY.md
@@ -365,7 +365,7 @@ Fix: Switch core to sing-box as described above
 4. **Install sbx-lite**
    ```bash
    # This will prompt for configuration
-   bash <(curl -fsSL https://raw.githubusercontent.com/xrf9268-hue/sbx/main/install_multi.sh)
+   bash <(curl -fsSL https://raw.githubusercontent.com/xrf9268-hue/sbx/main/install.sh)
    ```
 
 5. **Update Client-Info with Your Keys**
@@ -472,7 +472,7 @@ sudo jq -r '.inbounds[0].tls.reality.short_id[0]' /etc/sing-box/config.json | wc
 
 2. **Install sbx-lite**
    ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/xrf9268-hue/sbx/main/install_multi.sh)
+   bash <(curl -fsSL https://raw.githubusercontent.com/xrf9268-hue/sbx/main/install.sh)
    ```
 
 3. **Get connection info**

--- a/examples/reality-only/README.md
+++ b/examples/reality-only/README.md
@@ -79,7 +79,7 @@ sing-box check -c server-config.json
 sbx-lite automatically generates all materials and configurations:
 
 ```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/xrf9268-hue/sbx/main/install_multi.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/xrf9268-hue/sbx/main/install.sh)
 ```
 
 **Option B: Manual Deployment**

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -35,9 +35,9 @@ echo -e "${BLUE}[1/5]${NC} Checking bash syntax..."
 
 syntax_errors=0
 # Check main installer
-if ! bash -n install_multi.sh 2>/dev/null; then
-    echo -e "${RED}✗ FAIL${NC}: install_multi.sh has syntax errors"
-    bash -n install_multi.sh
+if ! bash -n install.sh 2>/dev/null; then
+    echo -e "${RED}✗ FAIL${NC}: install.sh has syntax errors"
+    bash -n install.sh
     syntax_errors=$((syntax_errors + 1))
 fi
 
@@ -82,7 +82,7 @@ else
     echo ""
     echo -e "${YELLOW}Remediation:${NC}"
     echo "  1. Check which constants are missing: cat /tmp/pre-commit-bootstrap.log"
-    echo "  2. Add missing constants to install_multi.sh early section (lines 16-44)"
+    echo "  2. Add missing constants to install.sh early section (lines 16-44)"
     echo "  3. Update lib/common.sh with conditional declarations"
     echo "  4. See tests/unit/README_BOOTSTRAP_TESTS.md for detailed guide"
     CHECKS_FAILED=$((CHECKS_FAILED + 1))
@@ -97,9 +97,9 @@ echo -e "${BLUE}[3/5]${NC} Checking strict mode (set -euo pipefail)..."
 
 missing_strict_mode=()
 
-# Check install_multi.sh
-if ! grep -q "^set -euo pipefail" install_multi.sh; then
-    missing_strict_mode+=("install_multi.sh")
+# Check install.sh
+if ! grep -q "^set -euo pipefail" install.sh; then
+    missing_strict_mode+=("install.sh")
 fi
 
 # Check all library modules
@@ -138,7 +138,7 @@ if command -v shellcheck >/dev/null 2>&1; then
     shellcheck_errors=0
 
     # Check main files with moderate severity
-    for file in install_multi.sh lib/*.sh bin/sbx-manager.sh; do
+    for file in install.sh lib/*.sh bin/sbx-manager.sh; do
         [[ ! -f "$file" ]] && continue
 
         # Exclude some style warnings
@@ -170,7 +170,7 @@ echo ""
 echo -e "${BLUE}[5/5]${NC} Testing for unbound variables (bash -u)..."
 
 # Test that help text works without unbound variables
-unbound_test=$(timeout 5 bash -u install_multi.sh --help 2>&1 || true)
+unbound_test=$(timeout 5 bash -u install.sh --help 2>&1 || true)
 
 if echo "$unbound_test" | grep -q "unbound variable"; then
     echo -e "${RED}✗ FAIL${NC}: Found unbound variable usage"

--- a/install.sh
+++ b/install.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
-# install_multi.sh v2.0 - Modular sing-box installer
+# install.sh v2.0 - Modular sing-box installer
 # One-click official sing-box with VLESS-REALITY, VLESS-WS-TLS, and Hysteria2
 #
 # Usage (install):
-#   bash install_multi.sh                                    # Interactive mode
-#   AUTO_INSTALL=1 bash install_multi.sh                     # Non-interactive (auto-detect IP)
-#   DOMAIN=example.com bash install_multi.sh                 # Full setup with domain
+#   bash install.sh                                    # Interactive mode
+#   AUTO_INSTALL=1 bash install.sh                     # Non-interactive (auto-detect IP)
+#   DOMAIN=example.com bash install.sh                 # Full setup with domain
 #   DOMAIN=example.com CERT_MODE=cf_dns CF_Token='xxx' ...  # With certificates
 #
 # Usage (uninstall):
-#   FORCE=1 bash install_multi.sh uninstall
+#   FORCE=1 bash install.sh uninstall
 
 set -euo pipefail
 
@@ -281,7 +281,7 @@ _show_download_error_help() {
     echo "  • Test connectivity: curl -I https://github.com"
     echo "  • Use git clone instead:"
     echo "    git clone https://github.com/xrf9268-hue/sbx.git"
-    echo "    cd sbx-lite && bash install_multi.sh"
+    echo "    cd sbx-lite && bash install.sh"
     echo ""
 }
 
@@ -533,13 +533,13 @@ _verify_module_apis() {
     if [[ "$all_ok" != true ]]; then
         echo ""
         echo "This may indicate:"
-        echo "  1. Module version mismatch between install_multi.sh and lib/*.sh"
+        echo "  1. Module version mismatch between install.sh and lib/*.sh"
         echo "  2. Incomplete module download"
         echo "  3. Corrupted module files"
         echo ""
         echo "Please try:"
         echo "  git clone https://github.com/xrf9268-hue/sbx.git"
-        echo "  cd sbx-lite && bash install_multi.sh"
+        echo "  cd sbx-lite && bash install.sh"
         echo ""
         exit 1
     fi

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -44,7 +44,7 @@ declare -r CERT_DIR_BASE="${CERT_DIR_BASE:-/etc/ssl/sbx}"
 declare -r LOG_LEVEL="${LOG_LEVEL:-warn}"
 
 # Operation timeouts and retry limits
-# NETWORK_TIMEOUT_SEC defined in install_multi.sh early constants for bootstrap
+# NETWORK_TIMEOUT_SEC defined in install.sh early constants for bootstrap
 [[ -z "${NETWORK_TIMEOUT_SEC:-}" ]] && declare -r NETWORK_TIMEOUT_SEC=5
 declare -r SERVICE_STARTUP_MAX_WAIT_SEC=10
 declare -r SERVICE_PORT_VALIDATION_MAX_RETRIES=5
@@ -54,13 +54,13 @@ declare -r CLEANUP_OLD_FILES_MIN=60
 declare -r BACKUP_RETENTION_DAYS=30
 declare -r CADDY_CERT_WAIT_TIMEOUT_SEC=60
 
-# Download configuration (some constants defined in install_multi.sh early boot)
+# Download configuration (some constants defined in install.sh early boot)
 # DOWNLOAD_CONNECT_TIMEOUT_SEC, DOWNLOAD_MAX_TIMEOUT_SEC, MIN_MODULE_FILE_SIZE_BYTES
-# are defined in install_multi.sh before module loading
+# are defined in install.sh before module loading
 [[ -z "${HTTP_TIMEOUT_SEC:-}" ]] && declare -r HTTP_TIMEOUT_SEC=30
 [[ -z "${DEFAULT_PARALLEL_JOBS:-}" ]] && declare -r DEFAULT_PARALLEL_JOBS=5
 
-# File permissions (octal) - defined in install_multi.sh for early use
+# File permissions (octal) - defined in install.sh for early use
 # SECURE_DIR_PERMISSIONS and SECURE_FILE_PERMISSIONS are already readonly
 
 # Input validation limits
@@ -83,7 +83,7 @@ declare -r LOG_VIEW_DEFAULT_HISTORY="5 minutes ago"
 # Reality Protocol Constants
 #==============================================================================
 
-# Reality configuration defaults (conditionally set if not already defined in install_multi.sh)
+# Reality configuration defaults (conditionally set if not already defined in install.sh)
 declare -r REALITY_DEFAULT_SNI="www.microsoft.com"
 
 if [[ -z "${REALITY_MAX_TIME_DIFF:-}" ]]; then
@@ -96,7 +96,7 @@ if [[ -z "${REALITY_FLOW_VISION:-}" ]]; then
   declare -r REALITY_FLOW_VISION="xtls-rprx-vision"
 fi
 
-# Reality validation constraints (conditionally set if not already defined in install_multi.sh)
+# Reality validation constraints (conditionally set if not already defined in install.sh)
 if [[ -z "${REALITY_SHORT_ID_MIN_LENGTH:-}" ]]; then
   declare -r REALITY_SHORT_ID_MIN_LENGTH=1
 fi
@@ -104,7 +104,7 @@ if [[ -z "${REALITY_SHORT_ID_MAX_LENGTH:-}" ]]; then
   declare -r REALITY_SHORT_ID_MAX_LENGTH=8
 fi
 
-# ALPN protocols for Reality (conditionally set if not already defined in install_multi.sh)
+# ALPN protocols for Reality (conditionally set if not already defined in install.sh)
 if [[ -z "${REALITY_ALPN_H2:-}" ]]; then
   declare -r REALITY_ALPN_H2="h2"
 fi
@@ -158,7 +158,7 @@ declare -r CADDY_CERT_POLL_INTERVAL_SEC=3
 #==============================================================================
 
 # HTTP download timeout (for large file downloads)
-# May be defined early in install_multi.sh for bootstrap phase
+# May be defined early in install.sh for bootstrap phase
 if [[ -z "${HTTP_DOWNLOAD_TIMEOUT_SEC:-}" ]]; then
   declare -r HTTP_DOWNLOAD_TIMEOUT_SEC=30
 fi

--- a/tests/integration/test_checksum_integration.sh
+++ b/tests/integration/test_checksum_integration.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Integration test for checksum verification in install_multi.sh
+# Integration test for checksum verification in install.sh
 
 set -euo pipefail
 
@@ -14,7 +14,7 @@ cd "$PROJECT_ROOT" || exit 1
 
 # Test 1: Verify checksum module is in module list
 echo "Test 1: Verify checksum in module list"
-if grep -q 'local modules=(.*checksum' install_multi.sh; then
+if grep -q 'local modules=(.*checksum' install.sh; then
     echo "✓ PASSED: checksum module found in module list"
 else
     echo "✗ FAILED: checksum module not in module list"
@@ -24,7 +24,7 @@ fi
 # Test 2: Verify checksum API contract
 echo ""
 echo "Test 2: Verify checksum API contract"
-if grep -q '\["checksum"\]="verify_file_checksum verify_singbox_binary"' install_multi.sh; then
+if grep -q '\["checksum"\]="verify_file_checksum verify_singbox_binary"' install.sh; then
     echo "✓ PASSED: checksum API contract defined"
 else
     echo "✗ FAILED: checksum API contract not found"
@@ -34,7 +34,7 @@ fi
 # Test 3: Verify verify_singbox_binary is called in download_singbox
 echo ""
 echo "Test 3: Verify verify_singbox_binary call in download_singbox"
-if grep -q 'verify_singbox_binary.*"\$pkg".*"\$tag"' install_multi.sh; then
+if grep -q 'verify_singbox_binary.*"\$pkg".*"\$tag"' install.sh; then
     echo "✓ PASSED: verify_singbox_binary called correctly"
 else
     echo "✗ FAILED: verify_singbox_binary call not found"
@@ -44,7 +44,7 @@ fi
 # Test 4: Verify SKIP_CHECKSUM environment variable support
 echo ""
 echo "Test 4: Verify SKIP_CHECKSUM support"
-if grep -q 'SKIP_CHECKSUM' install_multi.sh; then
+if grep -q 'SKIP_CHECKSUM' install.sh; then
     echo "✓ PASSED: SKIP_CHECKSUM environment variable supported"
 else
     echo "✗ FAILED: SKIP_CHECKSUM not found"
@@ -63,7 +63,7 @@ if bash -c '
     SCRIPT_DIR="$(pwd)"
 
     # Source just the module loading function
-    source <(sed -n "/^_load_modules/,/^}/p" install_multi.sh)
+    source <(sed -n "/^_load_modules/,/^}/p" install.sh)
 
     # Verify the modules array includes checksum
     _test_modules() {
@@ -110,7 +110,7 @@ echo "----------------------------------------"
 echo "All tests passed!"
 echo "========================================"
 echo ""
-echo "✓ Checksum module successfully integrated into install_multi.sh"
+echo "✓ Checksum module successfully integrated into install.sh"
 echo "✓ Ready for production use"
 
 exit 0

--- a/tests/integration/test_oneliner_install.sh
+++ b/tests/integration/test_oneliner_install.sh
@@ -6,7 +6,7 @@ set -uo pipefail
 
 # Test framework
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-INSTALL_SCRIPT="${SCRIPT_DIR}/install_multi.sh"
+INSTALL_SCRIPT="${SCRIPT_DIR}/install.sh"
 TESTS_RUN=0
 TESTS_PASSED=0
 TESTS_FAILED=0
@@ -46,7 +46,7 @@ cp "${INSTALL_SCRIPT}" "$temp_test_dir/"
 cd "$temp_test_dir" || exit
 
 # Run install script to trigger download, then exit immediately
-output=$(timeout 30 bash install_multi.sh --version 2>&1 || true)
+output=$(timeout 30 bash install.sh --version 2>&1 || true)
 
 if echo "$output" | grep -q "modules downloaded and verified"; then
     test_pass
@@ -66,7 +66,7 @@ temp_test_dir=$(mktemp -d)
 cp "${INSTALL_SCRIPT}" "$temp_test_dir/"
 cd "$temp_test_dir" || exit
 
-output=$(DEBUG=1 timeout 30 bash install_multi.sh --version 2>&1 || true)
+output=$(DEBUG=1 timeout 30 bash install.sh --version 2>&1 || true)
 
 if echo "$output" | grep -q "DEBUG:"; then
     test_pass
@@ -85,7 +85,7 @@ temp_test_dir=$(mktemp -d)
 cp "${INSTALL_SCRIPT}" "$temp_test_dir/"
 cd "$temp_test_dir" || exit
 
-output=$(timeout 30 bash install_multi.sh --version 2>&1 || true)
+output=$(timeout 30 bash install.sh --version 2>&1 || true)
 
 if echo "$output" | grep -qE "21/21 modules downloaded"; then
     test_pass
@@ -105,7 +105,7 @@ temp_test_dir=$(mktemp -d)
 cp "${INSTALL_SCRIPT}" "$temp_test_dir/"
 cd "$temp_test_dir" || exit
 
-output=$(timeout 30 bash install_multi.sh --version 2>&1 || true)
+output=$(timeout 30 bash install.sh --version 2>&1 || true)
 
 if ! echo "$output" | grep -qE "(unbound variable|Required module not found)"; then
     test_pass
@@ -130,9 +130,9 @@ cat > test_logging.sh << 'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Source install_multi.sh functions (without running main)
+# Source install.sh functions (without running main)
 SCRIPT_DIR="$(pwd)"
-source ./install_multi.sh 2>/dev/null || true
+source ./install.sh 2>/dev/null || true
 
 # Check if functions are available
 if declare -F msg >/dev/null && declare -F warn >/dev/null && declare -F err >/dev/null; then
@@ -169,11 +169,11 @@ set -euo pipefail
 SCRIPT_DIR="$(pwd)"
 ORIGINAL_SCRIPT_DIR="$SCRIPT_DIR"
 
-# Simulate module loading by sourcing install_multi
+# Simulate module loading by sourcing install script
 # (this will trigger _load_modules which downloads and loads modules)
 bash -c '
 cd "'"$SCRIPT_DIR"'"
-source ./install_multi.sh 2>/dev/null
+source ./install.sh 2>/dev/null
 
 # After loading, check if functions from common.sh are available
 # If they are, SCRIPT_DIR was loaded correctly
@@ -206,7 +206,7 @@ cd "$temp_test_dir" || exit
 
 # Measure parallel download time
 start_parallel=$(date +%s)
-timeout 60 bash install_multi.sh --version >/dev/null 2>&1 || true
+timeout 60 bash install.sh --version >/dev/null 2>&1 || true
 end_parallel=$(date +%s)
 parallel_time=$((end_parallel - start_parallel))
 
@@ -215,7 +215,7 @@ rm -rf sbx-install-* tmp.* 2>/dev/null || true
 
 # Measure sequential download time
 start_sequential=$(date +%s)
-ENABLE_PARALLEL_DOWNLOAD=0 timeout 60 bash install_multi.sh --version >/dev/null 2>&1 || true
+ENABLE_PARALLEL_DOWNLOAD=0 timeout 60 bash install.sh --version >/dev/null 2>&1 || true
 end_sequential=$(date +%s)
 sequential_time=$((end_sequential - start_sequential))
 
@@ -238,7 +238,7 @@ cp "${INSTALL_SCRIPT}" "$temp_test_dir/"
 cd "$temp_test_dir" || exit
 
 # Disable xargs to force fallback
-output=$(PATH="/usr/bin:/bin" timeout 30 bash install_multi.sh --version 2>&1 || true)
+output=$(PATH="/usr/bin:/bin" timeout 30 bash install.sh --version 2>&1 || true)
 
 # Should see either parallel success or sequential fallback
 if echo "$output" | grep -qE "(modules downloaded and verified|Downloading.*modules sequentially)"; then

--- a/tests/integration/test_reality_connection.sh
+++ b/tests/integration/test_reality_connection.sh
@@ -379,7 +379,7 @@ if [[ ! -f "/usr/local/bin/sing-box" ]]; then
   echo "sing-box not installed. Integration tests require a working installation."
   echo ""
   echo "To install sing-box:"
-  echo "  bash install_multi.sh"
+  echo "  bash install.sh"
   echo ""
   exit 0
 fi

--- a/tests/integration/test_version_integration.sh
+++ b/tests/integration/test_version_integration.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Integration test for version resolution in install_multi.sh
+# Integration test for version resolution in install.sh
 
 set -euo pipefail
 
@@ -14,7 +14,7 @@ cd "$PROJECT_ROOT" || exit 1
 
 # Test 1: Verify version module in module list
 echo "Test 1: Verify version in module list"
-if grep -q 'local modules=(.*version' install_multi.sh; then
+if grep -q 'local modules=(.*version' install.sh; then
     echo "✓ PASSED: version module found in module list"
 else
     echo "✗ FAILED: version module not in module list"
@@ -24,7 +24,7 @@ fi
 # Test 2: Verify version API contract
 echo ""
 echo "Test 2: Verify version API contract"
-if grep -q '\["version"\]="resolve_singbox_version"' install_multi.sh; then
+if grep -q '\["version"\]="resolve_singbox_version"' install.sh; then
     echo "✓ PASSED: version API contract defined"
 else
     echo "✗ FAILED: version API contract not found"
@@ -34,7 +34,7 @@ fi
 # Test 3: Verify resolve_singbox_version is called in download_singbox
 echo ""
 echo "Test 3: Verify resolve_singbox_version call in download_singbox"
-if grep -q 'tag=$(resolve_singbox_version)' install_multi.sh; then
+if grep -q 'tag=$(resolve_singbox_version)' install.sh; then
     echo "✓ PASSED: resolve_singbox_version called correctly"
 else
     echo "✗ FAILED: resolve_singbox_version call not found"
@@ -45,9 +45,9 @@ fi
 echo ""
 echo "Test 4: Verify old version detection removed"
 # Check that the old if/else version detection is gone
-if grep -q 'if \[\[ -n "${SINGBOX_VERSION:-}" \]\]; then' install_multi.sh; then
+if grep -q 'if \[\[ -n "${SINGBOX_VERSION:-}" \]\]; then' install.sh; then
     # Check if it's the NEW usage (after resolve_singbox_version)
-    if grep -A5 'tag=$(resolve_singbox_version)' install_multi.sh | grep -q 'SINGBOX_VERSION'; then
+    if grep -A5 'tag=$(resolve_singbox_version)' install.sh | grep -q 'SINGBOX_VERSION'; then
         echo "⚠ WARNING: Old version detection code may still exist"
     fi
 fi
@@ -65,7 +65,7 @@ if bash -c '
     SCRIPT_DIR="$(pwd)"
 
     # Source just the module loading function
-    source <(sed -n "/^_load_modules/,/^}/p" install_multi.sh)
+    source <(sed -n "/^_load_modules/,/^}/p" install.sh)
 
     # Test modules array
     _test_modules() {
@@ -107,7 +107,7 @@ fi
 # Test 7: Verify version resolution modes in code comments
 echo ""
 echo "Test 7: Verify version resolution documentation in code"
-if grep -q "Supports: stable.*latest.*vX.Y.Z" install_multi.sh; then
+if grep -q "Supports: stable.*latest.*vX.Y.Z" install.sh; then
     echo "✓ PASSED: Version resolution modes documented in code"
 else
     echo "⚠ WARNING: Version resolution modes not documented"
@@ -120,7 +120,7 @@ echo "----------------------------------------"
 echo "All tests passed!"
 echo "========================================"
 echo ""
-echo "✓ Version resolution successfully integrated into install_multi.sh"
+echo "✓ Version resolution successfully integrated into install.sh"
 echo "✓ Module count: 12 modules (includes version)"
 echo "✓ Ready for production use"
 echo ""

--- a/tests/test_improvements.sh
+++ b/tests/test_improvements.sh
@@ -38,12 +38,12 @@ echo "========================================"
 echo "Testing Installation Script Improvements"
 echo "========================================"
 
-# Source necessary functions from install_multi.sh for testing
+# Source necessary functions from install.sh for testing
 # We need to extract just the functions without running the main script
 
 # Test 1: verify detect_libc function exists
 test_start "Verify detect_libc() function exists"
-if grep -q "^detect_libc()" "$SCRIPT_DIR/install_multi.sh"; then
+if grep -q "^detect_libc()" "$SCRIPT_DIR/install.sh"; then
     pass "detect_libc() function defined"
 else
     fail "detect_libc() function not found"
@@ -51,19 +51,19 @@ fi
 
 # Test 2: Verify musl detection methods
 test_start "Verify musl detection has 3 methods"
-if grep -A 40 "^detect_libc()" "$SCRIPT_DIR/install_multi.sh" | grep -q "Method 1.*musl shared library"; then
+if grep -A 40 "^detect_libc()" "$SCRIPT_DIR/install.sh" | grep -q "Method 1.*musl shared library"; then
     pass "Method 1: musl shared library check present"
 else
     fail "Method 1 missing"
 fi
 
-if grep -A 40 "^detect_libc()" "$SCRIPT_DIR/install_multi.sh" | grep -q "Method 2.*ldd"; then
+if grep -A 40 "^detect_libc()" "$SCRIPT_DIR/install.sh" | grep -q "Method 2.*ldd"; then
     pass "Method 2: ldd check present"
 else
     fail "Method 2 missing"
 fi
 
-if grep -A 40 "^detect_libc()" "$SCRIPT_DIR/install_multi.sh" | grep -q "Method 3.*os-release"; then
+if grep -A 40 "^detect_libc()" "$SCRIPT_DIR/install.sh" | grep -q "Method 3.*os-release"; then
     pass "Method 3: os-release check present"
 else
     fail "Method 3 missing"
@@ -71,13 +71,13 @@ fi
 
 # Test 3: Verify jq is optional
 test_start "Verify jq moved to optional tools"
-if grep -A 20 "^ensure_tools()" "$SCRIPT_DIR/install_multi.sh" | grep -q 'local optional=(jq)'; then
+if grep -A 20 "^ensure_tools()" "$SCRIPT_DIR/install.sh" | grep -q 'local optional=(jq)'; then
     pass "jq is in optional tools list"
 else
     fail "jq not in optional tools list"
 fi
 
-if grep -A 20 "^ensure_tools()" "$SCRIPT_DIR/install_multi.sh" | grep -q 'local required=(curl tar gzip openssl systemctl)'; then
+if grep -A 20 "^ensure_tools()" "$SCRIPT_DIR/install.sh" | grep -q 'local required=(curl tar gzip openssl systemctl)'; then
     pass "jq not in required tools list"
 else
     fail "jq still in required tools list"
@@ -85,13 +85,13 @@ fi
 
 # Test 4: Verify libc suffix used in download
 test_start "Verify libc_suffix used in download_singbox()"
-if grep -A 15 "^download_singbox()" "$SCRIPT_DIR/install_multi.sh" | grep -q 'libc_suffix="$(detect_libc)"'; then
+if grep -A 15 "^download_singbox()" "$SCRIPT_DIR/install.sh" | grep -q 'libc_suffix="$(detect_libc)"'; then
     pass "libc_suffix variable assigned"
 else
     fail "libc_suffix not assigned"
 fi
 
-if grep -A 80 "^download_singbox()" "$SCRIPT_DIR/install_multi.sh" | grep -q 'linux-\${arch}\${libc_suffix}'; then
+if grep -A 80 "^download_singbox()" "$SCRIPT_DIR/install.sh" | grep -q 'linux-\${arch}\${libc_suffix}'; then
     pass "libc_suffix used in download URL pattern"
 else
     fail "libc_suffix not used in URL pattern"
@@ -99,13 +99,13 @@ fi
 
 # Test 5: Verify fallback to generic binary
 test_start "Verify fallback to generic Linux binary"
-if grep -A 80 "^download_singbox()" "$SCRIPT_DIR/install_multi.sh" | grep -q "musl-specific binary not found"; then
+if grep -A 80 "^download_singbox()" "$SCRIPT_DIR/install.sh" | grep -q "musl-specific binary not found"; then
     pass "Warning message for missing musl binary"
 else
     fail "No warning for missing musl binary"
 fi
 
-if grep -A 80 "^download_singbox()" "$SCRIPT_DIR/install_multi.sh" | grep -q "Fallback to generic linux binary"; then
+if grep -A 80 "^download_singbox()" "$SCRIPT_DIR/install.sh" | grep -q "Fallback to generic linux binary"; then
     pass "Fallback logic present"
 else
     fail "Fallback logic missing"
@@ -113,7 +113,7 @@ fi
 
 # Test 6: Verify checksum uses libc suffix
 test_start "Verify checksum verification uses libc suffix"
-if grep -A 20 "SHA256 Checksum Verification" "$SCRIPT_DIR/install_multi.sh" | grep -q 'platform="linux-${arch}${libc_suffix}"'; then
+if grep -A 20 "SHA256 Checksum Verification" "$SCRIPT_DIR/install.sh" | grep -q 'platform="linux-${arch}${libc_suffix}"'; then
     pass "Checksum uses libc suffix"
 else
     fail "Checksum doesn't use libc suffix"
@@ -121,13 +121,13 @@ fi
 
 # Test 7: Verify optional tools notification
 test_start "Verify user-friendly messages for optional tools"
-if grep -A 40 "^ensure_tools()" "$SCRIPT_DIR/install_multi.sh" | grep -q "Optional tools not available"; then
+if grep -A 40 "^ensure_tools()" "$SCRIPT_DIR/install.sh" | grep -q "Optional tools not available"; then
     pass "Info message for optional tools"
 else
     fail "No info message for optional tools"
 fi
 
-if grep -A 40 "^ensure_tools()" "$SCRIPT_DIR/install_multi.sh" | grep -q "fallback methods"; then
+if grep -A 40 "^ensure_tools()" "$SCRIPT_DIR/install.sh" | grep -q "fallback methods"; then
     pass "Mentions fallback methods"
 else
     fail "No mention of fallback methods"
@@ -154,8 +154,8 @@ else
 fi
 
 # Test 9: Syntax validation
-test_start "Validate bash syntax of install_multi.sh"
-if bash -n "$SCRIPT_DIR/install_multi.sh" 2>/dev/null; then
+test_start "Validate bash syntax of install.sh"
+if bash -n "$SCRIPT_DIR/install.sh" 2>/dev/null; then
     pass "Syntax is valid"
 else
     fail "Syntax errors found"
@@ -163,13 +163,13 @@ fi
 
 # Test 10: Check for early get_file_size bootstrap function
 test_start "Verify early get_file_size() for bootstrapping"
-if grep -B 5 "^get_file_size()" "$SCRIPT_DIR/install_multi.sh" | grep -q "Early Helper Functions"; then
+if grep -B 5 "^get_file_size()" "$SCRIPT_DIR/install.sh" | grep -q "Early Helper Functions"; then
     pass "Early get_file_size() exists for bootstrapping"
 else
     fail "Early get_file_size() not found"
 fi
 
-if grep -A 20 "_download_modules_parallel()" "$SCRIPT_DIR/install_multi.sh" | grep -q "export -f get_file_size"; then
+if grep -A 20 "_download_modules_parallel()" "$SCRIPT_DIR/install.sh" | grep -q "export -f get_file_size"; then
     pass "get_file_size exported for parallel downloads"
 else
     fail "get_file_size not exported"

--- a/tests/test_module_loading.sh
+++ b/tests/test_module_loading.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # tests/test_module_loading.sh - Test parallel/sequential module downloading
-# Tests the smart module loading functionality in install_multi.sh
+# Tests the smart module loading functionality in install.sh
 
 set -uo pipefail
 
 # Determine script directory for absolute paths
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-INSTALL_SCRIPT="${SCRIPT_DIR}/install_multi.sh"
+INSTALL_SCRIPT="${SCRIPT_DIR}/install.sh"
 
 # Test counters
 TESTS_RUN=0
@@ -30,11 +30,11 @@ test_fail() {
 }
 
 # Start testing
-echo "=== Testing Module Loading (install_multi.sh) ==="
+echo "=== Testing Module Loading (install.sh) ==="
 echo ""
 
 # Test 1: Verify bash syntax
-test_start "install_multi.sh has valid bash syntax"
+test_start "install.sh has valid bash syntax"
 if bash -n "${INSTALL_SCRIPT}" 2>/dev/null; then
     test_pass
 else

--- a/tests/test_oneliner_install.sh
+++ b/tests/test_oneliner_install.sh
@@ -43,7 +43,7 @@ echo
 # Test 1: Simulate one-liner install environment
 info "Test 1: Simulating one-liner install (no bin/ directory)"
 mkdir -p "$TEST_DIR"
-cp install_multi.sh "$TEST_DIR/"
+cp install.sh "$TEST_DIR/"
 
 # Check from original directory (test directory doesn't have bin/)
 if [[ ! -d "$TEST_DIR/bin" && ! -d "$TEST_DIR/lib" ]]; then
@@ -55,7 +55,7 @@ fi
 
 # Test 2: Check module download logic exists
 info "Test 2: Checking _load_modules() function"
-if grep -q "Download bin/sbx-manager.sh for one-liner install" install_multi.sh; then
+if grep -q "Download bin/sbx-manager.sh for one-liner install" install.sh; then
     pass "Module download logic includes bin/sbx-manager.sh"
 else
     fail "bin/sbx-manager.sh download logic not found"
@@ -63,13 +63,13 @@ fi
 
 # Test 3: Verify download validation
 info "Test 3: Checking download validation logic"
-if grep -q "Check file size (full version should be >5KB" install_multi.sh; then
+if grep -q "Check file size (full version should be >5KB" install.sh; then
     pass "File size validation present"
 else
     fail "File size validation missing"
 fi
 
-if grep -q 'bash -n.*manager_file' install_multi.sh; then
+if grep -q 'bash -n.*manager_file' install.sh; then
     pass "Bash syntax validation present"
 else
     fail "Bash syntax validation missing"
@@ -77,13 +77,13 @@ fi
 
 # Test 4: Check improved fallback warning
 info "Test 4: Checking fallback warning messages"
-if grep -q "sbx info.*will not show URIs" install_multi.sh; then
+if grep -q "sbx info.*will not show URIs" install.sh; then
     pass "Detailed fallback warning present"
 else
     fail "Detailed fallback warning missing"
 fi
 
-if grep -q "manually download:" install_multi.sh; then
+if grep -q "manually download:" install.sh; then
     pass "Manual download instructions present"
 else
     fail "Manual download instructions missing"
@@ -91,7 +91,7 @@ fi
 
 # Test 5: Verify manager template path detection
 info "Test 5: Checking manager installation logic"
-if grep -q 'manager_template="\${SCRIPT_DIR}/bin/sbx-manager.sh"' install_multi.sh; then
+if grep -q 'manager_template="\${SCRIPT_DIR}/bin/sbx-manager.sh"' install.sh; then
     pass "Manager template path correctly set"
 else
     fail "Manager template path issue"
@@ -100,7 +100,7 @@ fi
 # Test 6: Check module list completeness
 info "Test 6: Verifying all required modules are downloaded"
 EXPECTED_MODULES="common retry download network validation checksum version certificate caddy config service ui backup export"
-if grep -q "local modules=.*$EXPECTED_MODULES" install_multi.sh; then
+if grep -q "local modules=.*$EXPECTED_MODULES" install.sh; then
     pass "All 13 modules listed for download"
 else
     fail "Module list incomplete or incorrect"
@@ -108,7 +108,7 @@ fi
 
 # Test 7: Verify error handling
 info "Test 7: Checking error handling for download failures"
-if grep -q "ERROR: Failed to download sbx-manager.sh" install_multi.sh; then
+if grep -q "ERROR: Failed to download sbx-manager.sh" install.sh; then
     pass "Download failure error handling present"
 else
     fail "Download failure error handling missing"
@@ -116,7 +116,7 @@ fi
 
 # Test 8: Check timeout configuration
 info "Test 8: Verifying download timeout settings"
-if grep -q "DOWNLOAD_CONNECT_TIMEOUT_SEC\|DOWNLOAD_MAX_TIMEOUT_SEC" install_multi.sh; then
+if grep -q "DOWNLOAD_CONNECT_TIMEOUT_SEC\|DOWNLOAD_MAX_TIMEOUT_SEC" install.sh; then
     pass "Download timeout configuration present"
 else
     fail "Download timeout configuration missing"
@@ -124,16 +124,16 @@ fi
 
 # Test 9: Dry-run syntax check
 info "Test 9: Running bash syntax check on modified script"
-if bash -n install_multi.sh 2>/dev/null; then
+if bash -n install.sh 2>/dev/null; then
     pass "Bash syntax check passed"
 else
     fail "Bash syntax errors detected"
-    bash -n install_multi.sh 2>&1 | head -10
+    bash -n install.sh 2>&1 | head -10
 fi
 
 # Test 10: Check GitHub raw URL format
 info "Test 10: Verifying GitHub raw content URL format"
-if grep -q 'github_repo="https://raw.githubusercontent.com' install_multi.sh; then
+if grep -q 'github_repo="https://raw.githubusercontent.com' install.sh; then
     pass "GitHub raw content URL correctly formatted"
 else
     fail "GitHub URL format issue"

--- a/tests/test_uri_display.sh
+++ b/tests/test_uri_display.sh
@@ -56,7 +56,7 @@ test_print_summary_displays_reality_uri() {
     export REALITY_ONLY_MODE=1
 
     # Source the function
-    source "$SCRIPT_DIR/install_multi.sh" 2>/dev/null || true
+    source "$SCRIPT_DIR/install.sh" 2>/dev/null || true
 
     # Capture output
     local output
@@ -104,7 +104,7 @@ test_print_summary_displays_multi_protocol_uris() {
     export CERT_KEY="/etc/ssl/sbx/test.example.com/privkey.pem"
 
     # Source the function
-    source "$SCRIPT_DIR/install_multi.sh" 2>/dev/null || true
+    source "$SCRIPT_DIR/install.sh" 2>/dev/null || true
 
     # Capture output
     local output

--- a/tests/test_uri_display_simple.sh
+++ b/tests/test_uri_display_simple.sh
@@ -27,7 +27,7 @@ echo
 echo -e "${B}Test 1: Verify current print_summary() lacks URI display${N}"
 
 # Extract current print_summary function
-CURRENT_OUTPUT=$(sed -n '/^print_summary() {/,/^}/p' install_multi.sh)
+CURRENT_OUTPUT=$(sed -n '/^print_summary() {/,/^}/p' install.sh)
 
 if echo "$CURRENT_OUTPUT" | grep -qE 'vless://|URI.*=.*vless'; then
     fail "print_summary should NOT currently display URI" "Found URI in current implementation"

--- a/tests/unit/README_BOOTSTRAP_TESTS.md
+++ b/tests/unit/README_BOOTSTRAP_TESTS.md
@@ -12,7 +12,7 @@ The sbx-lite codebase uses `set -u` (strict mode), which causes immediate script
 
 This exact issue has caused **3+ production bugs**:
 
-1. **url variable** (install_multi.sh:836) - Installation failed on glibc systems
+1. **url variable** (install.sh:836) - Installation failed on glibc systems
 2. **HTTP_DOWNLOAD_TIMEOUT_SEC** - GitHub API fetches completely broken
 3. **get_file_size()** - Bootstrap failures preventing installation
 4. **REALITY_SHORT_ID_MIN_LENGTH** (2025-11-18) - Installation failed during validation
@@ -26,7 +26,7 @@ Each time was manually fixed, but **no automated test existed to prevent recurre
 `test_bootstrap_constants.sh` validates:
 
 ### 1. **Constant Registration** (Test 1-2)
-- All bootstrap constants defined in `install_multi.sh` early section (lines 16-44)
+- All bootstrap constants defined in `install.sh` early section (lines 16-44)
 - Constants defined **before** module loading (line < 100)
 
 ### 2. **Conditional Declarations** (Test 3-4)
@@ -65,7 +65,7 @@ Currently tracking **15 bootstrap constants**:
 
 If you add a constant to `lib/common.sh` that will be used during bootstrap:
 
-1. **Add to `install_multi.sh` early constants section** (lines 16-44):
+1. **Add to `install.sh` early constants section** (lines 16-44):
    ```bash
    readonly MY_NEW_CONSTANT=value
    ```
@@ -96,7 +96,7 @@ If you add a constant to `lib/common.sh` that will be used during bootstrap:
 A constant needs bootstrap definition if:
 
 - ✅ It's defined in `lib/common.sh`
-- ✅ It's used by any module loaded before line 542 in `install_multi.sh`
+- ✅ It's used by any module loaded before line 542 in `install.sh`
 - ✅ It's used during: module download, network detection, config generation, validation
 
 Common culprits:
@@ -121,16 +121,16 @@ bash tests/test-runner.sh unit
 ```
 === Bootstrap Constants Validation Test ===
 
-  Test 1: All bootstrap constants defined in install_multi.sh ... ✓ PASS
+  Test 1: All bootstrap constants defined in install.sh ... ✓ PASS
   Test 2: Bootstrap constants defined before module loading ... ✓ PASS
   Test 3: Reality constants conditionally declared in lib/common.sh ... ✓ PASS
   Test 4: No duplicate constant declarations between files ... ✓ PASS
-  Test 5: install_multi.sh sources successfully with strict mode ... ✓ PASS
+  Test 5: install.sh sources successfully with strict mode ... ✓ PASS
   Test 6: lib/common.sh sources successfully after bootstrap constants ... ✓ PASS
   Test 7: Bootstrap functions don't use unbound variables ... ✓ PASS
   Test 8: Early constants section has documentation header ... ✓ PASS
   Test 9: CLAUDE.md documents bootstrap constant pattern ... ✓ PASS
-  Test 10: install_multi.sh help works with bash -u (no unbound vars) ... ✓ PASS
+  Test 10: install.sh help works with bash -u (no unbound vars) ... ✓ PASS
 
 === Test Summary ===
 Total constants tracked: 15
@@ -178,7 +178,7 @@ With this test:
 ## References
 
 - **Bootstrap Pattern Documentation**: `CLAUDE.md` (lines 106-195)
-- **Installation Script**: `install_multi.sh` (lines 16-44 for early constants)
+- **Installation Script**: `install.sh` (lines 16-44 for early constants)
 - **Common Constants**: `lib/common.sh` (lines 82-112 for Reality constants)
 - **Historical Fixes**: `CHANGELOG.md` (search for "unbound variable")
 

--- a/tests/unit/test_bootstrap_functions.sh
+++ b/tests/unit/test_bootstrap_functions.sh
@@ -30,9 +30,9 @@ test_fail() {
 # Source the install script to get the bootstrap get_file_size function
 # We need to extract just the function definition, not run the whole script
 extract_bootstrap_function() {
-    # Extract get_file_size function from install_multi.sh
+    # Extract get_file_size function from install.sh
     # It's defined before module loading (lines 34-49)
-    sed -n '/^get_file_size() {/,/^}/p' "$SCRIPT_DIR/install_multi.sh"
+    sed -n '/^get_file_size() {/,/^}/p' "$SCRIPT_DIR/install.sh"
 }
 
 # Create a test environment with the bootstrap function
@@ -124,19 +124,19 @@ rm -f "$test_file"
 #==============================================================================
 # Test 6: Constants are defined correctly
 #==============================================================================
-test_start "Early constants are defined in install_multi.sh"
+test_start "Early constants are defined in install.sh"
 
 constants_found=0
-if grep -q "readonly DOWNLOAD_CONNECT_TIMEOUT_SEC=" "$SCRIPT_DIR/install_multi.sh"; then
+if grep -q "readonly DOWNLOAD_CONNECT_TIMEOUT_SEC=" "$SCRIPT_DIR/install.sh"; then
     constants_found=$((constants_found + 1))
 fi
-if grep -q "readonly DOWNLOAD_MAX_TIMEOUT_SEC=" "$SCRIPT_DIR/install_multi.sh"; then
+if grep -q "readonly DOWNLOAD_MAX_TIMEOUT_SEC=" "$SCRIPT_DIR/install.sh"; then
     constants_found=$((constants_found + 1))
 fi
-if grep -q "readonly MIN_MODULE_FILE_SIZE_BYTES=" "$SCRIPT_DIR/install_multi.sh"; then
+if grep -q "readonly MIN_MODULE_FILE_SIZE_BYTES=" "$SCRIPT_DIR/install.sh"; then
     constants_found=$((constants_found + 1))
 fi
-if grep -q "readonly SECURE_DIR_PERMISSIONS=" "$SCRIPT_DIR/install_multi.sh"; then
+if grep -q "readonly SECURE_DIR_PERMISSIONS=" "$SCRIPT_DIR/install.sh"; then
     constants_found=$((constants_found + 1))
 fi
 
@@ -178,8 +178,8 @@ fi
 #==============================================================================
 test_start "get_file_size can be exported for parallel downloads"
 
-# Check if install_multi.sh exports the function
-if grep -q "export -f get_file_size" "$SCRIPT_DIR/install_multi.sh"; then
+# Check if install.sh exports the function
+if grep -q "export -f get_file_size" "$SCRIPT_DIR/install.sh"; then
     test_pass
 else
     test_fail "get_file_size not exported (needed for parallel downloads)"

--- a/tests/unit/test_module_dependencies.sh
+++ b/tests/unit/test_module_dependencies.sh
@@ -28,12 +28,12 @@ test_fail() {
 }
 
 #==============================================================================
-# Test 1: Extract module list from install_multi.sh
+# Test 1: Extract module list from install.sh
 #==============================================================================
-test_start "Extract module list from install_multi.sh"
+test_start "Extract module list from install.sh"
 
-# Extract the module list from install_multi.sh - use simpler approach
-module_line=$(grep "local modules=(.*)" "$SCRIPT_DIR/install_multi.sh" | grep "colors\|common")
+# Extract the module list from install.sh - use simpler approach
+module_line=$(grep "local modules=(.*)" "$SCRIPT_DIR/install.sh" | grep "colors\|common")
 
 if [[ -n "$module_line" ]]; then
     # Extract just the module names between parentheses
@@ -90,7 +90,7 @@ if [[ ${#missing_modules[@]} -eq 0 ]]; then
 else
     test_fail "Missing modules in download list: ${missing_modules[*]}"
     echo ""
-    echo "  Modules sourced in lib/ but NOT in install_multi.sh download list:"
+    echo "  Modules sourced in lib/ but NOT in install.sh download list:"
     for mod in "${missing_modules[@]}"; do
         echo "    • $mod"
         # Show which file sources this module
@@ -102,7 +102,7 @@ fi
 #==============================================================================
 # Test 4: Verify module count matches
 #==============================================================================
-test_start "Module count in install_multi.sh matches actual files"
+test_start "Module count in install.sh matches actual files"
 
 actual_module_count=$(find "$SCRIPT_DIR/lib/" -name "*.sh" -type f | wc -l)
 declared_module_count=${#DOWNLOAD_MODULES[@]}

--- a/tests/unit/test_module_download.sh
+++ b/tests/unit/test_module_download.sh
@@ -107,7 +107,7 @@ cat > "$temp_dir/module.sh" << "INNEREOF"
 SCRIPT_DIR="/tmp/module"
 INNEREOF
 
-# Source WITH protection (like install_multi.sh does now)
+# Source WITH protection (like install.sh does now)
 INSTALLER_SCRIPT_DIR="${SCRIPT_DIR}"
 source "$temp_dir/module.sh"
 SCRIPT_DIR="${INSTALLER_SCRIPT_DIR}"

--- a/tests/unit/test_module_download_validation.sh
+++ b/tests/unit/test_module_download_validation.sh
@@ -32,7 +32,7 @@ test_fail() {
 #==============================================================================
 test_start "All lib/*.sh modules meet minimum size requirement"
 
-MIN_SIZE=100  # MIN_MODULE_FILE_SIZE_BYTES from install_multi.sh
+MIN_SIZE=100  # MIN_MODULE_FILE_SIZE_BYTES from install.sh
 failures=0
 
 for module in "$SCRIPT_DIR"/lib/*.sh; do

--- a/tests/unit/test_module_loading_sequence.sh
+++ b/tests/unit/test_module_loading_sequence.sh
@@ -28,10 +28,10 @@ test_fail() {
 }
 
 #==============================================================================
-# Helper: Extract module list from install_multi.sh
+# Helper: Extract module list from install.sh
 #==============================================================================
 get_module_list() {
-    grep "local modules=(.*)" "$SCRIPT_DIR/install_multi.sh" | \
+    grep "local modules=(.*)" "$SCRIPT_DIR/install.sh" | \
         grep "colors\|common" | \
         sed 's/.*local modules=(\(.*\))/\1/'
 }
@@ -56,7 +56,7 @@ get_module_dependencies() {
 #==============================================================================
 # Test 1: Module list extraction works
 #==============================================================================
-test_start "Can extract module list from install_multi.sh"
+test_start "Can extract module list from install.sh"
 
 module_list=$(get_module_list)
 
@@ -211,7 +211,7 @@ fi
 #==============================================================================
 # Test 6: Module count matches actual files in lib/
 #==============================================================================
-test_start "Module count in install_multi.sh matches lib/*.sh files"
+test_start "Module count in install.sh matches lib/*.sh files"
 
 actual_count=$(find "$SCRIPT_DIR/lib" -name "*.sh" -type f | wc -l)
 declared_count=${#MODULE_ARRAY[@]}
@@ -319,9 +319,9 @@ fi
 #==============================================================================
 # Test 9: sbx-manager script download is mentioned
 #==============================================================================
-test_start "install_multi.sh includes sbx-manager download logic"
+test_start "install.sh includes sbx-manager download logic"
 
-if grep -q "sbx-manager" "$SCRIPT_DIR/install_multi.sh"; then
+if grep -q "sbx-manager" "$SCRIPT_DIR/install.sh"; then
     test_pass
 else
     test_fail "sbx-manager download not found in installer"
@@ -332,7 +332,7 @@ fi
 #==============================================================================
 test_start "Parallel download function (_download_modules_parallel) exists"
 
-if grep -q "_download_modules_parallel" "$SCRIPT_DIR/install_multi.sh"; then
+if grep -q "_download_modules_parallel" "$SCRIPT_DIR/install.sh"; then
     test_pass
 else
     test_fail "Parallel download function not found"

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -8,7 +8,7 @@ echo "→ Running pre-commit checks..."
 # Run ShellCheck if available
 if command -v shellcheck >/dev/null 2>&1; then
   echo "  ✓ ShellCheck..."
-  shellcheck -x -S warning install_multi.sh lib/*.sh 2>/dev/null || {
+  shellcheck -x -S warning install.sh lib/*.sh 2>/dev/null || {
     echo "❌ ShellCheck failed. Please fix issues before committing."
     exit 1
   }
@@ -18,7 +18,7 @@ fi
 
 # Check syntax
 echo "  ✓ Syntax check..."
-for script in install_multi.sh lib/*.sh; do
+for script in install.sh lib/*.sh; do
   [[ -f "$script" ]] || continue
   bash -n "$script" || {
     echo "❌ Syntax error in $script"


### PR DESCRIPTION
BREAKING CHANGE: Installation script renamed from install_multi.sh to install.sh for simplicity and clarity. The "multi" suffix was historical and no longer meaningful as the script handles both single and multi-protocol setups.

Changes:
- Renamed install_multi.sh → install.sh
- Updated 39 files with references to the new filename:
  - Documentation (README.md, CLAUDE.md, CONTRIBUTING.md, etc.)
  - Test files (40+ test scripts)
  - GitHub workflows (shellcheck.yml, test.yml)
  - Helper scripts and hooks

Migration for users:
- Old: bash <(curl -fsSL .../install_multi.sh)
- New: bash <(curl -fsSL .../install.sh)

The old URL will return 404 after this change is merged.