### PR TITLE
Add Cloudflare API token creation guide to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ DOMAIN=your.domain.com CF_MODE=1 bash <(curl -fsSL https://raw.githubusercontent
 CF_API_TOKEN=your_token CERT_MODE=cf_dns DOMAIN=your.domain.com bash <(curl -fsSL https://raw.githubusercontent.com/xrf9268-hue/sbx/main/install.sh)
 ```
 
+> **Note:** See [docs/ADVANCED.md](docs/ADVANCED.md#how-to-create-a-cloudflare-api-token) for how to create a Cloudflare API token.
+
 ## Features
 
 - **Zero config** - Auto-detects IP, no domain/certs needed

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -86,6 +86,44 @@ CF_API_TOKEN=your_cf_api_token CERT_MODE=cf_dns DOMAIN=your.domain.com bash inst
 - Cloudflare API token with Zone:DNS:Edit permissions
 - Domain managed by Cloudflare DNS
 
+##### How to Create a Cloudflare API Token
+
+1. **Log in to Cloudflare Dashboard**
+   - Go to https://dash.cloudflare.com/
+   - Sign in with your Cloudflare account
+
+2. **Navigate to API Tokens**
+   - Click your profile icon (top right)
+   - Select **My Profile**
+   - Click **API Tokens** tab
+
+3. **Create Custom Token**
+   - Click **Create Token**
+   - Click **Get started** under "Create Custom Token"
+
+4. **Configure Token Permissions**
+   - **Token name**: `sbx-dns-01` (or any descriptive name)
+   - **Permissions**:
+     - Zone → DNS → Edit
+   - **Zone Resources**:
+     - Include → Specific zone → Select your domain
+   - **Client IP Address Filtering** (optional but recommended):
+     - Add your server's IP for extra security
+   - **TTL** (optional):
+     - Set expiration date if desired
+
+5. **Create and Copy Token**
+   - Click **Continue to summary**
+   - Click **Create Token**
+   - **Copy the token immediately** (it won't be shown again)
+
+6. **Use the Token**
+   ```bash
+   CF_API_TOKEN=your_copied_token CERT_MODE=cf_dns DOMAIN=your.domain.com bash install.sh
+   ```
+
+**Token format:** Cloudflare API tokens are 40 alphanumeric characters (e.g., `abcdefghijklmnopqrstuvwxyz1234567890ABCD`).
+
 **Security note:** The Caddy binary for DNS-01 mode is downloaded from caddyserver.com/api/download with dual-download integrity verification. For maximum security, build Caddy locally with xcaddy.
 
 ### Debugging

--- a/docs/REALITY_TROUBLESHOOTING.md
+++ b/docs/REALITY_TROUBLESHOOTING.md
@@ -84,6 +84,8 @@ Requirements:
 - Cloudflare API token with Zone:DNS:Edit permissions
 - Domain managed by Cloudflare DNS
 
+**How to get CF_API_TOKEN:** See [docs/ADVANCED.md](ADVANCED.md#how-to-create-a-cloudflare-api-token) for step-by-step instructions.
+
 **B. Free port 80:**
 ```bash
 # Find what's using port 80


### PR DESCRIPTION
## Summary
Added comprehensive documentation for creating Cloudflare API tokens, addressing a common pain point for users setting up DNS-01 certificate validation mode.

## Changes
- **README.md**: Added a note linking to the new Cloudflare API token creation guide
- **docs/ADVANCED.md**: Added detailed step-by-step instructions for creating a Cloudflare API token with proper permissions and security considerations
- **docs/REALITY_TROUBLESHOOTING.md**: Added a reference link to the API token creation guide

## Details
The new guide includes:
- Step-by-step instructions for accessing Cloudflare Dashboard and API Tokens section
- Token configuration with required Zone:DNS:Edit permissions
- Zone resource selection for specific domains
- Optional security recommendations (IP filtering, TTL/expiration)
- Token format reference for validation
- Usage example with the install command

This improves the user experience by providing clear, actionable guidance for users who need to set up DNS-01 certificate validation with Cloudflare.

https://claude.ai/code/session_012yDHUVb2LA54hb9NHGjSyP