### PR TITLE
docs: update client recommendations and clean up 1.12.0 version references

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,15 @@ sbx help      # All commands
 
 | Platform | Recommended Client |
 |----------|-------------------|
-| Windows/Linux | [NekoRay](https://github.com/MatsuriDayo/nekoray) |
-| macOS | [NekoBox](https://github.com/MatsuriDayo/NekoBoxForAndroid) |
-| Android | [NekoBox](https://github.com/MatsuriDayo/NekoBoxForAndroid) |
-| iOS | [sing-box](https://apps.apple.com/app/sing-box/id6451272673) (free) |
+| Windows | [v2rayN](https://github.com/2dust/v2rayN) (sing-box core) |
+| macOS | [Hiddify](https://github.com/hiddify/hiddify-app) |
+| Linux | [Hiddify](https://github.com/hiddify/hiddify-app) |
+| Android | [sing-box](https://sing-box.sagernet.org/clients/) (official SFA) |
+| iOS | [sing-box](https://apps.apple.com/app/sing-box/id6451272673) (official SFI) |
 
 **Import**: Copy URI → Paste in client → Connect
 
-> **v2rayN/v2rayNG users**: Switch core to sing-box in Settings → Core Type
+> **v2rayN users**: Switch core to sing-box in Settings → Core Type
 
 ## Troubleshooting
 

--- a/docs/REALITY_BEST_PRACTICES.md
+++ b/docs/REALITY_BEST_PRACTICES.md
@@ -678,16 +678,14 @@ sbx backup restore backup-file.tar.gz.enc
 
 | Platform | Client | sing-box Support | Notes |
 |----------|--------|------------------|-------|
-| Windows | NekoRay | ✅ Native | Best choice |
-| Windows | v2rayN | ✅ Switch core | Requires core switch |
-| macOS | NekoBox | ✅ Native | Recommended |
-| Linux | NekoRay | ✅ Native | Full support |
-| Android | v2rayNG | ✅ Switch core | Requires core switch |
-| Android | NekoBox | ✅ Native | Recommended |
-| iOS | Shadowrocket | ✅ Native | Commercial |
-| iOS | sing-box | ✅ Official | Free, open source |
+| Windows | v2rayN | ✅ sing-box core | Best choice, actively maintained |
+| macOS | Hiddify | ✅ Native | Open source, ad-free |
+| Linux | Hiddify | ✅ Native | Open source, ad-free |
+| Android | sing-box SFA | ✅ Official | Free, best compatibility |
+| Android | Hiddify | ✅ Native | Alternative, multi-core |
+| iOS | sing-box SFI | ✅ Official | Free, open source |
 
-**Key consideration:** Native sing-box support > Core switching required
+**Key consideration:** Official sing-box clients > Third-party with native support > Core switching required
 
 ---
 
@@ -700,7 +698,7 @@ sbx export uri reality
 
 # Import in client
 # - v2rayN: Import → From Clipboard
-# - NekoRay: Add → Import from Clipboard
+# - Hiddify: Add profile → Paste from clipboard
 ```
 
 **Method 2: JSON Configuration**
@@ -710,7 +708,7 @@ sbx export v2rayn reality > reality-client.json
 
 # Import in client
 # - v2rayN: Import → Custom config
-# - NekoRay: Import → From file
+# - Hiddify: Add profile → Import from file
 ```
 
 **Method 3: QR Code**
@@ -743,7 +741,7 @@ sbx export subscription
 - Check YAML syntax
 - Verify all required fields present
 
-**NekoRay import failed:**
+**Hiddify import failed:**
 - Remove line breaks from URI
 - Verify all parameters present
 - Check for typos in UUID/keys

--- a/docs/SING_BOX_VS_XRAY.md
+++ b/docs/SING_BOX_VS_XRAY.md
@@ -292,12 +292,10 @@ Public key: jNXHt1yRo0vDuchQlIP6Z0ZvjT3KtzVI-T4E7RoLJS0
 | Client | sing-box Core | Xray Core | Notes |
 |--------|---------------|-----------|-------|
 | **v2rayN** (Windows) | ✅ Supported | ✅ Supported | **Must manually switch core!** |
-| **v2rayNG** (Android) | ✅ Supported | ✅ Supported | **Must manually switch core!** |
-| **NekoRay/NekoBox** | ✅ Native | ✅ Supported | Detects automatically |
+| **Hiddify** (All platforms) | ✅ Native | ✅ Supported | Open source, ad-free |
 | **Clash Meta** | ✅ Supported | ✅ Supported | Auto-detects based on config |
-| **sing-box official** | ✅ Native | ❌ N/A | iOS, Android, CLI |
+| **sing-box official** (SFA/SFI) | ✅ Native | ❌ N/A | iOS, Android, recommended |
 | **Shadowrocket** (iOS) | ✅ Supported | ⚠️ Limited | Prefers sing-box format |
-| **Surge** (iOS/Mac) | ❌ Limited | ❌ Limited | Proprietary format |
 
 ### How to Switch Core in v2rayN
 

--- a/examples/reality-only/README.md
+++ b/examples/reality-only/README.md
@@ -130,7 +130,7 @@ sudo systemctl status sing-box
    clash-meta -d ~/.config/clash-meta
    ```
 
-#### NekoRay/NekoBox
+#### v2rayN / Hiddify / sing-box App
 
 1. Import share URI from `share-uri.txt`
 2. Or manually create:
@@ -143,6 +143,8 @@ sudo systemctl status sing-box
    - Public Key: (your public key)
    - Short ID: (your short ID)
    - SNI: www.microsoft.com
+
+> **v2rayN users**: Switch core to sing-box in Settings → Core Type
 
 ## Testing
 

--- a/examples/reality-only/server-config.json
+++ b/examples/reality-only/server-config.json
@@ -45,11 +45,10 @@
     {
       "type": "direct",
       "tag": "direct",
-      "tcp_fast_open": true
-    },
-    {
-      "type": "block",
-      "tag": "block"
+      "tcp_fast_open": true,
+      "udp_fragment": true,
+      "bind_address_no_port": true,
+      "tcp_keep_alive": "5m"
     }
   ],
   "route": {

--- a/examples/reality-only/share-uri.txt
+++ b/examples/reality-only/share-uri.txt
@@ -30,8 +30,8 @@ vless://REPLACE_WITH_YOUR_UUID@YOUR_SERVER_IP:443?encryption=none&flow=xtls-rprx
 # 2. Copy the entire line (no line breaks!)
 # 3. Import in your client:
 #    - v2rayN: Import → From Clipboard
-#    - NekoRay: Add → Import from Clipboard
-#    - Clash Meta: Parse subscription URL
+#    - Hiddify: Add profile → Paste from clipboard
+#    - sing-box App: Import → From Clipboard
 
 # Generating materials:
 #   UUID:        sing-box generate uuid

--- a/lib/config_validator.sh
+++ b/lib/config_validator.sh
@@ -282,7 +282,7 @@ validate_route_rules() {
 
     if [[ -n "${deprecated_sniff}" ]]; then
       err "Deprecated field 'sniff' found in inbound: ${deprecated_sniff}"
-      err "Use route rules with action: 'sniff' instead (sing-box 1.12.0+)"
+      err "Use route rules with action: 'sniff' instead (sing-box 1.13.0+)"
       has_errors=1
     fi
 
@@ -292,7 +292,7 @@ validate_route_rules() {
 
     if [[ -n "${deprecated_sniff_override}" ]]; then
       err "Deprecated field 'sniff_override_destination' found in inbound: ${deprecated_sniff_override}"
-      err "Use route rules instead (sing-box 1.12.0+)"
+      err "Use route rules instead (sing-box 1.13.0+)"
       has_errors=1
     fi
 
@@ -302,7 +302,7 @@ validate_route_rules() {
 
     if [[ -n "${deprecated_ds_inbound}" ]]; then
       err "Deprecated field 'domain_strategy' found in inbound: ${deprecated_ds_inbound}"
-      err "Use global dns.strategy instead (sing-box 1.12.0+)"
+      err "Use global dns.strategy instead (sing-box 1.13.0+)"
       has_errors=1
     fi
 
@@ -312,7 +312,7 @@ validate_route_rules() {
 
     if [[ -n "${deprecated_ds_outbound}" ]]; then
       err "Deprecated field 'domain_strategy' found in outbound: ${deprecated_ds_outbound}"
-      err "Use global dns.strategy instead (sing-box 1.12.0+)"
+      err "Use global dns.strategy instead (sing-box 1.13.0+)"
       has_errors=1
     fi
 

--- a/lib/network.sh
+++ b/lib/network.sh
@@ -314,11 +314,11 @@ detect_ipv6_support() {
   echo "${ipv6_supported}"
 }
 
-# Choose optimal listen address based on sing-box 1.12.0 best practices
+# Choose optimal listen address based on sing-box 1.13.0 best practices
 choose_listen_address() {
   local ipv6_supported="$1"
 
-  # Always use :: for dual-stack support as per sing-box 1.12.0 standards
+  # Always use :: for dual-stack support as per sing-box 1.13.0 standards
   # DNS strategy (ipv4_only/prefer_ipv4/prefer_ipv6) handles address selection
   # This is required to prevent "network unreachable" errors on IPv4-only systems
   # See: CLAUDE.md line 527, commit 771fca1

--- a/lib/schema_validator.sh
+++ b/lib/schema_validator.sh
@@ -2,7 +2,7 @@
 # lib/schema_validator.sh - JSON Schema validation for sing-box configurations
 #
 # This module provides JSON schema validation for Reality configurations
-# based on official sing-box 1.12.0+ standards.
+# based on official sing-box 1.13.0+ standards.
 #
 # Functions:
 #   - validate_config_schema: Validate configuration against JSON schema
@@ -52,7 +52,7 @@ check_schema_tool() {
   fi
 
   # Check for Python jsonschema
-  if have jsonschema 2>/dev/null; then
+  if have jsonschema 2> /dev/null; then
     echo "jsonschema"
     return 0
   fi
@@ -106,7 +106,7 @@ validate_config_schema() {
   msg "Validating configuration schema..."
 
   # Validate JSON syntax first
-  if ! jq empty "${config_file}" 2>/dev/null; then
+  if ! jq empty "${config_file}" 2> /dev/null; then
     err "Invalid JSON syntax in configuration file"
     return 1
   fi
@@ -176,7 +176,7 @@ _validate_reality_enabled() {
 
   # Check Reality enabled flag
   local reality_enabled=''
-  reality_enabled=$(jq -r '.inbounds[] | select(.tls.reality) | .tls.reality.enabled' "${config_file}" 2>/dev/null | head -1)
+  reality_enabled=$(jq -r '.inbounds[] | select(.tls.reality) | .tls.reality.enabled' "${config_file}" 2> /dev/null | head -1)
   if [[ "${reality_enabled}" != "true" ]]; then
     err "  ✗ Reality enabled flag not set to true"
     validation_failed=1
@@ -186,7 +186,7 @@ _validate_reality_enabled() {
 
   # Check TLS enabled when Reality is present
   local tls_enabled=''
-  tls_enabled=$(jq -r '.inbounds[] | select(.tls.reality) | .tls.enabled' "${config_file}" 2>/dev/null | head -1)
+  tls_enabled=$(jq -r '.inbounds[] | select(.tls.reality) | .tls.enabled' "${config_file}" 2> /dev/null | head -1)
   if [[ "${tls_enabled}" != "true" ]]; then
     err "  ✗ TLS must be enabled when using Reality"
     validation_failed=1
@@ -203,7 +203,7 @@ _validate_reality_required_fields() {
   local validation_failed=0
 
   # Check Reality is nested under tls, not top-level
-  if jq -e '.inbounds[].reality' "${config_file}" >/dev/null 2>&1; then
+  if jq -e '.inbounds[].reality' "${config_file}" > /dev/null 2>&1; then
     err "  ✗ Reality configuration is at top level (should be under tls.reality)"
     validation_failed=1
   else
@@ -214,7 +214,7 @@ _validate_reality_required_fields() {
   local required_fields=("private_key" "short_id" "handshake")
   local fields_ok=1
   for field in "${required_fields[@]}"; do
-    if ! jq -e ".inbounds[] | select(.tls.reality) | .tls.reality.${field}" "${config_file}" >/dev/null 2>&1; then
+    if ! jq -e ".inbounds[] | select(.tls.reality) | .tls.reality.${field}" "${config_file}" > /dev/null 2>&1; then
       err "  ✗ Missing required Reality field: ${field}"
       validation_failed=1
       fields_ok=0
@@ -234,7 +234,7 @@ _validate_reality_field_types() {
 
   # Check Short ID is array format
   local sid_type=''
-  sid_type=$(jq -r '.inbounds[] | select(.tls.reality) | .tls.reality.short_id | type' "${config_file}" 2>/dev/null | head -1)
+  sid_type=$(jq -r '.inbounds[] | select(.tls.reality) | .tls.reality.short_id | type' "${config_file}" 2> /dev/null | head -1)
   if [[ "${sid_type}" != "array" ]]; then
     err "  ✗ Short ID must be array format, got: ${sid_type}"
     validation_failed=1
@@ -254,7 +254,7 @@ _validate_reality_field_values() {
 
   # Check Short ID length (1-8 hex characters)
   local short_ids=''
-  short_ids=$(jq -r '.inbounds[] | select(.tls.reality) | .tls.reality.short_id[]?' "${config_file}" 2>/dev/null)
+  short_ids=$(jq -r '.inbounds[] | select(.tls.reality) | .tls.reality.short_id[]?' "${config_file}" 2> /dev/null)
   if [[ -n "${short_ids}" ]]; then
     sid_ok=1
     while IFS= read -r sid; do
@@ -271,7 +271,7 @@ _validate_reality_field_values() {
 
   # Check Flow field in users array
   local flow=''
-  flow=$(jq -r '.inbounds[] | select(.tls.reality) | .users[]?.flow?' "${config_file}" 2>/dev/null | head -1)
+  flow=$(jq -r '.inbounds[] | select(.tls.reality) | .users[]?.flow?' "${config_file}" 2> /dev/null | head -1)
   if [[ "${flow}" == "xtls-rprx-vision" ]]; then
     msg "  ✓ Flow field set to xtls-rprx-vision"
   elif [[ -z "${flow}" || "${flow}" == "null" ]]; then
@@ -282,8 +282,8 @@ _validate_reality_field_values() {
   fi
 
   # Check Handshake configuration
-  if jq -e '.inbounds[] | select(.tls.reality) | .tls.reality.handshake' "${config_file}" >/dev/null 2>&1; then
-    handshake_server=$(jq -r '.inbounds[] | select(.tls.reality) | .tls.reality.handshake.server' "${config_file}" 2>/dev/null | head -1)
+  if jq -e '.inbounds[] | select(.tls.reality) | .tls.reality.handshake' "${config_file}" > /dev/null 2>&1; then
+    handshake_server=$(jq -r '.inbounds[] | select(.tls.reality) | .tls.reality.handshake.server' "${config_file}" 2> /dev/null | head -1)
     if [[ -z "${handshake_server}" || "${handshake_server}" == "null" ]]; then
       err "  ✗ Handshake server not configured"
       validation_failed=1
@@ -291,7 +291,7 @@ _validate_reality_field_values() {
       msg "  ✓ Handshake server configured: ${handshake_server}"
     fi
 
-    handshake_port=$(jq -r '.inbounds[] | select(.tls.reality) | .tls.reality.handshake.server_port' "${config_file}" 2>/dev/null | head -1)
+    handshake_port=$(jq -r '.inbounds[] | select(.tls.reality) | .tls.reality.handshake.server_port' "${config_file}" 2> /dev/null | head -1)
     if [[ -z "${handshake_port}" || "${handshake_port}" == "null" ]]; then
       err "  ✗ Handshake server_port not configured"
       validation_failed=1
@@ -337,9 +337,9 @@ validate_reality_structure() {
   fi
 
   # Check if Reality configuration exists
-  if ! jq -e '.inbounds[].tls.reality' "${config_file}" >/dev/null 2>&1; then
+  if ! jq -e '.inbounds[].tls.reality' "${config_file}" > /dev/null 2>&1; then
     warn "No Reality configuration found in inbounds"
-    return 0  # Not a failure - config might not use Reality
+    return 0 # Not a failure - config might not use Reality
   fi
 
   msg "  ✓ Reality configuration detected"

--- a/lib/version.sh
+++ b/lib/version.sh
@@ -359,8 +359,8 @@ version_meets_minimum() {
 # Validate sing-box version for Reality protocol compatibility
 #
 # Checks:
-#   - Minimum version 1.8.0 (Reality support)
-#   - Recommended version 1.12.0 (modern config format)
+#   - Minimum version 1.13.0 (native ACME, deprecated removals)
+#   - Recommended version 1.13.0 (native ACME, no Caddy dependency)
 #
 # Returns:
 #   0 if validation passes (meets minimum)
@@ -373,7 +373,7 @@ version_meets_minimum() {
 #   validate_singbox_version || die "sing-box version too old"
 #
 validate_singbox_version() {
-  local min_version="1.13.0"          # ACME native + deprecated removals
+  local min_version="1.13.0"         # ACME native + deprecated removals
   local recommended_version="1.13.0" # Native ACME, no Caddy dependency
 
   msg "Checking sing-box version compatibility..."
@@ -436,18 +436,16 @@ show_version_info() {
   echo "============================"
   echo ""
   echo "Current version:     ${current_version}"
-  echo "Minimum required:    1.8.0  (Reality protocol support)"
-  echo "Recommended:         1.12.0 (Modern configuration format)"
+  echo "Minimum required:    1.13.0 (Native ACME, modern config format)"
+  echo "Recommended:         1.13.0 (Native ACME, no Caddy dependency)"
   echo "Latest info:         https://github.com/SagerNet/sing-box/releases"
   echo ""
 
   if [[ "${current_version}" != "unknown" ]]; then
-    if version_meets_minimum "${current_version}" "1.12.0"; then
+    if version_meets_minimum "${current_version}" "1.13.0"; then
       echo "Status: ✓ Fully compatible"
-    elif version_meets_minimum "${current_version}" "1.8.0"; then
-      echo "Status: ⚠ Compatible (upgrade recommended)"
     else
-      echo "Status: ✗ Upgrade required"
+      echo "Status: ✗ Upgrade required (minimum 1.13.0)"
     fi
   fi
 


### PR DESCRIPTION
- Replace discontinued NekoRay/NekoBox with actively maintained clients:
  Windows: v2rayN (sing-box core), macOS/Linux: Hiddify, Android: sing-box SFA
  NekoRay was archived 2025-03-17, NekoBox macOS link was incorrect
- Remove deprecated 'block' outbound from example server config
- Add 1.13.0 outbound fields to example config (bind_address_no_port, tcp_keep_alive)
- Update all remaining 1.12.0 version references to 1.13.0 in lib/ modules
- Simplify show_version_info() since min and recommended are both 1.13.0

https://claude.ai/code/session_014ghPAj9UDbZgKi4KBE7jPZ