### PR TITLE
Refactor log level checking to use centralized LOG_LEVELS array

### DIFF
--- a/lib/logging.sh
+++ b/lib/logging.sh
@@ -119,19 +119,11 @@ log_json() {
 # Check if message should be logged based on level
 _should_log() {
   local msg_level="$1"
-  # Map log level to numeric value
-  local msg_level_value=0
-  case "${msg_level}" in
-    ERROR) msg_level_value=0 ;;
-    WARN)  msg_level_value=1 ;;
-    INFO)  msg_level_value=2 ;;
-    DEBUG) msg_level_value=3 ;;
-    *)     msg_level_value=2 ;;  # Default to INFO level
-  esac
-
   [[ -z "${LOG_LEVEL_FILTER:-}" ]] && return 0
-  [[ ${msg_level_value} -le ${LOG_LEVEL_CURRENT:-2} ]] && return 0
-  return 1
+
+  # Use LOG_LEVELS array for lookup, defaulting to INFO level (2)
+  local msg_level_value="${LOG_LEVELS[${msg_level}]:-2}"
+  [[ ${msg_level_value} -le ${LOG_LEVEL_CURRENT:-2} ]]
 }
 
 #==============================================================================


### PR DESCRIPTION
## Summary
Refactored the `_should_log()` function to use a centralized `LOG_LEVELS` associative array for log level lookups instead of maintaining a local case statement. This improves code maintainability and reduces duplication.

## Key Changes
- Removed inline case statement that mapped log levels (ERROR, WARN, INFO, DEBUG) to numeric values
- Replaced with lookup from `LOG_LEVELS` array with a default fallback to INFO level (2)
- Simplified return logic by directly returning the result of the comparison instead of explicit return statements
- Reduced function from 14 lines to 8 lines while maintaining identical behavior

## Implementation Details
- The `LOG_LEVELS` array is now the single source of truth for log level mappings across the codebase
- Default value of 2 (INFO level) is preserved for unknown log levels via parameter expansion `${LOG_LEVELS[${msg_level}]:-2}`
- Function behavior remains unchanged: returns 0 (success) if message should be logged, 1 (failure) otherwise