### PR TITLE
Fix settings file command path

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/scripts/session-start.sh"
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/scripts/session-start.sh"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/scripts/format-and-lint-shell.sh",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/scripts/format-and-lint-shell.sh",
             "timeout": 15
           }
         ]


### PR DESCRIPTION
- Use escaped quotes format: ""/.claude/scripts/...
- Apply consistent format to SessionStart, PostToolUse, and Stop hooks
- Fixes path resolution for hook commands