### PR TITLE
Fix unspecified issue

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,6 +26,8 @@ readonly MIN_MANAGER_FILE_SIZE_BYTES=5000  # Manager script validation (~15KB ex
 
 # Network configuration
 readonly NETWORK_TIMEOUT_SEC=5  # Used by get_public_ip() during bootstrap
+readonly IPV6_TEST_TIMEOUT_SEC=3  # Used by detect_ipv6_support() during bootstrap
+readonly IPV6_PING_WAIT_SEC=2  # Used by detect_ipv6_support() during bootstrap
 
 # Reality validation constraints (used by lib/validation.sh during bootstrap)
 readonly REALITY_SHORT_ID_MIN_LENGTH=1

--- a/tests/unit/test_bootstrap_constants.sh
+++ b/tests/unit/test_bootstrap_constants.sh
@@ -5,12 +5,14 @@
 #
 # CONTEXT: This codebase has repeatedly suffered from constants being defined in
 # lib/common.sh but used during bootstrap before modules are loaded. This has
-# caused 3+ production bugs:
+# caused 6+ production bugs:
 # - url variable (install.sh:836)
 # - HTTP_DOWNLOAD_TIMEOUT_SEC
 # - get_file_size()
 # - REALITY_SHORT_ID_MIN_LENGTH (this fix)
 # - REALITY_FLOW_VISION (this fix)
+# - IPV6_TEST_TIMEOUT_SEC (this fix)
+# - IPV6_PING_WAIT_SEC (this fix)
 #
 # SOLUTION: This test validates:
 # 1. All bootstrap constants are defined in install.sh early section
@@ -63,6 +65,8 @@ DOWNLOAD_CONSTANTS=(
 # Network configuration constants
 NETWORK_CONSTANTS=(
     "NETWORK_TIMEOUT_SEC"
+    "IPV6_TEST_TIMEOUT_SEC"
+    "IPV6_PING_WAIT_SEC"
 )
 
 # Reality validation constants (used by lib/validation.sh during bootstrap)


### PR DESCRIPTION
…nstants

These constants were used by detect_ipv6_support() in lib/network.sh but only defined in lib/common.sh. During bootstrap, network.sh was sourced before common.sh definitions took effect, causing "unbound variable" errors on line 280.

Changes:
- Added IPV6_TEST_TIMEOUT_SEC=3 and IPV6_PING_WAIT_SEC=2 to install.sh early constants section
- Updated test_bootstrap_constants.sh to track these constants
- Updated bug count from 3+ to 6+ in test documentation

Root cause: Same pattern as previous unbound variable bugs (url, HTTP_DOWNLOAD_TIMEOUT_SEC, get_file_size, REALITY_* constants).

Tested: bash -u install.sh --help (no unbound variable errors)