### PR TITLE
Fix one-click install issue on Debian 13

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -440,11 +440,13 @@ HTTP_DOWNLOAD_TIMEOUT_SEC: unbound variable
 
 ## Recent Improvements (2025-11-18)
 
-### Optional jq Dependency
-✅ Implemented - Works on minimal systems (Alpine, BusyBox, containers)
-- Fallback chain: jq → python3 → python2 (via lib/tools.sh)
-- Faster installation (no package manager calls)
-- Full functionality maintained with python fallbacks
+### jq Dependency (Required)
+⚠️ **Note:** jq was temporarily marked as optional but has been reverted to required due to incomplete fallback implementation.
+
+- jq is automatically installed if missing on supported systems (Debian, Ubuntu, CentOS, Fedora, RHEL)
+- Fallback chain for JSON **parsing** exists: jq → python3 → python2 (via lib/tools.sh)
+- JSON **building** currently requires jq (python fallbacks not yet implemented)
+- Future: Complete python fallbacks for full jq-optional support
 
 ### Alpine Linux Support (musl libc Detection)
 ✅ Implemented - Proper support for Alpine/musl-based systems

--- a/install.sh
+++ b/install.sh
@@ -792,8 +792,8 @@ check_existing_installation() {
 
 # Ensure required tools are installed
 ensure_tools() {
-    local required=(curl tar gzip openssl systemctl)
-    local optional=(jq)
+    local required=(curl tar gzip openssl systemctl jq)
+    local optional=()
     local missing=()
     local missing_optional=()
 

--- a/tests/test_improvements.sh
+++ b/tests/test_improvements.sh
@@ -69,18 +69,23 @@ else
     fail "Method 3 missing"
 fi
 
-# Test 3: Verify jq is optional
-test_start "Verify jq moved to optional tools"
-if grep -A 20 "^ensure_tools()" "$SCRIPT_DIR/install.sh" | grep -q 'local optional=(jq)'; then
-    pass "jq is in optional tools list"
+# Test 3: Verify jq is required (reverted from optional due to incomplete fallback implementation)
+test_start "Verify jq is in required tools"
+if grep -A 20 "^ensure_tools()" "$SCRIPT_DIR/install.sh" | grep -q 'local required=(curl tar gzip openssl systemctl jq)'; then
+    pass "jq is in required tools list"
 else
-    fail "jq not in optional tools list"
+    fail "jq not in required tools list"
 fi
 
-if grep -A 20 "^ensure_tools()" "$SCRIPT_DIR/install.sh" | grep -q 'local required=(curl tar gzip openssl systemctl)'; then
-    pass "jq not in required tools list"
+if grep -A 20 "^ensure_tools()" "$SCRIPT_DIR/install.sh" | grep -q 'local optional=()'; then
+    pass "jq not in optional tools list (empty array)"
 else
-    fail "jq still in required tools list"
+    # Check if optional array doesn't contain jq
+    if ! grep -A 20 "^ensure_tools()" "$SCRIPT_DIR/install.sh" | grep -q 'local optional=(jq)'; then
+        pass "jq not in optional tools list"
+    else
+        fail "jq still in optional tools list"
+    fi
 fi
 
 # Test 4: Verify libc suffix used in download


### PR DESCRIPTION
Problem:
- Users on Debian systems encounter "Failed to create base configuration with jq" error during installation
- jq was marked as optional but lib/tools.sh json_build() function requires jq without python fallbacks
- create_base_config() in lib/config.sh calls jq directly
- Installation fails when jq is not pre-installed

Root Cause:
- json_parse() has python fallbacks (jq → python3 → python2) ✓
- json_build() does NOT have python fallbacks ✗
- "Optional jq" feature was only partially implemented

Solution:
- Reverted jq from optional to required in ensure_tools()
- jq now auto-installs on Debian/Ubuntu/CentOS/Fedora/RHEL if missing
- Updated test_improvements.sh to reflect jq is required
- Updated CLAUDE.md documentation with clarification

Changes:
- install.sh: Moved jq from optional[] to required[] array
- tests/test_improvements.sh: Updated Test 3 to check jq is required
- CLAUDE.md: Documented jq as required with explanation

Impact:
- Fixes installation failures on Debian/Ubuntu systems
- jq automatically installs if missing (no manual intervention)
- All tests pass
- Breaking: Systems without package manager and without jq will fail (but this was already the case - json_build requires jq)

Future Work:
- Implement python fallbacks for json_build() to make jq truly optional
- Would enable installation on minimal systems (Alpine, BusyBox)

Fixes: Installation failure on Debian systems with missing jq
Related: Branch claude/fix-debian-install-01BSszt5gCjF8B8Fh5ixB2gH