### PR TITLE
Fix sing-box installation and service restart

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -627,8 +627,15 @@ detect_libc() {
 # Get installed sing-box version
 get_installed_version() {
     if [[ -x "$SB_BIN" ]]; then
-        local version
-        version=$("$SB_BIN" version 2>/dev/null | head -1 | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
+        local version=""
+        # Match version with or without 'v' prefix (e.g., "v1.12.12" or "1.12.12")
+        version=$("$SB_BIN" version 2>/dev/null | head -1 | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
+
+        # Ensure version has 'v' prefix for consistency with the rest of the codebase
+        if [[ "$version" != "unknown" && "$version" != v* ]]; then
+            version="v${version}"
+        fi
+
         echo "$version"
     else
         echo "not_installed"


### PR DESCRIPTION
The version detection regex in get_installed_version() was expecting a 'v' prefix (e.g., "v1.12.12"), but sing-box 1.12.12 outputs version as "sing-box version 1.12.12" without the 'v' prefix.

This caused the version to be detected as "unknown" when running the installation script on systems with sing-box already installed.

Changes:
- Updated regex from 'v[0-9]+' to 'v?[0-9]+' (make 'v' optional)
- Added logic to ensure output always has 'v' prefix for consistency
- Added explanatory comments

Fixes version detection for both formats:
- "sing-box version 1.12.12" → "v1.12.12"
- "sing-box version v1.12.12" → "v1.12.12"

Issue: User reported "version: unknown" after re-running install script