### PR TITLE
Improve backup restore staging and rollback

### DIFF
--- a/lib/backup.sh
+++ b/lib/backup.sh
@@ -184,6 +184,74 @@ backup_restore() {
 
   local temp_dir
   temp_dir=$(create_temp_dir "restore") || return 1
+  local rollback_dir
+  rollback_dir=$(create_temp_dir "restore-rollback") || {
+    rm -rf "$temp_dir"
+    return 1
+  }
+  local stage_dir="$temp_dir/stage"
+  mkdir -p "$stage_dir"
+
+  local systemctl_available=0
+  local service_was_running=0
+  local rollback_prepared=false
+
+  restore_cleanup() {
+    local status=$1
+    local exit_msg="Restore failed"
+
+    # Disable errexit for cleanup operations
+    set +e
+
+    if [[ -d "$temp_dir" ]]; then
+      rm -rf "$temp_dir"
+    fi
+
+    if [[ $status -ne 0 && "$rollback_prepared" == "true" ]]; then
+      warn "Restore failed, rolling back changes..."
+
+      [[ -f "$rollback_dir/config/config.json" ]] && cp -a "$rollback_dir/config/config.json" "$SB_CONF"
+      [[ -f "$rollback_dir/config/client-info.txt" ]] && cp -a "$rollback_dir/config/client-info.txt" "$CLIENT_INFO"
+
+      if [[ -d "$rollback_dir/certificates" ]]; then
+        mkdir -p "$CERT_DIR_BASE"
+        for domain_dir in "$rollback_dir/certificates"/*; do
+          [[ -d "$domain_dir" ]] || continue
+          local domain_name
+          domain_name=$(basename "$domain_dir")
+          rm -rf "$CERT_DIR_BASE/$domain_name"
+          cp -a "$domain_dir" "$CERT_DIR_BASE/" 2>/dev/null || warn "Failed to restore certificates for $domain_name"
+        done
+      fi
+
+      if [[ -f "$rollback_dir/service/sing-box.service" ]]; then
+        cp -a "$rollback_dir/service/sing-box.service" "$SB_SVC" 2>/dev/null || warn "Failed to restore systemd service file"
+        if (( systemctl_available )); then
+          systemctl daemon-reload >/dev/null 2>&1 || warn "Failed to reload systemd during rollback"
+        fi
+      fi
+
+      warn "$exit_msg"
+    fi
+
+    if [[ -d "$rollback_dir" ]]; then
+      rm -rf "$rollback_dir"
+    fi
+
+    if (( systemctl_available )); then
+      if [[ $service_was_running -eq 1 ]]; then
+        msg "Restarting sing-box service..."
+        systemctl start sing-box >/dev/null 2>&1 && success "  ✓ Service restarted" || warn "  ✗ Failed to restart service"
+      elif [[ $status -eq 0 && "${AUTO_START:-1}" == "1" ]]; then
+        msg "Starting sing-box service..."
+        systemctl start sing-box >/dev/null 2>&1 && success "  ✓ Service started" || err "  ✗ Service failed to start"
+      fi
+    fi
+
+    # Re-enable errexit
+    set -e
+  }
+  trap 'restore_cleanup $?' EXIT
 
   # Decrypt if encrypted
   local archive_to_extract="$backup_file"
@@ -261,67 +329,119 @@ backup_restore() {
     die "Backup directory not found: $backup_root"
   fi
 
-  # Stop service before restore
-  if systemctl is-active sing-box >/dev/null 2>&1; then
-    msg "Stopping sing-box service..."
-    systemctl stop sing-box
-  fi
+  local required_config="$backup_root/config/config.json"
+  [[ -f "$required_config" ]] || die "Backup is missing required configuration file"
 
-  # Restore configuration
-  if [[ -f "$backup_root/config/config.json" ]]; then
-    mkdir -p "$SB_CONF_DIR"
-    cp "$backup_root/config/config.json" "$SB_CONF"
-    chmod 600 "$SB_CONF"
-    success "  ✓ Restored configuration"
-  fi
+  local client_info_source="$backup_root/config/client-info.txt"
+  local service_source="$backup_root/service/sing-box.service"
 
-  if [[ -f "$backup_root/config/client-info.txt" ]]; then
-    cp "$backup_root/config/client-info.txt" "$CLIENT_INFO"
-    chmod 600 "$CLIENT_INFO"
-    success "  ✓ Restored client info"
-  fi
-
-  # Restore certificates
+  local -a cert_domains=()
   if [[ -d "$backup_root/certificates" ]]; then
-    for domain_dir in "$backup_root/certificates"/*; do
+    while IFS= read -r domain_dir; do
       [[ -d "$domain_dir" ]] || continue
       local domain_name
       domain_name=$(basename "$domain_dir")
 
-      mkdir -p "$CERT_DIR_BASE/$domain_name"
-      cp "$domain_dir"/*.pem "$CERT_DIR_BASE/$domain_name/"
-      chmod 600 "$CERT_DIR_BASE/$domain_name"/*.pem
-      success "  ✓ Restored certificates for $domain_name"
+      if [[ ! -f "$domain_dir/fullchain.pem" || ! -f "$domain_dir/privkey.pem" ]]; then
+        die "Certificate set incomplete for domain: $domain_name"
+      fi
+
+      cert_domains+=("$domain_name")
+    done < <(find "$backup_root/certificates" -mindepth 1 -maxdepth 1 -type d | sort)
+  fi
+
+  if [[ -n "$service_source" && -f "$service_source" && ! -s "$service_source" ]]; then
+    die "Service file in backup is empty"
+  fi
+
+  mkdir -p "$stage_dir/config" "$stage_dir/certificates" "$stage_dir/service"
+  cp "$required_config" "$stage_dir/config/config.json"
+  [[ -f "$client_info_source" ]] && cp "$client_info_source" "$stage_dir/config/client-info.txt"
+  [[ -f "$service_source" ]] && cp "$service_source" "$stage_dir/service/sing-box.service"
+
+  for domain in "${cert_domains[@]}"; do
+    mkdir -p "$stage_dir/certificates/$domain"
+    cp "$backup_root/certificates/$domain"/*.pem "$stage_dir/certificates/$domain/"
+  done
+
+  if [[ -x "$SB_BIN" ]]; then
+    msg "Validating configuration..."
+    $SB_BIN check -c "$stage_dir/config/config.json" || die "Configuration validation failed"
+  else
+    warn "Cannot validate configuration: $SB_BIN not executable"
+  fi
+
+  if command -v systemctl >/dev/null 2>&1; then
+    systemctl_available=1
+    if systemctl is-active sing-box >/dev/null 2>&1; then
+      service_was_running=1
+    fi
+  fi
+
+  rollback_prepared=true
+  mkdir -p "$rollback_dir/config" "$rollback_dir/certificates" "$rollback_dir/service"
+  [[ -f "$SB_CONF" ]] && cp -a "$SB_CONF" "$rollback_dir/config/config.json"
+  [[ -f "$CLIENT_INFO" ]] && cp -a "$CLIENT_INFO" "$rollback_dir/config/client-info.txt"
+  [[ -f "$SB_SVC" ]] && cp -a "$SB_SVC" "$rollback_dir/service/sing-box.service"
+
+  for domain in "${cert_domains[@]}"; do
+    local existing_cert_dir="$CERT_DIR_BASE/$domain"
+    if [[ -d "$existing_cert_dir" ]]; then
+      mkdir -p "$rollback_dir/certificates"
+      cp -a "$existing_cert_dir" "$rollback_dir/certificates/"
+    fi
+  done
+
+  if (( systemctl_available )) && [[ $service_was_running -eq 1 ]]; then
+    msg "Stopping sing-box service..."
+    systemctl stop sing-box >/dev/null 2>&1 || warn "  ✗ Failed to stop service"
+  fi
+
+  mkdir -p "$SB_CONF_DIR"
+
+  local config_tmp
+  config_tmp=$(mktemp "$SB_CONF_DIR/config.json.XXXX")
+  cp "$stage_dir/config/config.json" "$config_tmp"
+  chmod 600 "$config_tmp"
+  mv -f "$config_tmp" "$SB_CONF"
+  success "  ✓ Restored configuration"
+
+  if [[ -f "$stage_dir/config/client-info.txt" ]]; then
+    local client_tmp
+    client_tmp=$(mktemp "$SB_CONF_DIR/client-info.txt.XXXX")
+    cp "$stage_dir/config/client-info.txt" "$client_tmp"
+    chmod 600 "$client_tmp"
+    mv -f "$client_tmp" "$CLIENT_INFO"
+    success "  ✓ Restored client info"
+  fi
+
+  if [[ ${#cert_domains[@]} -gt 0 ]]; then
+    mkdir -p "$CERT_DIR_BASE"
+    for domain in "${cert_domains[@]}"; do
+      local domain_target="$CERT_DIR_BASE/$domain"
+      local domain_tmp
+      domain_tmp=$(mktemp -d "$CERT_DIR_BASE/${domain}.XXXX")
+      cp "$stage_dir/certificates/$domain"/*.pem "$domain_tmp/"
+      chmod 600 "$domain_tmp"/*.pem
+      rm -rf "$domain_target"
+      mv -f "$domain_tmp" "$domain_target"
+      success "  ✓ Restored certificates for $domain"
     done
   fi
 
-  # Restore service file
-  if [[ -f "$backup_root/service/sing-box.service" ]]; then
-    cp "$backup_root/service/sing-box.service" "$SB_SVC"
-    systemctl daemon-reload
+  if [[ -f "$stage_dir/service/sing-box.service" ]]; then
+    local service_tmp
+    service_tmp=$(mktemp "$(dirname "$SB_SVC")/sing-box.service.XXXX")
+    cp "$stage_dir/service/sing-box.service" "$service_tmp"
+    chmod 644 "$service_tmp"
+    mv -f "$service_tmp" "$SB_SVC"
+    if (( systemctl_available )); then
+      systemctl daemon-reload >/dev/null 2>&1 || warn "  ✗ Failed to reload systemd"
+    fi
     success "  ✓ Restored systemd service"
   fi
 
-  # Validate restored configuration
-  if [[ -f "$SB_BIN" && -f "$SB_CONF" ]]; then
-    msg "Validating configuration..."
-    $SB_BIN check -c "$SB_CONF" || warn "Configuration validation failed"
-  fi
-
-  # Cleanup
-  rm -rf "$temp_dir"
-
   success "Restore completed successfully!"
-
-  # Prompt to start service
-  if [[ "${AUTO_START:-1}" == "1" ]]; then
-    msg "Starting sing-box service..."
-    systemctl start sing-box
-    sleep 2
-    systemctl is-active sing-box && success "  ✓ Service started" || err "  ✗ Service failed to start"
-  else
-    info "Start service manually with: systemctl start sing-box"
-  fi
 }
 
 #==============================================================================

--- a/tests/unit/test_backup_restore_failure_safety.sh
+++ b/tests/unit/test_backup_restore_failure_safety.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# tests/unit/test_backup_restore_failure_safety.sh - Validate restore safety on corrupted backups
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# Use test framework assertions
+source "${PROJECT_ROOT}/tests/test_framework.sh"
+
+# Keep certificates in a temp directory to avoid polluting /etc/ssl
+TEST_CERT_DIR="$(mktemp -d /tmp/sbx-test-certs.XXXXXX)"
+export CERT_DIR_BASE="$TEST_CERT_DIR"
+
+# Load the backup module
+source "${PROJECT_ROOT}/lib/backup.sh" 2>/dev/null || {
+  echo "ERROR: Failed to load lib/backup.sh"
+  exit 1
+}
+
+# Disable traps after loading modules
+trap - EXIT INT TERM
+set +e
+
+test_corrupted_archive_preserves_state() {
+  echo ""
+  echo "Test: corrupted archive does not change live state"
+
+  local tmpdir
+  tmpdir="$(create_test_tmpdir)"
+
+  local systemctl_log="${tmpdir}/systemctl.log"
+  mkdir -p "${tmpdir}/bin"
+  cat > "${tmpdir}/bin/systemctl" <<'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "${TMP_SYSTEMCTL_LOG}"
+if [[ "$1" == "is-active" ]]; then
+  exit 1
+fi
+exit 0
+EOF
+  chmod +x "${tmpdir}/bin/systemctl"
+  export TMP_SYSTEMCTL_LOG="$systemctl_log"
+  export PATH="${tmpdir}/bin:${PATH}"
+
+  local conf_root="${tmpdir}/conf"
+  local cert_root="${tmpdir}/certs"
+  local service_root="${tmpdir}/service"
+  mkdir -p "$conf_root" "$cert_root/example.com" "$service_root"
+
+  local cleanup_symlink_conf=false
+  local cleanup_symlink_certs=false
+  local restore_conf_backup=""
+  local restore_cert_backup=""
+  local restore_service_backup=""
+
+  if [[ -e /etc/sing-box ]]; then
+    restore_conf_backup="${tmpdir}/conf-backup"
+    cp -a /etc/sing-box "$restore_conf_backup"
+    rm -rf /etc/sing-box
+  fi
+
+  if [[ -e /etc/ssl/sbx ]]; then
+    restore_cert_backup="${tmpdir}/cert-backup"
+    cp -a /etc/ssl/sbx "$restore_cert_backup"
+    rm -rf /etc/ssl/sbx
+  fi
+
+  if [[ -e /etc/systemd/system/sing-box.service ]]; then
+    restore_service_backup="${tmpdir}/service-backup"
+    cp -a /etc/systemd/system/sing-box.service "$restore_service_backup"
+    rm -f /etc/systemd/system/sing-box.service
+  fi
+
+  ln -s "$conf_root" /etc/sing-box
+  cleanup_symlink_conf=true
+
+  ln -s "$cert_root" /etc/ssl/sbx
+  cleanup_symlink_certs=true
+
+  ln -s "$service_root/sing-box.service" /etc/systemd/system/sing-box.service
+
+  echo "original-config" > "$conf_root/config.json"
+  echo "original-client" > "$conf_root/client-info.txt"
+  echo "original-fullchain" > "$cert_root/example.com/fullchain.pem"
+  echo "original-privkey" > "$cert_root/example.com/privkey.pem"
+  echo "original-service" > "$service_root/sing-box.service"
+
+  local corrupt_archive
+  corrupt_archive="$(mktemp /tmp/sbx-corrupt-backup.XXXX)"
+  echo "not-a-tarball" > "$corrupt_archive"
+
+  local status=0
+  (FORCE=1 TMP_SYSTEMCTL_LOG="$systemctl_log" backup_restore "$corrupt_archive") || status=$?
+
+  assert_failure "[[ $status -eq 0 ]]" "Restore should fail for corrupted archive"
+  assert_equals "original-config" "$(cat "$conf_root/config.json")" "Config unchanged after failed restore"
+  assert_equals "original-client" "$(cat "$conf_root/client-info.txt")" "Client info unchanged after failed restore"
+  assert_equals "original-fullchain" "$(cat "$cert_root/example.com/fullchain.pem")" "Certificate fullchain unchanged after failed restore"
+  assert_equals "original-privkey" "$(cat "$cert_root/example.com/privkey.pem")" "Certificate privkey unchanged after failed restore"
+  assert_equals "original-service" "$(cat "$service_root/sing-box.service")" "Service file unchanged after failed restore"
+  assert_equals "" "$(cat "$systemctl_log" 2>/dev/null)" "Service state unchanged (no systemctl calls)"
+
+  rm -f "$corrupt_archive"
+
+  if [[ -n "$restore_service_backup" ]]; then
+    mv "$restore_service_backup" /etc/systemd/system/sing-box.service
+  else
+    rm -f /etc/systemd/system/sing-box.service
+  fi
+
+  if $cleanup_symlink_conf; then
+    rm -f /etc/sing-box
+  fi
+  if [[ -n "$restore_conf_backup" ]]; then
+    mv "$restore_conf_backup" /etc/sing-box
+  fi
+
+  if $cleanup_symlink_certs; then
+    rm -f /etc/ssl/sbx
+  fi
+  if [[ -n "$restore_cert_backup" ]]; then
+    mv "$restore_cert_backup" /etc/ssl/sbx
+  fi
+
+  cleanup_test_tmpdir "$tmpdir"
+  rm -rf "$TEST_CERT_DIR"
+}
+
+echo ""
+echo "=========================================="
+echo "Running test suite: backup_restore safety"
+echo "=========================================="
+
+test_corrupted_archive_preserves_state
+
+print_test_summary
+exit $?


### PR DESCRIPTION
## Summary
- stage restored config, certificates, and service files in a temporary directory, validating inputs before atomic replacement
- add rollback and service restart handling to preserve prior state when restore fails
- add a unit test that simulates a corrupted backup archive to ensure config and service remain unchanged after failure

## Testing
- tests/test-runner.sh unit


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695353bc4d888324bc4fa7aa3ae94dc4)