### PR TITLE
Simplify service status check and remove redundant return statement

### DIFF
--- a/lib/service.sh
+++ b/lib/service.sh
@@ -203,11 +203,7 @@ validate_port_listening() {
 
 # Check if sing-box service is running
 check_service_status() {
-  if systemctl is-active sing-box > /dev/null 2>&1; then
-    return 0
-  else
-    return 1
-  fi
+  systemctl is-active sing-box > /dev/null 2>&1
 }
 
 # Stop sing-box service

--- a/lib/validation.sh
+++ b/lib/validation.sh
@@ -569,8 +569,6 @@ _validate_incompatible_combinations() {
       return 0
       ;;
   esac
-
-  return 0
 }
 
 #==============================================================================


### PR DESCRIPTION
## Summary
This PR refactors two functions to improve code clarity and remove unnecessary logic:

## Key Changes
- **lib/service.sh**: Simplified `check_service_status()` function by removing the explicit if-else block and directly returning the exit code from `systemctl is-active`. The function now returns the command's exit status directly (0 for success, 1 for failure).
- **lib/validation.sh**: Removed redundant `return 0` statement at the end of `_validate_incompatible_combinations()` function, as the function already returns 0 in all code paths via the case statement.

## Implementation Details
These changes follow the principle of code simplification without altering functionality:
- The `systemctl is-active` command already returns the appropriate exit code, eliminating the need for conditional logic
- Both functions maintain their original behavior while reducing lines of code and improving readability