### PR TITLE
Improve coverage harness stability

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1370,5 +1370,7 @@ main() {
     fi
 }
 
-# Execute main function
-main "$@"
+# Execute main function only when run directly (not when sourced for tests)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/tests/test-runner.sh
+++ b/tests/test-runner.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+export TERM="xterm"
 
 # Test statistics
 TOTAL_TESTS=0

--- a/tests/unit/test_config_generation.sh
+++ b/tests/unit/test_config_generation.sh
@@ -6,6 +6,7 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
+export TERM="xterm"
 
 # Test statistics
 TOTAL_TESTS=0

--- a/tests/unit/test_logging_core.sh
+++ b/tests/unit/test_logging_core.sh
@@ -7,6 +7,7 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
+export TERM="xterm"
 
 # Test statistics
 TOTAL_TESTS=0
@@ -60,6 +61,7 @@ assert_contains() {
     local test_name="$1"
     local haystack="$2"
     local needle="$3"
+    haystack="$(echo -e "$haystack" | sed -E $'s/\\x1B\\[[0-9;]*[A-Za-z]//g; s/\\x1B\\(B//g')"
 
     TOTAL_TESTS=$((TOTAL_TESTS + 1))
 
@@ -79,6 +81,7 @@ assert_not_contains() {
     local test_name="$1"
     local haystack="$2"
     local needle="$3"
+    haystack="$(echo -e "$haystack" | sed -E $'s/\\x1B\\[[0-9;]*[A-Za-z]//g; s/\\x1B\\(B//g')"
 
     TOTAL_TESTS=$((TOTAL_TESTS + 1))
 


### PR DESCRIPTION
## Summary
- guard install.sh so main only runs when executed directly, allowing tests to source it safely
- stabilize test harnesses by exporting TERM and stripping ANSI sequences in logging assertions
- remove generated coverage artifacts and the stub-only coverage helper to keep the suite honest

## Testing
- bash tests/test-runner.sh unit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69533c229a408324bc8288d908793b10)