### PR TITLE
Change error handling test from failure to informational warning

### DIFF
--- a/tests/unit/test_module_download_validation.sh
+++ b/tests/unit/test_module_download_validation.sh
@@ -212,7 +212,7 @@ fi
 #==============================================================================
 test_start "Modules have error handling (die, err, or return codes)"
 
-failures=0
+warnings=0
 for module in "$SCRIPT_DIR"/lib/*.sh; do
   # Skip colors.sh as it just defines constants
   if [[ "$(basename "$module")" == "colors.sh" ]]; then
@@ -222,18 +222,14 @@ for module in "$SCRIPT_DIR"/lib/*.sh; do
   # Check if module has error handling
   if ! grep -qE 'die |err |return 1|exit 1' "$module"; then
     echo ""
-    echo "  WARNING: $(basename "$module") may lack error handling"
-    failures=$((failures + 1))
+    echo "  INFO: $(basename "$module") may lack error handling"
+    warnings=$((warnings + 1))
   fi
 done
 
-if [[ $failures -eq 0 ]]; then
-  test_pass
-else
-  # This is a warning, not a failure
-  test_pass
-  echo "    (Note: $failures modules may need error handling review)"
-fi
+# This is informational only - modules without error handling may be intentional
+test_pass
+[[ $warnings -gt 0 ]] && echo "    (Note: $warnings modules may need error handling review)"
 
 #==============================================================================
 # Test 9: Module size distribution is reasonable


### PR DESCRIPTION
## Summary
Updated the module error handling validation test to treat missing error handling as an informational warning rather than a test failure. This acknowledges that some modules may intentionally lack error handling mechanisms.

## Key Changes
- Renamed `failures` variable to `warnings` to better reflect the test's purpose
- Changed warning message from "WARNING" to "INFO" to indicate informational status
- Modified test logic to always pass (`test_pass`) regardless of whether modules lack error handling
- Simplified the conditional logic by removing the redundant if/else block
- Added clarifying comment explaining that missing error handling may be intentional

## Implementation Details
The test now:
1. Scans all modules in `lib/*.sh` for error handling patterns (die, err, return 1, exit 1)
2. Reports any modules without these patterns as informational notes
3. Always passes the test, treating the findings as guidance rather than blockers
4. Displays a summary count of modules that may need review if any are found

This change makes the test less strict while still providing visibility into modules that might benefit from improved error handling.