### PR TITLE
feat: add TUIC V5 and Trojan protocol support (issue #96)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -76,6 +76,8 @@ readonly REALITY_SHORT_ID_MAX_LENGTH=8
 readonly REALITY_PORT_DEFAULT=443
 readonly WS_PORT_DEFAULT=8444
 readonly HY2_PORT_DEFAULT=8443
+readonly TUIC_PORT_DEFAULT=8445
+readonly TROJAN_PORT_DEFAULT=8446
 
 # ACME data directory (used by lib/config.sh for native ACME)
 readonly ACME_DATA_DIRECTORY="/var/lib/sing-box/acme"
@@ -113,7 +115,7 @@ get_file_size() {
   # Cross-platform file size retrieval
   # Linux: stat -c%s
   # BSD/macOS: stat -f%z
-  stat -c%s "${file}" 2>/dev/null || stat -f%z "${file}" 2>/dev/null || echo "0"
+  stat -c%s "${file}" 2> /dev/null || stat -f%z "${file}" 2> /dev/null || echo "0"
 }
 
 # Temporary create_temp_dir implementation for bootstrapping
@@ -122,14 +124,14 @@ create_temp_dir() {
   local prefix="${1:-sbx}"
   local temp_dir=''
 
-  if ! temp_dir=$(mktemp -d -t "${prefix}.XXXXXX" 2>/dev/null); then
+  if ! temp_dir=$(mktemp -d -t "${prefix}.XXXXXX" 2> /dev/null); then
     echo "ERROR: Failed to create temporary directory" >&2
     return 1
   fi
 
-  chmod "${SECURE_DIR_PERMISSIONS}" "${temp_dir}" 2>/dev/null || {
+  chmod "${SECURE_DIR_PERMISSIONS}" "${temp_dir}" 2> /dev/null || {
     echo "ERROR: Failed to set permissions on temporary directory: ${temp_dir}" >&2
-    rm -rf "${temp_dir}" 2>/dev/null || true
+    rm -rf "${temp_dir}" 2> /dev/null || true
     return 1
   }
 
@@ -139,7 +141,7 @@ create_temp_dir() {
 
 # Print usage help (must work before module loading)
 _print_help() {
-  cat <<'EOF'
+  cat << 'EOF'
 sbx-lite sing-box installer
 
 Usage:
@@ -192,13 +194,13 @@ _download_single_module() {
   [[ "${DEBUG:-0}" == "1" ]] && echo "DEBUG: Downloading ${module} from ${module_url}" >&2
 
   # Download module
-  if command -v curl >/dev/null 2>&1; then
+  if command -v curl > /dev/null 2>&1; then
     if ! curl -fsSL --connect-timeout "${DOWNLOAD_CONNECT_TIMEOUT_SEC}" --max-time "${DOWNLOAD_MAX_TIMEOUT_SEC}" "${module_url}" -o "${module_file}" 2>&1; then
       echo "DOWNLOAD_FAILED:${module}" >&2
       [[ "${DEBUG:-0}" == "1" ]] && echo "DEBUG: curl failed for ${module}" >&2
       return 1
     fi
-  elif command -v wget >/dev/null 2>&1; then
+  elif command -v wget > /dev/null 2>&1; then
     if ! wget -q --timeout="${DOWNLOAD_MAX_TIMEOUT_SEC}" "${module_url}" -O "${module_file}" 2>&1; then
       echo "DOWNLOAD_FAILED:${module}" >&2
       [[ "${DEBUG:-0}" == "1" ]] && echo "DEBUG: wget failed for ${module}" >&2
@@ -227,7 +229,7 @@ _download_single_module() {
   fi
 
   # Validate bash syntax
-  if ! bash -n "${module_file}" 2>/dev/null; then
+  if ! bash -n "${module_file}" 2> /dev/null; then
     echo "SYNTAX_ERROR:${module}" >&2
     [[ "${DEBUG:-0}" == "1" ]] && echo "DEBUG: Syntax check failed for ${module}" >&2
     return 1
@@ -322,15 +324,15 @@ _download_modules_sequential() {
     printf "  [%d/%d] Downloading %s..." "${current}" "${total}" "${module}.sh"
 
     # Download
-    if command -v curl >/dev/null 2>&1; then
-      if ! curl -fsSL --connect-timeout "${DOWNLOAD_CONNECT_TIMEOUT_SEC}" --max-time "${DOWNLOAD_MAX_TIMEOUT_SEC}" "${module_url}" -o "${module_file}" 2>/dev/null; then
+    if command -v curl > /dev/null 2>&1; then
+      if ! curl -fsSL --connect-timeout "${DOWNLOAD_CONNECT_TIMEOUT_SEC}" --max-time "${DOWNLOAD_MAX_TIMEOUT_SEC}" "${module_url}" -o "${module_file}" 2> /dev/null; then
         echo " ✗ FAILED"
         rm -rf "${temp_lib_dir}"
         _show_download_error_help "${module}" "${module_url}"
         return 1
       fi
-    elif command -v wget >/dev/null 2>&1; then
-      if ! wget -q --timeout="${DOWNLOAD_MAX_TIMEOUT_SEC}" "${module_url}" -O "${module_file}" 2>/dev/null; then
+    elif command -v wget > /dev/null 2>&1; then
+      if ! wget -q --timeout="${DOWNLOAD_MAX_TIMEOUT_SEC}" "${module_url}" -O "${module_file}" 2> /dev/null; then
         echo " ✗ FAILED"
         rm -rf "${temp_lib_dir}"
         _show_download_error_help "${module}" "${module_url}"
@@ -354,7 +356,7 @@ _download_modules_sequential() {
       return 1
     fi
 
-    if ! bash -n "${module_file}" 2>/dev/null; then
+    if ! bash -n "${module_file}" 2> /dev/null; then
       echo " ✗ SYNTAX ERROR"
       rm -rf "${temp_lib_dir}"
       _show_syntax_error "${module}"
@@ -447,15 +449,15 @@ _download_and_validate_manager_script() {
   [[ "${DEBUG:-0}" == "1" ]] && echo "DEBUG: Creating ${installer_dir}/bin directory" >&2
   mkdir -p "${installer_dir}/bin"
 
-  if command -v curl >/dev/null 2>&1; then
+  if command -v curl > /dev/null 2>&1; then
     [[ "${DEBUG:-0}" == "1" ]] && echo "DEBUG: Downloading sbx-manager.sh via curl from ${manager_url}" >&2
     if curl -fsSL --connect-timeout "${DOWNLOAD_CONNECT_TIMEOUT_SEC}" \
-      --max-time "${DOWNLOAD_MAX_TIMEOUT_SEC}" "${manager_url}" -o "${manager_file}" 2>/dev/null; then
+      --max-time "${DOWNLOAD_MAX_TIMEOUT_SEC}" "${manager_url}" -o "${manager_file}" 2> /dev/null; then
       download_success=1
     fi
-  elif command -v wget >/dev/null 2>&1; then
+  elif command -v wget > /dev/null 2>&1; then
     [[ "${DEBUG:-0}" == "1" ]] && echo "DEBUG: Downloading sbx-manager.sh via wget from ${manager_url}" >&2
-    if wget -q --timeout="${DOWNLOAD_MAX_TIMEOUT_SEC}" "${manager_url}" -O "${manager_file}" 2>/dev/null; then
+    if wget -q --timeout="${DOWNLOAD_MAX_TIMEOUT_SEC}" "${manager_url}" -O "${manager_file}" 2> /dev/null; then
       download_success=1
     fi
   else
@@ -485,7 +487,7 @@ _download_and_validate_manager_script() {
     return 1
   fi
 
-  if ! bash -n "${manager_file}" 2>/dev/null; then
+  if ! bash -n "${manager_file}" 2> /dev/null; then
     echo "ERROR: Invalid bash syntax in downloaded sbx-manager.sh"
     echo "       File may be corrupted."
     return 1
@@ -525,7 +527,7 @@ _load_modules() {
     fi
 
     # Download modules (parallel with fallback to sequential on failure)
-    if [[ ${use_parallel} -eq 1 ]] && command -v xargs >/dev/null 2>&1; then
+    if [[ ${use_parallel} -eq 1 ]] && command -v xargs > /dev/null 2>&1; then
       # Try parallel download first
       if ! _download_modules_parallel "${temp_lib_dir}" "${github_repo}" "${modules[@]}"; then
         # Parallel failed, fallback to sequential
@@ -641,7 +643,7 @@ _verify_module_apis() {
     local missing_functions=()
 
     for func in ${required_functions}; do
-      if ! declare -F "${func}" >/dev/null 2>&1; then
+      if ! declare -F "${func}" > /dev/null 2>&1; then
         missing_functions+=("${func}")
         all_ok=false
       fi
@@ -733,8 +735,8 @@ detect_libc() {
   fi
 
   # Method 2: Parse ldd output
-  if command -v ldd >/dev/null 2>&1; then
-    if ldd /bin/sh 2>/dev/null | grep -q musl; then
+  if command -v ldd > /dev/null 2>&1; then
+    if ldd /bin/sh 2> /dev/null | grep -q musl; then
       msg "Detected musl libc via ldd"
       echo "-musl"
       return
@@ -760,7 +762,7 @@ get_installed_version() {
   local version=''
   if [[ -x "${SB_BIN}" ]]; then
     # Match version with or without 'v' prefix (e.g., "v1.12.12" or "1.12.12")
-    version=$("${SB_BIN}" version 2>/dev/null | head -1 | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
+    version=$("${SB_BIN}" version 2> /dev/null | head -1 | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
 
     # Ensure version has 'v' prefix for consistency with the rest of the codebase
     if [[ "${version}" != "unknown" && "${version}" != v* ]]; then
@@ -810,8 +812,8 @@ compare_versions() {
   fi
 
   # Semantic version comparison (major.minor.patch)
-  IFS='.' read -r -a current_parts <<<"${current}"
-  IFS='.' read -r -a latest_parts <<<"${latest}"
+  IFS='.' read -r -a current_parts <<< "${current}"
+  IFS='.' read -r -a latest_parts <<< "${latest}"
 
   # Compare each component
   for i in 0 1 2; do
@@ -1088,7 +1090,7 @@ download_singbox() {
   # Stop service before replacing binary (prevents "Text file busy" error)
   # The service will be restarted by setup_service or restart_service in main flow
   local service_was_running=0
-  if check_service_status 2>/dev/null; then
+  if check_service_status 2> /dev/null; then
     msg "Stopping sing-box service for binary replacement..."
     stop_service
     service_was_running=1
@@ -1097,7 +1099,7 @@ download_singbox() {
   cp "${extracted_bin}" "${SB_BIN}" || {
     rm -rf "${tmp}"
     # Try to restart service if we stopped it
-    [[ "${service_was_running}" -eq 1 ]] && start_service_with_retry 2>/dev/null
+    [[ "${service_was_running}" -eq 1 ]] && start_service_with_retry 2> /dev/null
     die_with_code "SBX-DOWNLOAD-008" "Failed to install sing-box binary to target path." \
       "Check filesystem permissions and mount flags for /usr/local/bin." \
       "ls -ld /usr/local/bin && id"
@@ -1185,6 +1187,8 @@ _configure_cloudflare_mode() {
     ENABLE_REALITY="${ENABLE_REALITY:-0}"
     ENABLE_WS="${ENABLE_WS:-1}"
     ENABLE_HY2="${ENABLE_HY2:-0}"
+    ENABLE_TUIC="${ENABLE_TUIC:-0}"
+    ENABLE_TROJAN="${ENABLE_TROJAN:-0}"
 
     if [[ "${WS_PORT_USER_SPECIFIED:-0}" == "1" ]]; then
       WS_PORT="${WS_PORT:-443}"
@@ -1207,8 +1211,10 @@ _configure_cloudflare_mode() {
     ENABLE_REALITY="${ENABLE_REALITY:-1}"
     ENABLE_WS="${ENABLE_WS:-1}"
     ENABLE_HY2="${ENABLE_HY2:-1}"
+    ENABLE_TUIC="${ENABLE_TUIC:-0}"
+    ENABLE_TROJAN="${ENABLE_TROJAN:-0}"
   fi
-  export ENABLE_REALITY ENABLE_WS ENABLE_HY2
+  export ENABLE_REALITY ENABLE_WS ENABLE_HY2 ENABLE_TUIC ENABLE_TROJAN
 }
 
 # Validate protocol configuration
@@ -1222,9 +1228,10 @@ _validate_protocol_config() {
     return 0
   fi
 
-  if [[ "${ENABLE_REALITY}" != "1" && "${ENABLE_WS}" != "1" && "${ENABLE_HY2}" != "1" ]]; then
+  if [[ "${ENABLE_REALITY}" != "1" && "${ENABLE_WS}" != "1" && "${ENABLE_HY2}" != "1" &&
+    "${ENABLE_TUIC:-0}" != "1" && "${ENABLE_TROJAN:-0}" != "1" ]]; then
     die_with_code "SBX-CONFIG-004" "All protocols are disabled." \
-      "Enable at least one of ENABLE_REALITY, ENABLE_WS, or ENABLE_HY2." \
+      "Enable at least one of ENABLE_REALITY, ENABLE_WS, ENABLE_HY2, ENABLE_TUIC, or ENABLE_TROJAN." \
       "ENABLE_REALITY=1 bash install.sh"
   fi
 
@@ -1246,7 +1253,7 @@ _configure_reality_sni() {
     return 0
   fi
 
-  if ! command -v select_reality_sni_domain >/dev/null 2>&1; then
+  if ! command -v select_reality_sni_domain > /dev/null 2>&1; then
     warn "SNI probe helper unavailable, using ${preferred_sni}"
     export SNI="${preferred_sni}"
     return 0
@@ -1274,7 +1281,7 @@ _configure_reality_sni() {
 }
 
 # Generate cryptographic credentials
-# Sets: UUID, PRIV, PUB, SID
+# Sets: UUID, PRIV, PUB, SID, HY2_PASS, TUIC_PASS, TROJAN_PASS
 _generate_credentials() {
   export UUID
   UUID=$(generate_uuid)
@@ -1285,7 +1292,7 @@ _generate_credentials() {
     "Ensure openssl is available and retry." \
     "openssl rand -hex 32"
   export PRIV PUB
-  read -r PRIV PUB <<<"${keypair}"
+  read -r PRIV PUB <<< "${keypair}"
   success "  ✓ Reality keypair generated"
 
   export SID
@@ -1293,6 +1300,20 @@ _generate_credentials() {
   validate_short_id "${SID}" || die_with_code "SBX-CONFIG-007" "Generated invalid short ID: ${SID}." \
     "Regenerate short ID with 1-8 hex chars."
   success "  ✓ Short ID generated: ${SID}"
+
+  if [[ "${REALITY_ONLY_MODE:-0}" != "1" ]]; then
+    if [[ "${ENABLE_TUIC:-0}" == "1" ]]; then
+      export TUIC_PASS
+      TUIC_PASS=$(generate_hex_string 16)
+      success "  ✓ TUIC password generated"
+    fi
+
+    if [[ "${ENABLE_TROJAN:-0}" == "1" ]]; then
+      export TROJAN_PASS
+      TROJAN_PASS=$(generate_hex_string 16)
+      success "  ✓ Trojan password generated"
+    fi
+  fi
 }
 
 # Allocate ports for enabled protocols
@@ -1312,6 +1333,7 @@ _allocate_ports() {
 
   if [[ "${REALITY_ONLY_MODE:-0}" != "1" ]]; then
     export WS_PORT_CHOSEN="" HY2_PORT_CHOSEN="" HY2_PASS=""
+    export TUIC_PORT_CHOSEN="" TROJAN_PORT_CHOSEN=""
 
     if [[ "${ENABLE_WS}" == "1" ]]; then
       WS_PORT_CHOSEN=$(allocate_port "${WS_PORT}" "${WS_PORT_FALLBACK}" "WS-TLS") || die_with_code "SBX-NETWORK-004" "Failed to allocate WS port." \
@@ -1326,6 +1348,20 @@ _allocate_ports() {
         "HY2_PORT=30445 bash install.sh"
       HY2_PASS=$(generate_hex_string 16)
       success "  ✓ Hysteria2 port: ${HY2_PORT_CHOSEN}"
+    fi
+
+    if [[ "${ENABLE_TUIC:-0}" == "1" ]]; then
+      TUIC_PORT_CHOSEN=$(allocate_port "${TUIC_PORT}" "${TUIC_PORT_FALLBACK}" "TUIC") || die_with_code "SBX-NETWORK-006" "Failed to allocate TUIC port." \
+        "Free occupied ports or set TUIC_PORT to an available one." \
+        "TUIC_PORT=8445 bash install.sh"
+      success "  ✓ TUIC port: ${TUIC_PORT_CHOSEN}"
+    fi
+
+    if [[ "${ENABLE_TROJAN:-0}" == "1" ]]; then
+      TROJAN_PORT_CHOSEN=$(allocate_port "${TROJAN_PORT}" "${TROJAN_PORT_FALLBACK}" "Trojan") || die_with_code "SBX-NETWORK-007" "Failed to allocate Trojan port." \
+        "Free occupied ports or set TROJAN_PORT to an available one." \
+        "TROJAN_PORT=8446 bash install.sh"
+      success "  ✓ Trojan port: ${TROJAN_PORT_CHOSEN}"
     fi
   fi
 }
@@ -1349,7 +1385,7 @@ gen_materials() {
 save_client_info() {
   msg "Saving client information..."
 
-  cat >"${CLIENT_INFO}" <<EOF
+  cat > "${CLIENT_INFO}" << EOF
 # sing-box client configuration
 # Generated: $(date)
 
@@ -1363,20 +1399,34 @@ EOF
 
   if [[ "${REALITY_ONLY_MODE:-0}" != "1" ]]; then
     if [[ "${ENABLE_WS:-0}" == "1" ]]; then
-      cat >>"${CLIENT_INFO}" <<EOF
+      cat >> "${CLIENT_INFO}" << EOF
 WS_PORT="${WS_PORT_CHOSEN}"
 EOF
     fi
 
     if [[ "${ENABLE_HY2:-0}" == "1" ]]; then
-      cat >>"${CLIENT_INFO}" <<EOF
+      cat >> "${CLIENT_INFO}" << EOF
 HY2_PORT="${HY2_PORT_CHOSEN}"
 HY2_PASS="${HY2_PASS}"
 EOF
     fi
 
+    if [[ "${ENABLE_TUIC:-0}" == "1" ]]; then
+      cat >> "${CLIENT_INFO}" << EOF
+TUIC_PORT="${TUIC_PORT_CHOSEN}"
+TUIC_PASS="${TUIC_PASS}"
+EOF
+    fi
+
+    if [[ "${ENABLE_TROJAN:-0}" == "1" ]]; then
+      cat >> "${CLIENT_INFO}" << EOF
+TROJAN_PORT="${TROJAN_PORT_CHOSEN}"
+TROJAN_PASS="${TROJAN_PASS}"
+EOF
+    fi
+
     if [[ -n "${CERT_FULLCHAIN:-}" || -n "${CERT_KEY:-}" ]]; then
-      cat >>"${CLIENT_INFO}" <<EOF
+      cat >> "${CLIENT_INFO}" << EOF
 CERT_FULLCHAIN="${CERT_FULLCHAIN}"
 CERT_KEY="${CERT_KEY}"
 EOF
@@ -1406,18 +1456,27 @@ save_state_info() {
   local hy2_pass=''
 
   [[ "${REALITY_ONLY_MODE:-0}" == "1" ]] && mode="reality_only"
-  installed_at=$(date -Iseconds 2>/dev/null || date)
-  resolved_version=$(get_installed_version 2>/dev/null || echo "")
+  installed_at=$(date -Iseconds 2> /dev/null || date)
+  resolved_version=$(get_installed_version 2> /dev/null || echo "")
 
-  if validate_ip_address "${DOMAIN}" >/dev/null 2>&1; then
+  if validate_ip_address "${DOMAIN}" > /dev/null 2>&1; then
     server_ip="${DOMAIN}"
   else
     server_domain="${DOMAIN}"
   fi
 
+  local tuic_enabled=false
+  local trojan_enabled=false
+  local tuic_port=''
+  local tuic_pass=''
+  local trojan_port=''
+  local trojan_pass=''
+
   if [[ "${REALITY_ONLY_MODE:-0}" != "1" ]]; then
     local enable_ws="${ENABLE_WS:-}"
     local enable_hy2="${ENABLE_HY2:-}"
+    local enable_tuic="${ENABLE_TUIC:-0}"
+    local enable_trojan="${ENABLE_TROJAN:-0}"
 
     [[ -z "${enable_ws}" && -n "${WS_PORT_CHOSEN:-}" ]] && enable_ws="1"
     [[ -z "${enable_hy2}" && -n "${HY2_PORT_CHOSEN:-}" ]] && enable_hy2="1"
@@ -1431,6 +1490,18 @@ save_state_info() {
       hy2_enabled=true
       hy2_port="${HY2_PORT_CHOSEN:-}"
       hy2_pass="${HY2_PASS:-}"
+    fi
+
+    if [[ "${enable_tuic}" == "1" ]]; then
+      tuic_enabled=true
+      tuic_port="${TUIC_PORT_CHOSEN:-}"
+      tuic_pass="${TUIC_PASS:-}"
+    fi
+
+    if [[ "${enable_trojan}" == "1" ]]; then
+      trojan_enabled=true
+      trojan_port="${TROJAN_PORT_CHOSEN:-}"
+      trojan_pass="${TROJAN_PASS:-}"
     fi
 
     cert_path="${CERT_FULLCHAIN:-}"
@@ -1456,6 +1527,12 @@ save_state_info() {
     --argjson hy2_enabled "${hy2_enabled}" \
     --argjson hy2_port "${hy2_port:-0}" \
     --arg hy2_pass "${hy2_pass}" \
+    --argjson tuic_enabled "${tuic_enabled}" \
+    --argjson tuic_port "${tuic_port:-0}" \
+    --arg tuic_pass "${tuic_pass}" \
+    --argjson trojan_enabled "${trojan_enabled}" \
+    --argjson trojan_port "${trojan_port:-0}" \
+    --arg trojan_pass "${trojan_pass}" \
     '{
       version: $version,
       installed_at: $installed_at,
@@ -1484,9 +1561,19 @@ save_state_info() {
           enabled: $hy2_enabled,
           port: (if $hy2_enabled and $hy2_port != 0 then $hy2_port else null end),
           password: (if $hy2_enabled and $hy2_pass != "" then $hy2_pass else null end)
+        },
+        tuic: {
+          enabled: $tuic_enabled,
+          port: (if $tuic_enabled and $tuic_port != 0 then $tuic_port else null end),
+          password: (if $tuic_enabled and $tuic_pass != "" then $tuic_pass else null end)
+        },
+        trojan: {
+          enabled: $trojan_enabled,
+          port: (if $trojan_enabled and $trojan_port != 0 then $trojan_port else null end),
+          password: (if $trojan_enabled and $trojan_pass != "" then $trojan_pass else null end)
         }
       }
-    }' >"${state_file}"
+    }' > "${state_file}"
 
   chmod "${SECURE_FILE_PERMISSIONS}" "${state_file}"
   success "  ✓ State saved to: ${state_file}"
@@ -1559,7 +1646,7 @@ install_manager_script() {
     err "Creating minimal fallback version (limited functionality)..."
 
     # Fallback to inline version if template not found
-    cat >/usr/local/bin/sbx-manager <<'EOF'
+    cat > /usr/local/bin/sbx-manager << 'EOF'
 #!/bin/bash
 case "$1" in
     info)
@@ -1587,26 +1674,40 @@ EOF
 
 # Open firewall ports
 open_firewall() {
-  local ports_to_open=("${REALITY_PORT_CHOSEN}")
+  local ports_to_open=()
+  [[ -n "${REALITY_PORT_CHOSEN:-}" ]] && ports_to_open+=("${REALITY_PORT_CHOSEN}")
 
   if [[ "${REALITY_ONLY_MODE:-0}" != "1" ]]; then
-    ports_to_open+=("${WS_PORT_CHOSEN}" "${HY2_PORT_CHOSEN}")
+    [[ -n "${WS_PORT_CHOSEN:-}" ]] && ports_to_open+=("${WS_PORT_CHOSEN}")
+    [[ -n "${HY2_PORT_CHOSEN:-}" ]] && ports_to_open+=("${HY2_PORT_CHOSEN}")
+    [[ -n "${TUIC_PORT_CHOSEN:-}" ]] && ports_to_open+=("${TUIC_PORT_CHOSEN}")
+    [[ -n "${TROJAN_PORT_CHOSEN:-}" ]] && ports_to_open+=("${TROJAN_PORT_CHOSEN}")
   fi
 
+  [[ ${#ports_to_open[@]} -eq 0 ]] && return 0
+
   msg "Configuring firewall..."
+
+  # TUIC uses UDP; Hysteria2 also uses UDP
+  _is_udp_port() {
+    local p="$1"
+    [[ -n "${HY2_PORT_CHOSEN:-}" && "${p}" == "${HY2_PORT_CHOSEN}" ]] && return 0
+    [[ -n "${TUIC_PORT_CHOSEN:-}" && "${p}" == "${TUIC_PORT_CHOSEN}" ]] && return 0
+    return 1
+  }
 
   # Try different firewall managers
   if have firewall-cmd; then
     for port in "${ports_to_open[@]}"; do
-      firewall-cmd --permanent --add-port="${port}/tcp" 2>/dev/null || true
-      [[ -n "${HY2_PORT_CHOSEN:-}" && "${port}" == "${HY2_PORT_CHOSEN}" ]] && firewall-cmd --permanent --add-port="${port}/udp" 2>/dev/null || true
+      firewall-cmd --permanent --add-port="${port}/tcp" 2> /dev/null || true
+      _is_udp_port "${port}" && firewall-cmd --permanent --add-port="${port}/udp" 2> /dev/null || true
     done
-    firewall-cmd --reload 2>/dev/null || true
+    firewall-cmd --reload 2> /dev/null || true
     success "  ✓ Firewall configured (firewalld)"
   elif have ufw; then
     for port in "${ports_to_open[@]}"; do
-      ufw allow "${port}/tcp" 2>/dev/null || true
-      [[ -n "${HY2_PORT_CHOSEN:-}" && "${port}" == "${HY2_PORT_CHOSEN}" ]] && ufw allow "${port}/udp" 2>/dev/null || true
+      ufw allow "${port}/tcp" 2> /dev/null || true
+      _is_udp_port "${port}" && ufw allow "${port}/udp" 2> /dev/null || true
     done
     success "  ✓ Firewall configured (ufw)"
   else
@@ -1633,6 +1734,8 @@ print_summary() {
   local enable_reality="${ENABLE_REALITY:-1}"
   local enable_ws="${ENABLE_WS:-1}"
   local enable_hy2="${ENABLE_HY2:-1}"
+  local enable_tuic="${ENABLE_TUIC:-0}"
+  local enable_trojan="${ENABLE_TROJAN:-0}"
 
   if [[ "${enable_reality}" == "1" && -n "${REALITY_PORT_CHOSEN:-}" ]]; then
     echo "  • VLESS-REALITY (port ${REALITY_PORT_CHOSEN})"
@@ -1644,6 +1747,12 @@ print_summary() {
     fi
     if [[ "${enable_hy2}" == "1" && -n "${HY2_PORT_CHOSEN:-}" ]]; then
       echo "  • Hysteria2 (port ${HY2_PORT_CHOSEN})"
+    fi
+    if [[ "${enable_tuic}" == "1" && -n "${TUIC_PORT_CHOSEN:-}" ]]; then
+      echo "  • TUIC V5 (port ${TUIC_PORT_CHOSEN})"
+    fi
+    if [[ "${enable_trojan}" == "1" && -n "${TROJAN_PORT_CHOSEN:-}" ]]; then
+      echo "  • Trojan (port ${TROJAN_PORT_CHOSEN})"
     fi
   fi
 
@@ -1670,7 +1779,7 @@ print_summary() {
     echo "  ${uri_real}"
   fi
 
-  # WS-TLS and Hysteria2 URIs (if not Reality-only mode and enabled)
+  # WS-TLS, Hysteria2, TUIC, Trojan URIs (if not Reality-only mode and enabled)
   if [[ "${REALITY_ONLY_MODE:-0}" != "1" && -n "${CERT_FULLCHAIN:-}" ]]; then
     if [[ "${enable_ws}" == "1" && -n "${WS_PORT_CHOSEN:-}" ]]; then
       echo
@@ -1684,6 +1793,20 @@ print_summary() {
       local uri_hy2="hysteria2://${HY2_PASS}@${DOMAIN}:${HY2_PORT_CHOSEN}/?sni=${DOMAIN}&alpn=h3&insecure=0#Hysteria2-${DOMAIN}"
       echo -e "${G}Hysteria2:${N}"
       echo "  ${uri_hy2}"
+    fi
+
+    if [[ "${enable_tuic}" == "1" && -n "${TUIC_PORT_CHOSEN:-}" ]]; then
+      echo
+      local uri_tuic="tuic://${UUID}:${TUIC_PASS}@${DOMAIN}:${TUIC_PORT_CHOSEN}?congestion_control=bbr&alpn=h3&sni=${DOMAIN}&udp_relay_mode=native#TUIC-${DOMAIN}"
+      echo -e "${G}TUIC V5:${N}"
+      echo "  ${uri_tuic}"
+    fi
+
+    if [[ "${enable_trojan}" == "1" && -n "${TROJAN_PORT_CHOSEN:-}" ]]; then
+      echo
+      local uri_trojan="trojan://${TROJAN_PASS}@${DOMAIN}:${TROJAN_PORT_CHOSEN}?sni=${DOMAIN}&security=tls&type=tcp&fp=chrome#Trojan-${DOMAIN}"
+      echo -e "${G}Trojan:${N}"
+      echo "  ${uri_trojan}"
     fi
   fi
 
@@ -1722,7 +1845,7 @@ dry_run_flow() {
     export REALITY_ONLY_MODE=1
     mode_desc="Reality-only (no domain specified)"
     display_domain="<auto-detect during install>"
-  elif validate_ip_address "${DOMAIN}" >/dev/null 2>&1; then
+  elif validate_ip_address "${DOMAIN}" > /dev/null 2>&1; then
     export REALITY_ONLY_MODE=1
     mode_desc="Reality-only (ip: ${DOMAIN})"
     display_domain="${DOMAIN}"
@@ -1741,6 +1864,8 @@ dry_run_flow() {
   reality_port_preview="${REALITY_PORT:-${REALITY_PORT_DEFAULT}}"
   ws_port_preview="${WS_PORT:-${WS_PORT_DEFAULT}}"
   hy2_port_preview="${HY2_PORT:-${HY2_PORT_DEFAULT}}"
+  local tuic_port_preview="${TUIC_PORT:-${TUIC_PORT_DEFAULT}}"
+  local trojan_port_preview="${TROJAN_PORT:-${TROJAN_PORT_DEFAULT}}"
 
   echo
   echo "sbx dry-run preview:"
@@ -1762,6 +1887,14 @@ dry_run_flow() {
       echo "    - Hysteria2 on port ${hy2_port_preview}/udp"
       preview_ports+=("${hy2_port_preview}/udp")
     fi
+    if [[ "${ENABLE_TUIC:-0}" == "1" ]]; then
+      echo "    - TUIC V5 on port ${tuic_port_preview}/udp"
+      preview_ports+=("${tuic_port_preview}/udp")
+    fi
+    if [[ "${ENABLE_TROJAN:-0}" == "1" ]]; then
+      echo "    - Trojan on port ${trojan_port_preview}/tcp"
+      preview_ports+=("${trojan_port_preview}/tcp")
+    fi
   fi
 
   if [[ "${REALITY_ONLY_MODE:-0}" != "1" ]]; then
@@ -1775,7 +1908,7 @@ dry_run_flow() {
     echo "  Certificates: ${cert_desc}"
   fi
 
-  arch_desc=$(uname -m 2>/dev/null || echo "unknown")
+  arch_desc=$(uname -m 2> /dev/null || echo "unknown")
   echo "  SNI: ${sni_preview} (validated during real install)"
   echo "  Binary: sing-box ${SINGBOX_VERSION:-stable} (${arch_desc})"
   echo "  Config: ${SB_CONF}"

--- a/install.sh
+++ b/install.sh
@@ -115,7 +115,7 @@ get_file_size() {
   # Cross-platform file size retrieval
   # Linux: stat -c%s
   # BSD/macOS: stat -f%z
-  stat -c%s "${file}" 2> /dev/null || stat -f%z "${file}" 2> /dev/null || echo "0"
+  stat -c%s "${file}" 2>/dev/null || stat -f%z "${file}" 2>/dev/null || echo "0"
 }
 
 # Temporary create_temp_dir implementation for bootstrapping
@@ -124,14 +124,14 @@ create_temp_dir() {
   local prefix="${1:-sbx}"
   local temp_dir=''
 
-  if ! temp_dir=$(mktemp -d -t "${prefix}.XXXXXX" 2> /dev/null); then
+  if ! temp_dir=$(mktemp -d -t "${prefix}.XXXXXX" 2>/dev/null); then
     echo "ERROR: Failed to create temporary directory" >&2
     return 1
   fi
 
-  chmod "${SECURE_DIR_PERMISSIONS}" "${temp_dir}" 2> /dev/null || {
+  chmod "${SECURE_DIR_PERMISSIONS}" "${temp_dir}" 2>/dev/null || {
     echo "ERROR: Failed to set permissions on temporary directory: ${temp_dir}" >&2
-    rm -rf "${temp_dir}" 2> /dev/null || true
+    rm -rf "${temp_dir}" 2>/dev/null || true
     return 1
   }
 
@@ -141,7 +141,7 @@ create_temp_dir() {
 
 # Print usage help (must work before module loading)
 _print_help() {
-  cat << 'EOF'
+  cat <<'EOF'
 sbx-lite sing-box installer
 
 Usage:
@@ -194,13 +194,13 @@ _download_single_module() {
   [[ "${DEBUG:-0}" == "1" ]] && echo "DEBUG: Downloading ${module} from ${module_url}" >&2
 
   # Download module
-  if command -v curl > /dev/null 2>&1; then
+  if command -v curl >/dev/null 2>&1; then
     if ! curl -fsSL --connect-timeout "${DOWNLOAD_CONNECT_TIMEOUT_SEC}" --max-time "${DOWNLOAD_MAX_TIMEOUT_SEC}" "${module_url}" -o "${module_file}" 2>&1; then
       echo "DOWNLOAD_FAILED:${module}" >&2
       [[ "${DEBUG:-0}" == "1" ]] && echo "DEBUG: curl failed for ${module}" >&2
       return 1
     fi
-  elif command -v wget > /dev/null 2>&1; then
+  elif command -v wget >/dev/null 2>&1; then
     if ! wget -q --timeout="${DOWNLOAD_MAX_TIMEOUT_SEC}" "${module_url}" -O "${module_file}" 2>&1; then
       echo "DOWNLOAD_FAILED:${module}" >&2
       [[ "${DEBUG:-0}" == "1" ]] && echo "DEBUG: wget failed for ${module}" >&2
@@ -229,7 +229,7 @@ _download_single_module() {
   fi
 
   # Validate bash syntax
-  if ! bash -n "${module_file}" 2> /dev/null; then
+  if ! bash -n "${module_file}" 2>/dev/null; then
     echo "SYNTAX_ERROR:${module}" >&2
     [[ "${DEBUG:-0}" == "1" ]] && echo "DEBUG: Syntax check failed for ${module}" >&2
     return 1
@@ -324,15 +324,15 @@ _download_modules_sequential() {
     printf "  [%d/%d] Downloading %s..." "${current}" "${total}" "${module}.sh"
 
     # Download
-    if command -v curl > /dev/null 2>&1; then
-      if ! curl -fsSL --connect-timeout "${DOWNLOAD_CONNECT_TIMEOUT_SEC}" --max-time "${DOWNLOAD_MAX_TIMEOUT_SEC}" "${module_url}" -o "${module_file}" 2> /dev/null; then
+    if command -v curl >/dev/null 2>&1; then
+      if ! curl -fsSL --connect-timeout "${DOWNLOAD_CONNECT_TIMEOUT_SEC}" --max-time "${DOWNLOAD_MAX_TIMEOUT_SEC}" "${module_url}" -o "${module_file}" 2>/dev/null; then
         echo " ✗ FAILED"
         rm -rf "${temp_lib_dir}"
         _show_download_error_help "${module}" "${module_url}"
         return 1
       fi
-    elif command -v wget > /dev/null 2>&1; then
-      if ! wget -q --timeout="${DOWNLOAD_MAX_TIMEOUT_SEC}" "${module_url}" -O "${module_file}" 2> /dev/null; then
+    elif command -v wget >/dev/null 2>&1; then
+      if ! wget -q --timeout="${DOWNLOAD_MAX_TIMEOUT_SEC}" "${module_url}" -O "${module_file}" 2>/dev/null; then
         echo " ✗ FAILED"
         rm -rf "${temp_lib_dir}"
         _show_download_error_help "${module}" "${module_url}"
@@ -356,7 +356,7 @@ _download_modules_sequential() {
       return 1
     fi
 
-    if ! bash -n "${module_file}" 2> /dev/null; then
+    if ! bash -n "${module_file}" 2>/dev/null; then
       echo " ✗ SYNTAX ERROR"
       rm -rf "${temp_lib_dir}"
       _show_syntax_error "${module}"
@@ -449,15 +449,15 @@ _download_and_validate_manager_script() {
   [[ "${DEBUG:-0}" == "1" ]] && echo "DEBUG: Creating ${installer_dir}/bin directory" >&2
   mkdir -p "${installer_dir}/bin"
 
-  if command -v curl > /dev/null 2>&1; then
+  if command -v curl >/dev/null 2>&1; then
     [[ "${DEBUG:-0}" == "1" ]] && echo "DEBUG: Downloading sbx-manager.sh via curl from ${manager_url}" >&2
     if curl -fsSL --connect-timeout "${DOWNLOAD_CONNECT_TIMEOUT_SEC}" \
-      --max-time "${DOWNLOAD_MAX_TIMEOUT_SEC}" "${manager_url}" -o "${manager_file}" 2> /dev/null; then
+      --max-time "${DOWNLOAD_MAX_TIMEOUT_SEC}" "${manager_url}" -o "${manager_file}" 2>/dev/null; then
       download_success=1
     fi
-  elif command -v wget > /dev/null 2>&1; then
+  elif command -v wget >/dev/null 2>&1; then
     [[ "${DEBUG:-0}" == "1" ]] && echo "DEBUG: Downloading sbx-manager.sh via wget from ${manager_url}" >&2
-    if wget -q --timeout="${DOWNLOAD_MAX_TIMEOUT_SEC}" "${manager_url}" -O "${manager_file}" 2> /dev/null; then
+    if wget -q --timeout="${DOWNLOAD_MAX_TIMEOUT_SEC}" "${manager_url}" -O "${manager_file}" 2>/dev/null; then
       download_success=1
     fi
   else
@@ -487,7 +487,7 @@ _download_and_validate_manager_script() {
     return 1
   fi
 
-  if ! bash -n "${manager_file}" 2> /dev/null; then
+  if ! bash -n "${manager_file}" 2>/dev/null; then
     echo "ERROR: Invalid bash syntax in downloaded sbx-manager.sh"
     echo "       File may be corrupted."
     return 1
@@ -527,7 +527,7 @@ _load_modules() {
     fi
 
     # Download modules (parallel with fallback to sequential on failure)
-    if [[ ${use_parallel} -eq 1 ]] && command -v xargs > /dev/null 2>&1; then
+    if [[ ${use_parallel} -eq 1 ]] && command -v xargs >/dev/null 2>&1; then
       # Try parallel download first
       if ! _download_modules_parallel "${temp_lib_dir}" "${github_repo}" "${modules[@]}"; then
         # Parallel failed, fallback to sequential
@@ -643,7 +643,7 @@ _verify_module_apis() {
     local missing_functions=()
 
     for func in ${required_functions}; do
-      if ! declare -F "${func}" > /dev/null 2>&1; then
+      if ! declare -F "${func}" >/dev/null 2>&1; then
         missing_functions+=("${func}")
         all_ok=false
       fi
@@ -735,8 +735,8 @@ detect_libc() {
   fi
 
   # Method 2: Parse ldd output
-  if command -v ldd > /dev/null 2>&1; then
-    if ldd /bin/sh 2> /dev/null | grep -q musl; then
+  if command -v ldd >/dev/null 2>&1; then
+    if ldd /bin/sh 2>/dev/null | grep -q musl; then
       msg "Detected musl libc via ldd"
       echo "-musl"
       return
@@ -762,7 +762,7 @@ get_installed_version() {
   local version=''
   if [[ -x "${SB_BIN}" ]]; then
     # Match version with or without 'v' prefix (e.g., "v1.12.12" or "1.12.12")
-    version=$("${SB_BIN}" version 2> /dev/null | head -1 | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
+    version=$("${SB_BIN}" version 2>/dev/null | head -1 | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
 
     # Ensure version has 'v' prefix for consistency with the rest of the codebase
     if [[ "${version}" != "unknown" && "${version}" != v* ]]; then
@@ -812,8 +812,8 @@ compare_versions() {
   fi
 
   # Semantic version comparison (major.minor.patch)
-  IFS='.' read -r -a current_parts <<< "${current}"
-  IFS='.' read -r -a latest_parts <<< "${latest}"
+  IFS='.' read -r -a current_parts <<<"${current}"
+  IFS='.' read -r -a latest_parts <<<"${latest}"
 
   # Compare each component
   for i in 0 1 2; do
@@ -1090,7 +1090,7 @@ download_singbox() {
   # Stop service before replacing binary (prevents "Text file busy" error)
   # The service will be restarted by setup_service or restart_service in main flow
   local service_was_running=0
-  if check_service_status 2> /dev/null; then
+  if check_service_status 2>/dev/null; then
     msg "Stopping sing-box service for binary replacement..."
     stop_service
     service_was_running=1
@@ -1099,7 +1099,7 @@ download_singbox() {
   cp "${extracted_bin}" "${SB_BIN}" || {
     rm -rf "${tmp}"
     # Try to restart service if we stopped it
-    [[ "${service_was_running}" -eq 1 ]] && start_service_with_retry 2> /dev/null
+    [[ "${service_was_running}" -eq 1 ]] && start_service_with_retry 2>/dev/null
     die_with_code "SBX-DOWNLOAD-008" "Failed to install sing-box binary to target path." \
       "Check filesystem permissions and mount flags for /usr/local/bin." \
       "ls -ld /usr/local/bin && id"
@@ -1253,7 +1253,7 @@ _configure_reality_sni() {
     return 0
   fi
 
-  if ! command -v select_reality_sni_domain > /dev/null 2>&1; then
+  if ! command -v select_reality_sni_domain >/dev/null 2>&1; then
     warn "SNI probe helper unavailable, using ${preferred_sni}"
     export SNI="${preferred_sni}"
     return 0
@@ -1292,7 +1292,7 @@ _generate_credentials() {
     "Ensure openssl is available and retry." \
     "openssl rand -hex 32"
   export PRIV PUB
-  read -r PRIV PUB <<< "${keypair}"
+  read -r PRIV PUB <<<"${keypair}"
   success "  ✓ Reality keypair generated"
 
   export SID
@@ -1385,7 +1385,7 @@ gen_materials() {
 save_client_info() {
   msg "Saving client information..."
 
-  cat > "${CLIENT_INFO}" << EOF
+  cat >"${CLIENT_INFO}" <<EOF
 # sing-box client configuration
 # Generated: $(date)
 
@@ -1399,34 +1399,34 @@ EOF
 
   if [[ "${REALITY_ONLY_MODE:-0}" != "1" ]]; then
     if [[ "${ENABLE_WS:-0}" == "1" ]]; then
-      cat >> "${CLIENT_INFO}" << EOF
+      cat >>"${CLIENT_INFO}" <<EOF
 WS_PORT="${WS_PORT_CHOSEN}"
 EOF
     fi
 
     if [[ "${ENABLE_HY2:-0}" == "1" ]]; then
-      cat >> "${CLIENT_INFO}" << EOF
+      cat >>"${CLIENT_INFO}" <<EOF
 HY2_PORT="${HY2_PORT_CHOSEN}"
 HY2_PASS="${HY2_PASS}"
 EOF
     fi
 
     if [[ "${ENABLE_TUIC:-0}" == "1" ]]; then
-      cat >> "${CLIENT_INFO}" << EOF
+      cat >>"${CLIENT_INFO}" <<EOF
 TUIC_PORT="${TUIC_PORT_CHOSEN}"
 TUIC_PASS="${TUIC_PASS}"
 EOF
     fi
 
     if [[ "${ENABLE_TROJAN:-0}" == "1" ]]; then
-      cat >> "${CLIENT_INFO}" << EOF
+      cat >>"${CLIENT_INFO}" <<EOF
 TROJAN_PORT="${TROJAN_PORT_CHOSEN}"
 TROJAN_PASS="${TROJAN_PASS}"
 EOF
     fi
 
     if [[ -n "${CERT_FULLCHAIN:-}" || -n "${CERT_KEY:-}" ]]; then
-      cat >> "${CLIENT_INFO}" << EOF
+      cat >>"${CLIENT_INFO}" <<EOF
 CERT_FULLCHAIN="${CERT_FULLCHAIN}"
 CERT_KEY="${CERT_KEY}"
 EOF
@@ -1456,10 +1456,10 @@ save_state_info() {
   local hy2_pass=''
 
   [[ "${REALITY_ONLY_MODE:-0}" == "1" ]] && mode="reality_only"
-  installed_at=$(date -Iseconds 2> /dev/null || date)
-  resolved_version=$(get_installed_version 2> /dev/null || echo "")
+  installed_at=$(date -Iseconds 2>/dev/null || date)
+  resolved_version=$(get_installed_version 2>/dev/null || echo "")
 
-  if validate_ip_address "${DOMAIN}" > /dev/null 2>&1; then
+  if validate_ip_address "${DOMAIN}" >/dev/null 2>&1; then
     server_ip="${DOMAIN}"
   else
     server_domain="${DOMAIN}"
@@ -1573,7 +1573,7 @@ save_state_info() {
           password: (if $trojan_enabled and $trojan_pass != "" then $trojan_pass else null end)
         }
       }
-    }' > "${state_file}"
+    }' >"${state_file}"
 
   chmod "${SECURE_FILE_PERMISSIONS}" "${state_file}"
   success "  ✓ State saved to: ${state_file}"
@@ -1646,7 +1646,7 @@ install_manager_script() {
     err "Creating minimal fallback version (limited functionality)..."
 
     # Fallback to inline version if template not found
-    cat > /usr/local/bin/sbx-manager << 'EOF'
+    cat >/usr/local/bin/sbx-manager <<'EOF'
 #!/bin/bash
 case "$1" in
     info)
@@ -1699,15 +1699,15 @@ open_firewall() {
   # Try different firewall managers
   if have firewall-cmd; then
     for port in "${ports_to_open[@]}"; do
-      firewall-cmd --permanent --add-port="${port}/tcp" 2> /dev/null || true
-      _is_udp_port "${port}" && firewall-cmd --permanent --add-port="${port}/udp" 2> /dev/null || true
+      firewall-cmd --permanent --add-port="${port}/tcp" 2>/dev/null || true
+      _is_udp_port "${port}" && firewall-cmd --permanent --add-port="${port}/udp" 2>/dev/null || true
     done
-    firewall-cmd --reload 2> /dev/null || true
+    firewall-cmd --reload 2>/dev/null || true
     success "  ✓ Firewall configured (firewalld)"
   elif have ufw; then
     for port in "${ports_to_open[@]}"; do
-      ufw allow "${port}/tcp" 2> /dev/null || true
-      _is_udp_port "${port}" && ufw allow "${port}/udp" 2> /dev/null || true
+      ufw allow "${port}/tcp" 2>/dev/null || true
+      _is_udp_port "${port}" && ufw allow "${port}/udp" 2>/dev/null || true
     done
     success "  ✓ Firewall configured (ufw)"
   else
@@ -1845,7 +1845,7 @@ dry_run_flow() {
     export REALITY_ONLY_MODE=1
     mode_desc="Reality-only (no domain specified)"
     display_domain="<auto-detect during install>"
-  elif validate_ip_address "${DOMAIN}" > /dev/null 2>&1; then
+  elif validate_ip_address "${DOMAIN}" >/dev/null 2>&1; then
     export REALITY_ONLY_MODE=1
     mode_desc="Reality-only (ip: ${DOMAIN})"
     display_domain="${DOMAIN}"
@@ -1908,7 +1908,7 @@ dry_run_flow() {
     echo "  Certificates: ${cert_desc}"
   fi
 
-  arch_desc=$(uname -m 2> /dev/null || echo "unknown")
+  arch_desc=$(uname -m 2>/dev/null || echo "unknown")
   echo "  SNI: ${sni_preview} (validated during real install)"
   echo "  Binary: sing-box ${SINGBOX_VERSION:-stable} (${arch_desc})"
   echo "  Config: ${SB_CONF}"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -249,11 +249,11 @@ SBX_TMP_DIR="${SBX_TMP_DIR:-}"
 # Check if running as root
 need_root() {
   if [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
-    if declare -f die_with_code > /dev/null 2>&1; then
+    if declare -f die_with_code >/dev/null 2>&1; then
       die_with_code "SBX-SYSTEM-001" "Root privileges are required." \
         "Re-run the installer with sudo." \
         "sudo bash install.sh"
-    elif declare -f err > /dev/null 2>&1; then
+    elif declare -f err >/dev/null 2>&1; then
       err "Please run as root (sudo)."
       return 1
     else
@@ -265,7 +265,7 @@ need_root() {
 
 # Check if command exists
 have() {
-  command -v "$1" > /dev/null 2>&1
+  command -v "$1" >/dev/null 2>&1
 }
 
 # Safe temporary directory cleanup
@@ -275,7 +275,7 @@ safe_rm_temp() {
   [[ -n "${temp_path}" && "${temp_path}" != "/" ]] || return 1
   # Accept both Linux /tmp/ and macOS /var/folders/ temp directories
   [[ "${temp_path}" =~ ^/tmp/ || "${temp_path}" =~ ^/var/folders/ ]] || return 1
-  [[ -d "${temp_path}" ]] && rm -rf "${temp_path}" 2> /dev/null || true
+  [[ -d "${temp_path}" ]] && rm -rf "${temp_path}" 2>/dev/null || true
 }
 
 # Get file size in bytes (cross-platform)
@@ -298,7 +298,7 @@ get_file_size() {
   # Cross-platform file size retrieval
   # Linux: stat -c%s
   # BSD/macOS: stat -f%z
-  stat -c%s "${file}" 2> /dev/null || stat -f%z "${file}" 2> /dev/null || echo "0"
+  stat -c%s "${file}" 2>/dev/null || stat -f%z "${file}" 2>/dev/null || echo "0"
 }
 
 #------------------------------------------------------------------------------
@@ -326,9 +326,9 @@ get_file_mtime() {
   # Cross-platform modification time retrieval
   # Linux: stat -c %y (returns: YYYY-MM-DD HH:MM:SS.nanoseconds +timezone)
   # BSD/macOS: stat -f %Sm (returns: format depends on -t option)
-  stat -c %y "${file}" 2> /dev/null | cut -d' ' -f1,2 | cut -d'.' -f1 \
-    || stat -f %Sm "${file}" 2> /dev/null \
-    || echo ""
+  stat -c %y "${file}" 2>/dev/null | cut -d' ' -f1,2 | cut -d'.' -f1 ||
+    stat -f %Sm "${file}" 2>/dev/null ||
+    echo ""
 }
 
 #==============================================================================
@@ -341,7 +341,7 @@ cleanup() {
   # Skip error reporting in test mode (tests manage their own error reporting)
   if [[ ${exit_code} -ne 0 && -z "${SBX_TEST_MODE:-}" && -z "${_SBX_ERROR_CONTEXT_EMITTED:-}" ]]; then
     # err() function will be available from logging.sh
-    if declare -f err > /dev/null 2>&1; then
+    if declare -f err >/dev/null 2>&1; then
       err "Script execution failed with exit code ${exit_code}"
     else
       echo "[ERR] Script execution failed with exit code ${exit_code}" >&2
@@ -352,24 +352,24 @@ cleanup() {
   if [[ -n "${SBX_TMP_DIR:-}" && -d "${SBX_TMP_DIR}" ]]; then
     # Verify it's a safe path before removal
     if [[ "${SBX_TMP_DIR}" =~ ^/tmp/sbx-[a-zA-Z0-9._-]+$ ]]; then
-      rm -rf "${SBX_TMP_DIR}" 2> /dev/null || true
+      rm -rf "${SBX_TMP_DIR}" 2>/dev/null || true
     fi
   fi
 
   # Clean up known temporary config files (specific to this process)
-  rm -f "${SB_CONF}.tmp" 2> /dev/null || true
+  rm -f "${SB_CONF}.tmp" 2>/dev/null || true
 
   # Remove temporary installer directory created during one-liner bootstrap
   if [[ -n "${INSTALLER_TEMP_DIR:-}" && -d "${INSTALLER_TEMP_DIR}" ]]; then
     # Validate: Must be in a temp directory and contain PID pattern for safety
     if [[ "${INSTALLER_TEMP_DIR}" =~ ^(/tmp|/var/tmp)/sbx-install-[0-9]+$ ]]; then
-      if ! rm -rf "${INSTALLER_TEMP_DIR}" 2> /dev/null; then
-        if declare -f warn > /dev/null 2>&1; then
+      if ! rm -rf "${INSTALLER_TEMP_DIR}" 2>/dev/null; then
+        if declare -f warn >/dev/null 2>&1; then
           warn "Failed to cleanup temporary installer directory: ${INSTALLER_TEMP_DIR}"
         fi
       fi
     else
-      if declare -f warn > /dev/null 2>&1; then
+      if declare -f warn >/dev/null 2>&1; then
         warn "Skipping cleanup of INSTALLER_TEMP_DIR (path validation failed): ${INSTALLER_TEMP_DIR}"
       fi
     fi
@@ -378,14 +378,14 @@ cleanup() {
   # Clean up stale port lock files (over 60 minutes old, with safe timeout)
   # This is safe because it only removes very old locks that are likely orphaned
   if [[ -d "/var/lock" ]]; then
-    find /var/lock -maxdepth 1 -name 'sbx-port-*.lock' -type f -mmin +"${CLEANUP_OLD_FILES_MIN:-60}" -delete 2> /dev/null || true
+    find /var/lock -maxdepth 1 -name 'sbx-port-*.lock' -type f -mmin +"${CLEANUP_OLD_FILES_MIN:-60}" -delete 2>/dev/null || true
   fi
 
   # If we're in the middle of an upgrade/install and something fails,
   # try to restore service if it was previously running
   if [[ ${exit_code} -ne 0 && -f "${SB_SVC}" ]]; then
-    if systemctl is-enabled sing-box > /dev/null 2>&1; then
-      systemctl start sing-box 2> /dev/null || true
+    if systemctl is-enabled sing-box >/dev/null 2>&1; then
+      systemctl start sing-box 2>/dev/null || true
     fi
   fi
 
@@ -422,7 +422,7 @@ create_temp_dir() {
   # Set secure permissions
   chmod 700 "${temp_dir}" || {
     err "Failed to set permissions on temp directory: ${temp_dir}"
-    rm -rf "${temp_dir}" 2> /dev/null
+    rm -rf "${temp_dir}" 2>/dev/null
     return 1
   }
 
@@ -464,7 +464,7 @@ create_temp_dir_in_dir() {
 
   chmod 700 "${temp_dir}" || {
     err "Failed to set permissions on temp directory: ${temp_dir}"
-    rm -rf "${temp_dir}" 2> /dev/null
+    rm -rf "${temp_dir}" 2>/dev/null
     return 1
   }
 
@@ -498,7 +498,7 @@ create_temp_file() {
   # Set secure permissions
   chmod 600 "${tmpfile}" || {
     err "Failed to set permissions on temp file: ${tmpfile}"
-    rm -f "${tmpfile}" 2> /dev/null
+    rm -f "${tmpfile}" 2>/dev/null
     return 1
   }
 
@@ -540,7 +540,7 @@ create_temp_file_in_dir() {
 
   chmod 600 "${tmpfile}" || {
     err "Failed to set permissions on temp file: ${tmpfile}"
-    rm -f "${tmpfile}" 2> /dev/null
+    rm -f "${tmpfile}" 2>/dev/null
     return 1
   }
 
@@ -564,10 +564,10 @@ with_flock() {
   fi
 
   [[ $# -gt 0 ]] || {
-    if declare -f die_with_code > /dev/null 2>&1; then
+    if declare -f die_with_code >/dev/null 2>&1; then
       die_with_code "SBX-SYSTEM-002" "with_flock requires a command to execute." \
         "Call with_flock with a target command and optional timeout."
-    elif declare -f err > /dev/null 2>&1; then
+    elif declare -f err >/dev/null 2>&1; then
       err "with_flock requires a command to execute"
       return 1
     else
@@ -586,7 +586,7 @@ with_flock() {
   fi
 
   if ! have flock; then
-    if declare -f warn > /dev/null 2>&1; then
+    if declare -f warn >/dev/null 2>&1; then
       warn "flock not available; running without process lock"
     fi
     "${cmd[@]}"
@@ -595,10 +595,10 @@ with_flock() {
 
   (
     if ! flock -w "${timeout}" 200; then
-      if declare -f die_with_code > /dev/null 2>&1; then
+      if declare -f die_with_code >/dev/null 2>&1; then
         die_with_code "SBX-SYSTEM-003" "Could not acquire sbx lock within ${timeout}s." \
           "Another sbx process may be running; retry after it exits."
-      elif declare -f err > /dev/null 2>&1; then
+      elif declare -f err >/dev/null 2>&1; then
         err "Could not acquire sbx lock within ${timeout}s (another sbx process may be running)"
         return 1
       else
@@ -607,7 +607,7 @@ with_flock() {
       return 1
     fi
     "${cmd[@]}"
-  ) 200> "${lock_file}"
+  ) 200>"${lock_file}"
 }
 
 #==============================================================================

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -39,11 +39,19 @@ fi
 if [[ -z "${HY2_PORT_DEFAULT:-}" ]]; then
   declare -gr HY2_PORT_DEFAULT=8443
 fi
+if [[ -z "${TUIC_PORT_DEFAULT:-}" ]]; then
+  declare -gr TUIC_PORT_DEFAULT=8445
+fi
+if [[ -z "${TROJAN_PORT_DEFAULT:-}" ]]; then
+  declare -gr TROJAN_PORT_DEFAULT=8446
+fi
 
 # Fallback ports
 declare -gr REALITY_PORT_FALLBACK=24443
 declare -gr WS_PORT_FALLBACK=24444
 declare -gr HY2_PORT_FALLBACK=24445
+declare -gr TUIC_PORT_FALLBACK=24447
+declare -gr TROJAN_PORT_FALLBACK=24448
 
 # Default values
 declare -gr SNI_DEFAULT="${SNI_DEFAULT:-www.microsoft.com}"
@@ -208,6 +216,8 @@ CERT_KEY="${CERT_KEY:-}"
 REALITY_PORT="${REALITY_PORT:-${REALITY_PORT_DEFAULT}}"
 WS_PORT="${WS_PORT:-${WS_PORT_DEFAULT}}"
 HY2_PORT="${HY2_PORT:-${HY2_PORT_DEFAULT}}"
+TUIC_PORT="${TUIC_PORT:-${TUIC_PORT_DEFAULT}}"
+TROJAN_PORT="${TROJAN_PORT:-${TROJAN_PORT_DEFAULT}}"
 
 SINGBOX_VERSION="${SINGBOX_VERSION:-}"
 
@@ -219,10 +229,14 @@ SID="${SID:-}"
 PUBLIC_KEY="${PUBLIC_KEY:-}"
 SHORT_ID="${SHORT_ID:-}"
 HY2_PASS="${HY2_PASS:-}"
+TUIC_PASS="${TUIC_PASS:-}"
+TROJAN_PASS="${TROJAN_PASS:-}"
 SNI="${SNI:-}"
 REALITY_PORT_CHOSEN="${REALITY_PORT_CHOSEN:-}"
 WS_PORT_CHOSEN="${WS_PORT_CHOSEN:-}"
 HY2_PORT_CHOSEN="${HY2_PORT_CHOSEN:-}"
+TUIC_PORT_CHOSEN="${TUIC_PORT_CHOSEN:-}"
+TROJAN_PORT_CHOSEN="${TROJAN_PORT_CHOSEN:-}"
 
 # Process-specific temporary directory for secure cleanup
 # Created with secure permissions and cleaned up automatically
@@ -235,11 +249,11 @@ SBX_TMP_DIR="${SBX_TMP_DIR:-}"
 # Check if running as root
 need_root() {
   if [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
-    if declare -f die_with_code >/dev/null 2>&1; then
+    if declare -f die_with_code > /dev/null 2>&1; then
       die_with_code "SBX-SYSTEM-001" "Root privileges are required." \
         "Re-run the installer with sudo." \
         "sudo bash install.sh"
-    elif declare -f err >/dev/null 2>&1; then
+    elif declare -f err > /dev/null 2>&1; then
       err "Please run as root (sudo)."
       return 1
     else
@@ -251,7 +265,7 @@ need_root() {
 
 # Check if command exists
 have() {
-  command -v "$1" >/dev/null 2>&1
+  command -v "$1" > /dev/null 2>&1
 }
 
 # Safe temporary directory cleanup
@@ -261,7 +275,7 @@ safe_rm_temp() {
   [[ -n "${temp_path}" && "${temp_path}" != "/" ]] || return 1
   # Accept both Linux /tmp/ and macOS /var/folders/ temp directories
   [[ "${temp_path}" =~ ^/tmp/ || "${temp_path}" =~ ^/var/folders/ ]] || return 1
-  [[ -d "${temp_path}" ]] && rm -rf "${temp_path}" 2>/dev/null || true
+  [[ -d "${temp_path}" ]] && rm -rf "${temp_path}" 2> /dev/null || true
 }
 
 # Get file size in bytes (cross-platform)
@@ -284,7 +298,7 @@ get_file_size() {
   # Cross-platform file size retrieval
   # Linux: stat -c%s
   # BSD/macOS: stat -f%z
-  stat -c%s "${file}" 2>/dev/null || stat -f%z "${file}" 2>/dev/null || echo "0"
+  stat -c%s "${file}" 2> /dev/null || stat -f%z "${file}" 2> /dev/null || echo "0"
 }
 
 #------------------------------------------------------------------------------
@@ -312,9 +326,9 @@ get_file_mtime() {
   # Cross-platform modification time retrieval
   # Linux: stat -c %y (returns: YYYY-MM-DD HH:MM:SS.nanoseconds +timezone)
   # BSD/macOS: stat -f %Sm (returns: format depends on -t option)
-  stat -c %y "${file}" 2>/dev/null | cut -d' ' -f1,2 | cut -d'.' -f1 ||
-    stat -f %Sm "${file}" 2>/dev/null ||
-    echo ""
+  stat -c %y "${file}" 2> /dev/null | cut -d' ' -f1,2 | cut -d'.' -f1 \
+    || stat -f %Sm "${file}" 2> /dev/null \
+    || echo ""
 }
 
 #==============================================================================
@@ -327,7 +341,7 @@ cleanup() {
   # Skip error reporting in test mode (tests manage their own error reporting)
   if [[ ${exit_code} -ne 0 && -z "${SBX_TEST_MODE:-}" && -z "${_SBX_ERROR_CONTEXT_EMITTED:-}" ]]; then
     # err() function will be available from logging.sh
-    if declare -f err >/dev/null 2>&1; then
+    if declare -f err > /dev/null 2>&1; then
       err "Script execution failed with exit code ${exit_code}"
     else
       echo "[ERR] Script execution failed with exit code ${exit_code}" >&2
@@ -338,24 +352,24 @@ cleanup() {
   if [[ -n "${SBX_TMP_DIR:-}" && -d "${SBX_TMP_DIR}" ]]; then
     # Verify it's a safe path before removal
     if [[ "${SBX_TMP_DIR}" =~ ^/tmp/sbx-[a-zA-Z0-9._-]+$ ]]; then
-      rm -rf "${SBX_TMP_DIR}" 2>/dev/null || true
+      rm -rf "${SBX_TMP_DIR}" 2> /dev/null || true
     fi
   fi
 
   # Clean up known temporary config files (specific to this process)
-  rm -f "${SB_CONF}.tmp" 2>/dev/null || true
+  rm -f "${SB_CONF}.tmp" 2> /dev/null || true
 
   # Remove temporary installer directory created during one-liner bootstrap
   if [[ -n "${INSTALLER_TEMP_DIR:-}" && -d "${INSTALLER_TEMP_DIR}" ]]; then
     # Validate: Must be in a temp directory and contain PID pattern for safety
     if [[ "${INSTALLER_TEMP_DIR}" =~ ^(/tmp|/var/tmp)/sbx-install-[0-9]+$ ]]; then
-      if ! rm -rf "${INSTALLER_TEMP_DIR}" 2>/dev/null; then
-        if declare -f warn >/dev/null 2>&1; then
+      if ! rm -rf "${INSTALLER_TEMP_DIR}" 2> /dev/null; then
+        if declare -f warn > /dev/null 2>&1; then
           warn "Failed to cleanup temporary installer directory: ${INSTALLER_TEMP_DIR}"
         fi
       fi
     else
-      if declare -f warn >/dev/null 2>&1; then
+      if declare -f warn > /dev/null 2>&1; then
         warn "Skipping cleanup of INSTALLER_TEMP_DIR (path validation failed): ${INSTALLER_TEMP_DIR}"
       fi
     fi
@@ -364,14 +378,14 @@ cleanup() {
   # Clean up stale port lock files (over 60 minutes old, with safe timeout)
   # This is safe because it only removes very old locks that are likely orphaned
   if [[ -d "/var/lock" ]]; then
-    find /var/lock -maxdepth 1 -name 'sbx-port-*.lock' -type f -mmin +"${CLEANUP_OLD_FILES_MIN:-60}" -delete 2>/dev/null || true
+    find /var/lock -maxdepth 1 -name 'sbx-port-*.lock' -type f -mmin +"${CLEANUP_OLD_FILES_MIN:-60}" -delete 2> /dev/null || true
   fi
 
   # If we're in the middle of an upgrade/install and something fails,
   # try to restore service if it was previously running
   if [[ ${exit_code} -ne 0 && -f "${SB_SVC}" ]]; then
-    if systemctl is-enabled sing-box >/dev/null 2>&1; then
-      systemctl start sing-box 2>/dev/null || true
+    if systemctl is-enabled sing-box > /dev/null 2>&1; then
+      systemctl start sing-box 2> /dev/null || true
     fi
   fi
 
@@ -408,7 +422,7 @@ create_temp_dir() {
   # Set secure permissions
   chmod 700 "${temp_dir}" || {
     err "Failed to set permissions on temp directory: ${temp_dir}"
-    rm -rf "${temp_dir}" 2>/dev/null
+    rm -rf "${temp_dir}" 2> /dev/null
     return 1
   }
 
@@ -450,7 +464,7 @@ create_temp_dir_in_dir() {
 
   chmod 700 "${temp_dir}" || {
     err "Failed to set permissions on temp directory: ${temp_dir}"
-    rm -rf "${temp_dir}" 2>/dev/null
+    rm -rf "${temp_dir}" 2> /dev/null
     return 1
   }
 
@@ -484,7 +498,7 @@ create_temp_file() {
   # Set secure permissions
   chmod 600 "${tmpfile}" || {
     err "Failed to set permissions on temp file: ${tmpfile}"
-    rm -f "${tmpfile}" 2>/dev/null
+    rm -f "${tmpfile}" 2> /dev/null
     return 1
   }
 
@@ -526,7 +540,7 @@ create_temp_file_in_dir() {
 
   chmod 600 "${tmpfile}" || {
     err "Failed to set permissions on temp file: ${tmpfile}"
-    rm -f "${tmpfile}" 2>/dev/null
+    rm -f "${tmpfile}" 2> /dev/null
     return 1
   }
 
@@ -550,10 +564,10 @@ with_flock() {
   fi
 
   [[ $# -gt 0 ]] || {
-    if declare -f die_with_code >/dev/null 2>&1; then
+    if declare -f die_with_code > /dev/null 2>&1; then
       die_with_code "SBX-SYSTEM-002" "with_flock requires a command to execute." \
         "Call with_flock with a target command and optional timeout."
-    elif declare -f err >/dev/null 2>&1; then
+    elif declare -f err > /dev/null 2>&1; then
       err "with_flock requires a command to execute"
       return 1
     else
@@ -572,7 +586,7 @@ with_flock() {
   fi
 
   if ! have flock; then
-    if declare -f warn >/dev/null 2>&1; then
+    if declare -f warn > /dev/null 2>&1; then
       warn "flock not available; running without process lock"
     fi
     "${cmd[@]}"
@@ -581,10 +595,10 @@ with_flock() {
 
   (
     if ! flock -w "${timeout}" 200; then
-      if declare -f die_with_code >/dev/null 2>&1; then
+      if declare -f die_with_code > /dev/null 2>&1; then
         die_with_code "SBX-SYSTEM-003" "Could not acquire sbx lock within ${timeout}s." \
           "Another sbx process may be running; retry after it exits."
-      elif declare -f err >/dev/null 2>&1; then
+      elif declare -f err > /dev/null 2>&1; then
         err "Could not acquire sbx lock within ${timeout}s (another sbx process may be running)"
         return 1
       else
@@ -593,7 +607,7 @@ with_flock() {
       return 1
     fi
     "${cmd[@]}"
-  ) 200>"${lock_file}"
+  ) 200> "${lock_file}"
 }
 
 #==============================================================================

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -27,7 +27,7 @@ _config_die() {
   local resolution="${3:-}"
   local example="${4:-}"
 
-  if declare -f die_with_code > /dev/null 2>&1; then
+  if declare -f die_with_code >/dev/null 2>&1; then
     die_with_code "${code}" "${reason}" "${resolution}" "${example}"
   fi
 
@@ -106,7 +106,7 @@ create_base_config() {
       outbounds: [
         { type: "direct", tag: "direct" }
       ]
-    }' 2> /dev/null); then
+    }' 2>/dev/null); then
     err "Failed to create base configuration with jq"
     return 1
   fi
@@ -155,13 +155,13 @@ create_reality_inbound() {
   }
 
   # Validate port range
-  if ! validate_port "${port}" 2> /dev/null; then
+  if ! validate_port "${port}" 2>/dev/null; then
     err "Invalid port: ${port} (must be 1-65535)"
     return 1
   fi
 
   # Validate transport+security+flow pairing
-  if ! validate_transport_security_pairing "tcp" "reality" "${REALITY_FLOW_VISION}" 2> /dev/null; then
+  if ! validate_transport_security_pairing "tcp" "reality" "${REALITY_FLOW_VISION}" 2>/dev/null; then
     err "Invalid transport+security+flow combination for Reality"
     return 1
   fi
@@ -245,7 +245,7 @@ _build_tls_block() {
         certificate_path: $cert_path,
         key_path: $key_path,
         alpn: $alpn
-      }' 2> /dev/null); then
+      }' 2>/dev/null); then
       err "Failed to build manual TLS block"
       return 1
     fi
@@ -266,7 +266,7 @@ _build_tls_block() {
           email: "",
           provider: "letsencrypt",
           disable_tls_alpn_challenge: true
-        }' 2> /dev/null); then
+        }' 2>/dev/null); then
         err "Failed to build ACME HTTP-01 block"
         return 1
       fi
@@ -287,7 +287,7 @@ _build_tls_block() {
             provider: "cloudflare",
             api_token: $api_token
           }
-        }' 2> /dev/null); then
+        }' 2>/dev/null); then
         err "Failed to build ACME DNS-01 block"
         return 1
       fi
@@ -308,7 +308,7 @@ _build_tls_block() {
       alpn: $alpn,
       acme: $acme,
       certificate: { store: "chrome" }
-    }' 2> /dev/null); then
+    }' 2>/dev/null); then
     err "Failed to build ACME TLS block"
     return 1
   fi
@@ -349,7 +349,7 @@ create_ws_inbound() {
       },
       tls: $tls,
       transport: { type: "ws", path: "/ws" }
-    }' 2> /dev/null); then
+    }' 2>/dev/null); then
     err "Failed to create WS-TLS configuration with jq"
     return 1
   fi
@@ -381,7 +381,7 @@ create_hysteria2_inbound() {
       up_mbps: 100,
       down_mbps: 100,
       tls: $tls
-    }' 2> /dev/null); then
+    }' 2>/dev/null); then
     err "Failed to create Hysteria2 configuration with jq"
     return 1
   fi
@@ -416,7 +416,7 @@ create_tuic_inbound() {
       zero_rtt_handshake: false,
       heartbeat: "10s",
       tls: $tls
-    }' 2> /dev/null); then
+    }' 2>/dev/null); then
     err "Failed to create TUIC V5 configuration with jq"
     return 1
   fi
@@ -446,7 +446,7 @@ create_trojan_inbound() {
       listen_port: ($port | tonumber),
       users: [{ password: $password }],
       tls: $tls
-    }' 2> /dev/null); then
+    }' 2>/dev/null); then
     err "Failed to create Trojan configuration with jq"
     return 1
   fi
@@ -481,7 +481,7 @@ add_route_config() {
     "default_domain_resolver": {
       "server": "dns-local"
     }
-  }' 2> /dev/null); then
+  }' 2>/dev/null); then
     err "Failed to add route configuration"
     return 1
   fi
@@ -509,7 +509,7 @@ add_outbound_config() {
       "bind_address_no_port": true,
       "tcp_keep_alive": $tcp_keep_alive
     }' \
-    2> /dev/null); then
+    2>/dev/null); then
     warn "Failed to add outbound parameters, continuing with default configuration"
     echo "${config}"
     return 0
@@ -536,8 +536,8 @@ _validate_certificate_config() {
   # Check manual certificate mode
   if [[ -n "${cert_fullchain}" && -n "${cert_key}" && -f "${cert_fullchain}" && -f "${cert_key}" ]]; then
     has_manual_certs="true"
-    validate_cert_files "${cert_fullchain}" "${cert_key}" \
-      || die_with_code "SBX-CERT-002" "Certificate file validation failed." \
+    validate_cert_files "${cert_fullchain}" "${cert_key}" ||
+      die_with_code "SBX-CERT-002" "Certificate file validation failed." \
         "Ensure fullchain/key paths are correct, readable, and matching." \
         "openssl x509 -in ${cert_fullchain} -noout -text | head"
   fi
@@ -547,8 +547,8 @@ _validate_certificate_config() {
     has_acme="true"
     # Validate CF_API_TOKEN for DNS-01 mode
     if [[ "${cert_mode}" == "cf_dns" ]]; then
-      [[ -n "${CF_API_TOKEN:-}" ]] \
-        || die_with_code "SBX-CERT-001" "CF_API_TOKEN is required for CERT_MODE=cf_dns." \
+      [[ -n "${CF_API_TOKEN:-}" ]] ||
+        die_with_code "SBX-CERT-001" "CF_API_TOKEN is required for CERT_MODE=cf_dns." \
           "Provide a valid Cloudflare API token with DNS edit permission." \
           "CERT_MODE=cf_dns CF_API_TOKEN=xxxx DOMAIN=example.com bash install.sh"
     fi
@@ -560,8 +560,8 @@ _validate_certificate_config() {
   fi
 
   # Validate domain is set
-  [[ -n "${DOMAIN:-}" ]] \
-    || die_with_code "SBX-CERT-003" "Domain is not set for certificate/ACME configuration." \
+  [[ -n "${DOMAIN:-}" ]] ||
+    die_with_code "SBX-CERT-003" "Domain is not set for certificate/ACME configuration." \
       "Set DOMAIN when using manual certificates or ACME certificate mode." \
       "DOMAIN=example.com bash install.sh"
 
@@ -572,41 +572,41 @@ _validate_certificate_config() {
   local enable_trojan="${ENABLE_TROJAN:-0}"
 
   if [[ "${enable_ws}" == "1" ]]; then
-    [[ -n "${WS_PORT_CHOSEN:-}" ]] \
-      || die_with_code "SBX-CONFIG-010" "WS port is missing while ENABLE_WS=1." \
+    [[ -n "${WS_PORT_CHOSEN:-}" ]] ||
+      die_with_code "SBX-CONFIG-010" "WS port is missing while ENABLE_WS=1." \
         "Set WS_PORT or keep automatic port allocation enabled." \
         "WS_PORT=8444 bash install.sh"
   fi
 
   if [[ "${enable_hy2}" == "1" ]]; then
-    [[ -n "${HY2_PORT_CHOSEN:-}" ]] \
-      || die_with_code "SBX-CONFIG-011" "Hysteria2 port is missing while ENABLE_HY2=1." \
+    [[ -n "${HY2_PORT_CHOSEN:-}" ]] ||
+      die_with_code "SBX-CONFIG-011" "Hysteria2 port is missing while ENABLE_HY2=1." \
         "Set HY2_PORT or keep automatic port allocation enabled." \
         "HY2_PORT=8443 bash install.sh"
-    [[ -n "${HY2_PASS:-}" ]] \
-      || die_with_code "SBX-CONFIG-012" "Hysteria2 password is missing while ENABLE_HY2=1." \
+    [[ -n "${HY2_PASS:-}" ]] ||
+      die_with_code "SBX-CONFIG-012" "Hysteria2 password is missing while ENABLE_HY2=1." \
         "Ensure HY2_PASS is generated or provided before config generation." \
         "HY2_PASS=$(openssl rand -hex 16) bash install.sh"
   fi
 
   if [[ "${enable_tuic}" == "1" ]]; then
-    [[ -n "${TUIC_PORT_CHOSEN:-}" ]] \
-      || die_with_code "SBX-CONFIG-013" "TUIC port is missing while ENABLE_TUIC=1." \
+    [[ -n "${TUIC_PORT_CHOSEN:-}" ]] ||
+      die_with_code "SBX-CONFIG-013" "TUIC port is missing while ENABLE_TUIC=1." \
         "Set TUIC_PORT or keep automatic port allocation enabled." \
         "TUIC_PORT=8445 bash install.sh"
-    [[ -n "${TUIC_PASS:-}" ]] \
-      || die_with_code "SBX-CONFIG-014" "TUIC password is missing while ENABLE_TUIC=1." \
+    [[ -n "${TUIC_PASS:-}" ]] ||
+      die_with_code "SBX-CONFIG-014" "TUIC password is missing while ENABLE_TUIC=1." \
         "Ensure TUIC_PASS is generated or provided before config generation." \
         "TUIC_PASS=\$(openssl rand -hex 16) bash install.sh"
   fi
 
   if [[ "${enable_trojan}" == "1" ]]; then
-    [[ -n "${TROJAN_PORT_CHOSEN:-}" ]] \
-      || die_with_code "SBX-CONFIG-015" "Trojan port is missing while ENABLE_TROJAN=1." \
+    [[ -n "${TROJAN_PORT_CHOSEN:-}" ]] ||
+      die_with_code "SBX-CONFIG-015" "Trojan port is missing while ENABLE_TROJAN=1." \
         "Set TROJAN_PORT or keep automatic port allocation enabled." \
         "TROJAN_PORT=8446 bash install.sh"
-    [[ -n "${TROJAN_PASS:-}" ]] \
-      || die_with_code "SBX-CONFIG-016" "Trojan password is missing while ENABLE_TROJAN=1." \
+    [[ -n "${TROJAN_PASS:-}" ]] ||
+      die_with_code "SBX-CONFIG-016" "Trojan password is missing while ENABLE_TROJAN=1." \
         "Ensure TROJAN_PASS is generated or provided before config generation." \
         "TROJAN_PASS=\$(openssl rand -hex 16) bash install.sh"
   fi
@@ -639,13 +639,13 @@ _create_all_inbounds() {
   if [[ "${enable_reality}" == "1" && -n "${reality_port}" ]]; then
     local reality_config=''
     reality_config=$(create_reality_inbound "${uuid}" "${reality_port}" "${listen_addr}" \
-      "${sni}" "${priv_key}" "${short_id}") \
-      || _config_die "SBX-CONFIG-030" "Failed to create Reality inbound" \
+      "${sni}" "${priv_key}" "${short_id}") ||
+      _config_die "SBX-CONFIG-030" "Failed to create Reality inbound" \
         "Check Reality parameters (UUID/ports/keys/SNI) and retry."
 
     base_config=$(echo "${base_config}" | jq --argjson reality "${reality_config}" \
-      '.inbounds += [$reality]' 2> /dev/null) \
-      || _config_die "SBX-CONFIG-031" "Failed to add Reality configuration to base config" \
+      '.inbounds += [$reality]' 2>/dev/null) ||
+      _config_die "SBX-CONFIG-031" "Failed to add Reality configuration to base config" \
         "Verify generated Reality JSON is valid."
   fi
 
@@ -669,19 +669,19 @@ _create_all_inbounds() {
     if [[ "${enable_ws}" == "1" && -n "${WS_PORT_CHOSEN:-}" ]]; then
       local ws_tls=''
       ws_tls=$(_build_tls_block "${DOMAIN}" '["h2","http/1.1"]' \
-        "${cert_fullchain}" "${cert_key}" "${cert_mode}" "${CF_API_TOKEN:-}") \
-        || _config_die "SBX-CONFIG-032" "Failed to build WS TLS configuration" \
+        "${cert_fullchain}" "${cert_key}" "${cert_mode}" "${CF_API_TOKEN:-}") ||
+        _config_die "SBX-CONFIG-032" "Failed to build WS TLS configuration" \
           "Check certificate mode and TLS inputs."
 
       local ws_config=''
       ws_config=$(create_ws_inbound "${uuid}" "${WS_PORT_CHOSEN}" "${listen_addr}" \
-        "${DOMAIN}" "${ws_tls}") \
-        || _config_die "SBX-CONFIG-033" "Failed to create WS-TLS inbound" \
+        "${DOMAIN}" "${ws_tls}") ||
+        _config_die "SBX-CONFIG-033" "Failed to create WS-TLS inbound" \
           "Verify WS port/domain/TLS settings."
 
       base_config=$(echo "${base_config}" | jq --argjson ws "${ws_config}" \
-        '.inbounds += [$ws]' 2> /dev/null) \
-        || _config_die "SBX-CONFIG-034" "Failed to add WS-TLS configuration" \
+        '.inbounds += [$ws]' 2>/dev/null) ||
+        _config_die "SBX-CONFIG-034" "Failed to add WS-TLS configuration" \
           "Verify WS inbound JSON generation."
     fi
 
@@ -689,19 +689,19 @@ _create_all_inbounds() {
     if [[ "${enable_hy2}" == "1" && -n "${HY2_PORT_CHOSEN:-}" ]]; then
       local hy2_tls=''
       hy2_tls=$(_build_tls_block "${DOMAIN}" '["h3"]' \
-        "${cert_fullchain}" "${cert_key}" "${cert_mode}" "${CF_API_TOKEN:-}") \
-        || _config_die "SBX-CONFIG-035" "Failed to build Hysteria2 TLS configuration" \
+        "${cert_fullchain}" "${cert_key}" "${cert_mode}" "${CF_API_TOKEN:-}") ||
+        _config_die "SBX-CONFIG-035" "Failed to build Hysteria2 TLS configuration" \
           "Check certificate mode and TLS inputs."
 
       local hy2_config=''
       hy2_config=$(create_hysteria2_inbound "${HY2_PASS}" "${HY2_PORT_CHOSEN}" "${listen_addr}" \
-        "${hy2_tls}") \
-        || _config_die "SBX-CONFIG-036" "Failed to create Hysteria2 inbound" \
+        "${hy2_tls}") ||
+        _config_die "SBX-CONFIG-036" "Failed to create Hysteria2 inbound" \
           "Verify Hysteria2 password/port/TLS settings."
 
       base_config=$(echo "${base_config}" | jq --argjson hy2 "${hy2_config}" \
-        '.inbounds += [$hy2]' 2> /dev/null) \
-        || _config_die "SBX-CONFIG-037" "Failed to add Hysteria2 configuration" \
+        '.inbounds += [$hy2]' 2>/dev/null) ||
+        _config_die "SBX-CONFIG-037" "Failed to add Hysteria2 configuration" \
           "Verify Hysteria2 inbound JSON generation."
     fi
 
@@ -709,19 +709,19 @@ _create_all_inbounds() {
     if [[ "${enable_tuic}" == "1" && -n "${TUIC_PORT_CHOSEN:-}" ]]; then
       local tuic_tls=''
       tuic_tls=$(_build_tls_block "${DOMAIN}" '["h3"]' \
-        "${cert_fullchain}" "${cert_key}" "${cert_mode}" "${CF_API_TOKEN:-}") \
-        || _config_die "SBX-CONFIG-050" "Failed to build TUIC TLS configuration" \
+        "${cert_fullchain}" "${cert_key}" "${cert_mode}" "${CF_API_TOKEN:-}") ||
+        _config_die "SBX-CONFIG-050" "Failed to build TUIC TLS configuration" \
           "Check certificate mode and TLS inputs."
 
       local tuic_config=''
       tuic_config=$(create_tuic_inbound "${uuid}" "${TUIC_PASS}" "${TUIC_PORT_CHOSEN}" \
-        "${listen_addr}" "${tuic_tls}") \
-        || _config_die "SBX-CONFIG-051" "Failed to create TUIC inbound" \
+        "${listen_addr}" "${tuic_tls}") ||
+        _config_die "SBX-CONFIG-051" "Failed to create TUIC inbound" \
           "Verify TUIC uuid/password/port/TLS settings."
 
       base_config=$(echo "${base_config}" | jq --argjson tuic "${tuic_config}" \
-        '.inbounds += [$tuic]' 2> /dev/null) \
-        || _config_die "SBX-CONFIG-052" "Failed to add TUIC configuration" \
+        '.inbounds += [$tuic]' 2>/dev/null) ||
+        _config_die "SBX-CONFIG-052" "Failed to add TUIC configuration" \
           "Verify TUIC inbound JSON generation."
     fi
 
@@ -729,19 +729,19 @@ _create_all_inbounds() {
     if [[ "${enable_trojan}" == "1" && -n "${TROJAN_PORT_CHOSEN:-}" ]]; then
       local trojan_tls=''
       trojan_tls=$(_build_tls_block "${DOMAIN}" '["h2","http/1.1"]' \
-        "${cert_fullchain}" "${cert_key}" "${cert_mode}" "${CF_API_TOKEN:-}") \
-        || _config_die "SBX-CONFIG-053" "Failed to build Trojan TLS configuration" \
+        "${cert_fullchain}" "${cert_key}" "${cert_mode}" "${CF_API_TOKEN:-}") ||
+        _config_die "SBX-CONFIG-053" "Failed to build Trojan TLS configuration" \
           "Check certificate mode and TLS inputs."
 
       local trojan_config=''
       trojan_config=$(create_trojan_inbound "${TROJAN_PASS}" "${TROJAN_PORT_CHOSEN}" \
-        "${listen_addr}" "${trojan_tls}") \
-        || _config_die "SBX-CONFIG-054" "Failed to create Trojan inbound" \
+        "${listen_addr}" "${trojan_tls}") ||
+        _config_die "SBX-CONFIG-054" "Failed to create Trojan inbound" \
           "Verify Trojan password/port/TLS settings."
 
       base_config=$(echo "${base_config}" | jq --argjson trojan "${trojan_config}" \
-        '.inbounds += [$trojan]' 2> /dev/null) \
-        || _config_die "SBX-CONFIG-055" "Failed to add Trojan configuration" \
+        '.inbounds += [$trojan]' 2>/dev/null) ||
+        _config_die "SBX-CONFIG-055" "Failed to add Trojan configuration" \
           "Verify Trojan inbound JSON generation."
     fi
   fi
@@ -791,14 +791,14 @@ _write_config_impl() {
 
   # Setup automatic cleanup on function exit/error
   cleanup_write_config() {
-    [[ -f "${temp_conf}" ]] && rm -f "${temp_conf}" 2> /dev/null || true
+    [[ -f "${temp_conf}" ]] && rm -f "${temp_conf}" 2>/dev/null || true
   }
   trap cleanup_write_config RETURN ERR EXIT INT TERM
 
   # Create base configuration
   local base_config=''
-  base_config=$(create_base_config "${ipv6_supported}" "${LOG_LEVEL:-warn}") \
-    || _config_die "SBX-CONFIG-040" "Failed to create base configuration" \
+  base_config=$(create_base_config "${ipv6_supported}" "${LOG_LEVEL:-warn}") ||
+    _config_die "SBX-CONFIG-040" "Failed to create base configuration" \
       "Check jq availability and base config template logic."
 
   # Create all inbounds (Reality + optional WS-TLS and Hysteria2)
@@ -812,30 +812,34 @@ _write_config_impl() {
 
   # Build route inbound tag list from actually-enabled inbound configurations
   local route_inbound_tags=()
-  [[ "${ENABLE_REALITY:-1}" == "1" && -n "${REALITY_PORT_CHOSEN:-}" ]] \
-    && route_inbound_tags+=("in-reality")
+  [[ "${ENABLE_REALITY:-1}" == "1" && -n "${REALITY_PORT_CHOSEN:-}" ]] &&
+    route_inbound_tags+=("in-reality")
   if [[ "${has_certs}" == "true" ]]; then
-    [[ "${ENABLE_WS:-1}" == "1" && -n "${WS_PORT_CHOSEN:-}" ]] \
-      && route_inbound_tags+=("in-ws")
-    [[ "${ENABLE_HY2:-1}" == "1" && -n "${HY2_PORT_CHOSEN:-}" ]] \
-      && route_inbound_tags+=("in-hy2")
-    [[ "${ENABLE_TUIC:-0}" == "1" && -n "${TUIC_PORT_CHOSEN:-}" ]] \
-      && route_inbound_tags+=("in-tuic")
-    [[ "${ENABLE_TROJAN:-0}" == "1" && -n "${TROJAN_PORT_CHOSEN:-}" ]] \
-      && route_inbound_tags+=("in-trojan")
+    [[ "${ENABLE_WS:-1}" == "1" && -n "${WS_PORT_CHOSEN:-}" ]] &&
+      route_inbound_tags+=("in-ws")
+    [[ "${ENABLE_HY2:-1}" == "1" && -n "${HY2_PORT_CHOSEN:-}" ]] &&
+      route_inbound_tags+=("in-hy2")
+    [[ "${ENABLE_TUIC:-0}" == "1" && -n "${TUIC_PORT_CHOSEN:-}" ]] &&
+      route_inbound_tags+=("in-tuic")
+    [[ "${ENABLE_TROJAN:-0}" == "1" && -n "${TROJAN_PORT_CHOSEN:-}" ]] &&
+      route_inbound_tags+=("in-trojan")
   fi
   local route_inbounds_json=''
-  route_inbounds_json=$(printf '%s\n' "${route_inbound_tags[@]}" | jq -R . | jq -sc .)
+  if [[ ${#route_inbound_tags[@]} -eq 0 ]]; then
+    route_inbounds_json='[]'
+  else
+    route_inbounds_json=$(printf '%s\n' "${route_inbound_tags[@]}" | jq -R . | jq -sc .)
+  fi
 
   # Add route and outbound configurations
-  base_config=$(add_route_config "${base_config}" "${route_inbounds_json}") \
-    || _config_die "SBX-CONFIG-041" "Failed to add route configuration" \
+  base_config=$(add_route_config "${base_config}" "${route_inbounds_json}") ||
+    _config_die "SBX-CONFIG-041" "Failed to add route configuration" \
       "Verify route generation inputs and JSON integrity."
   base_config=$(add_outbound_config "${base_config}")
 
   # Write configuration to temporary file
-  echo "${base_config}" > "${temp_conf}" \
-    || _config_die "SBX-CONFIG-042" "Failed to write configuration to temporary file" \
+  echo "${base_config}" >"${temp_conf}" ||
+    _config_die "SBX-CONFIG-042" "Failed to write configuration to temporary file" \
       "Check filesystem writability for temporary directory."
 
   # Run comprehensive validation pipeline before applying

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -27,7 +27,7 @@ _config_die() {
   local resolution="${3:-}"
   local example="${4:-}"
 
-  if declare -f die_with_code >/dev/null 2>&1; then
+  if declare -f die_with_code > /dev/null 2>&1; then
     die_with_code "${code}" "${reason}" "${resolution}" "${example}"
   fi
 
@@ -106,7 +106,7 @@ create_base_config() {
       outbounds: [
         { type: "direct", tag: "direct" }
       ]
-    }' 2>/dev/null); then
+    }' 2> /dev/null); then
     err "Failed to create base configuration with jq"
     return 1
   fi
@@ -155,13 +155,13 @@ create_reality_inbound() {
   }
 
   # Validate port range
-  if ! validate_port "${port}" 2>/dev/null; then
+  if ! validate_port "${port}" 2> /dev/null; then
     err "Invalid port: ${port} (must be 1-65535)"
     return 1
   fi
 
   # Validate transport+security+flow pairing
-  if ! validate_transport_security_pairing "tcp" "reality" "${REALITY_FLOW_VISION}" 2>/dev/null; then
+  if ! validate_transport_security_pairing "tcp" "reality" "${REALITY_FLOW_VISION}" 2> /dev/null; then
     err "Invalid transport+security+flow combination for Reality"
     return 1
   fi
@@ -245,7 +245,7 @@ _build_tls_block() {
         certificate_path: $cert_path,
         key_path: $key_path,
         alpn: $alpn
-      }' 2>/dev/null); then
+      }' 2> /dev/null); then
       err "Failed to build manual TLS block"
       return 1
     fi
@@ -266,7 +266,7 @@ _build_tls_block() {
           email: "",
           provider: "letsencrypt",
           disable_tls_alpn_challenge: true
-        }' 2>/dev/null); then
+        }' 2> /dev/null); then
         err "Failed to build ACME HTTP-01 block"
         return 1
       fi
@@ -287,7 +287,7 @@ _build_tls_block() {
             provider: "cloudflare",
             api_token: $api_token
           }
-        }' 2>/dev/null); then
+        }' 2> /dev/null); then
         err "Failed to build ACME DNS-01 block"
         return 1
       fi
@@ -308,7 +308,7 @@ _build_tls_block() {
       alpn: $alpn,
       acme: $acme,
       certificate: { store: "chrome" }
-    }' 2>/dev/null); then
+    }' 2> /dev/null); then
     err "Failed to build ACME TLS block"
     return 1
   fi
@@ -349,7 +349,7 @@ create_ws_inbound() {
       },
       tls: $tls,
       transport: { type: "ws", path: "/ws" }
-    }' 2>/dev/null); then
+    }' 2> /dev/null); then
     err "Failed to create WS-TLS configuration with jq"
     return 1
   fi
@@ -381,7 +381,7 @@ create_hysteria2_inbound() {
       up_mbps: 100,
       down_mbps: 100,
       tls: $tls
-    }' 2>/dev/null); then
+    }' 2> /dev/null); then
     err "Failed to create Hysteria2 configuration with jq"
     return 1
   fi
@@ -389,19 +389,81 @@ create_hysteria2_inbound() {
   echo "${hy2_config}"
 }
 
+# Create TUIC V5 inbound configuration
+# Args: uuid password port listen_addr tls_json
+create_tuic_inbound() {
+  local uuid="$1"
+  local password="$2"
+  local port="$3"
+  local listen_addr="$4"
+  local tls_json="$5"
+
+  local tuic_config=''
+
+  if ! tuic_config=$(jq -n \
+    --arg uuid "${uuid}" \
+    --arg password "${password}" \
+    --arg port "${port}" \
+    --arg listen_addr "${listen_addr}" \
+    --argjson tls "${tls_json}" \
+    '{
+      type: "tuic",
+      tag: "in-tuic",
+      listen: $listen_addr,
+      listen_port: ($port | tonumber),
+      users: [{ uuid: $uuid, password: $password }],
+      congestion_control: "bbr",
+      zero_rtt_handshake: false,
+      heartbeat: "10s",
+      tls: $tls
+    }' 2> /dev/null); then
+    err "Failed to create TUIC V5 configuration with jq"
+    return 1
+  fi
+
+  echo "${tuic_config}"
+}
+
+# Create Trojan inbound configuration
+# Args: password port listen_addr tls_json
+create_trojan_inbound() {
+  local password="$1"
+  local port="$2"
+  local listen_addr="$3"
+  local tls_json="$4"
+
+  local trojan_config=''
+
+  if ! trojan_config=$(jq -n \
+    --arg password "${password}" \
+    --arg port "${port}" \
+    --arg listen_addr "${listen_addr}" \
+    --argjson tls "${tls_json}" \
+    '{
+      type: "trojan",
+      tag: "in-trojan",
+      listen: $listen_addr,
+      listen_port: ($port | tonumber),
+      users: [{ password: $password }],
+      tls: $tls
+    }' 2> /dev/null); then
+    err "Failed to create Trojan configuration with jq"
+    return 1
+  fi
+
+  echo "${trojan_config}"
+}
+
 #==============================================================================
 # Route Configuration
 #==============================================================================
 
 # Add route configuration for sing-box 1.13.0+ compatibility
+# Args: config inbounds_json
+#   inbounds_json: JSON array of inbound tags to include in sniff rule
 add_route_config() {
   local config="$1"
-  local has_certs="${2:-false}"
-
-  local route_inbounds='["in-reality"]'
-  if [[ "${has_certs}" == "true" ]]; then
-    route_inbounds='["in-reality", "in-ws", "in-hy2"]'
-  fi
+  local route_inbounds="${2:-[\"in-reality\"]}"
 
   local updated_config=''
   if ! updated_config=$(echo "${config}" | jq --argjson inbounds "${route_inbounds}" '.route = {
@@ -419,7 +481,7 @@ add_route_config() {
     "default_domain_resolver": {
       "server": "dns-local"
     }
-  }' 2>/dev/null); then
+  }' 2> /dev/null); then
     err "Failed to add route configuration"
     return 1
   fi
@@ -447,7 +509,7 @@ add_outbound_config() {
       "bind_address_no_port": true,
       "tcp_keep_alive": $tcp_keep_alive
     }' \
-    2>/dev/null); then
+    2> /dev/null); then
     warn "Failed to add outbound parameters, continuing with default configuration"
     echo "${config}"
     return 0
@@ -474,8 +536,8 @@ _validate_certificate_config() {
   # Check manual certificate mode
   if [[ -n "${cert_fullchain}" && -n "${cert_key}" && -f "${cert_fullchain}" && -f "${cert_key}" ]]; then
     has_manual_certs="true"
-    validate_cert_files "${cert_fullchain}" "${cert_key}" ||
-      die_with_code "SBX-CERT-002" "Certificate file validation failed." \
+    validate_cert_files "${cert_fullchain}" "${cert_key}" \
+      || die_with_code "SBX-CERT-002" "Certificate file validation failed." \
         "Ensure fullchain/key paths are correct, readable, and matching." \
         "openssl x509 -in ${cert_fullchain} -noout -text | head"
   fi
@@ -485,8 +547,8 @@ _validate_certificate_config() {
     has_acme="true"
     # Validate CF_API_TOKEN for DNS-01 mode
     if [[ "${cert_mode}" == "cf_dns" ]]; then
-      [[ -n "${CF_API_TOKEN:-}" ]] ||
-        die_with_code "SBX-CERT-001" "CF_API_TOKEN is required for CERT_MODE=cf_dns." \
+      [[ -n "${CF_API_TOKEN:-}" ]] \
+        || die_with_code "SBX-CERT-001" "CF_API_TOKEN is required for CERT_MODE=cf_dns." \
           "Provide a valid Cloudflare API token with DNS edit permission." \
           "CERT_MODE=cf_dns CF_API_TOKEN=xxxx DOMAIN=example.com bash install.sh"
     fi
@@ -498,38 +560,62 @@ _validate_certificate_config() {
   fi
 
   # Validate domain is set
-  [[ -n "${DOMAIN:-}" ]] ||
-    die_with_code "SBX-CERT-003" "Domain is not set for certificate/ACME configuration." \
+  [[ -n "${DOMAIN:-}" ]] \
+    || die_with_code "SBX-CERT-003" "Domain is not set for certificate/ACME configuration." \
       "Set DOMAIN when using manual certificates or ACME certificate mode." \
       "DOMAIN=example.com bash install.sh"
 
   # Validate required variables based on enabled protocols
   local enable_ws="${ENABLE_WS:-1}"
   local enable_hy2="${ENABLE_HY2:-1}"
+  local enable_tuic="${ENABLE_TUIC:-0}"
+  local enable_trojan="${ENABLE_TROJAN:-0}"
 
   if [[ "${enable_ws}" == "1" ]]; then
-    [[ -n "${WS_PORT_CHOSEN:-}" ]] ||
-      die_with_code "SBX-CONFIG-010" "WS port is missing while ENABLE_WS=1." \
+    [[ -n "${WS_PORT_CHOSEN:-}" ]] \
+      || die_with_code "SBX-CONFIG-010" "WS port is missing while ENABLE_WS=1." \
         "Set WS_PORT or keep automatic port allocation enabled." \
         "WS_PORT=8444 bash install.sh"
   fi
 
   if [[ "${enable_hy2}" == "1" ]]; then
-    [[ -n "${HY2_PORT_CHOSEN:-}" ]] ||
-      die_with_code "SBX-CONFIG-011" "Hysteria2 port is missing while ENABLE_HY2=1." \
+    [[ -n "${HY2_PORT_CHOSEN:-}" ]] \
+      || die_with_code "SBX-CONFIG-011" "Hysteria2 port is missing while ENABLE_HY2=1." \
         "Set HY2_PORT or keep automatic port allocation enabled." \
         "HY2_PORT=8443 bash install.sh"
-    [[ -n "${HY2_PASS:-}" ]] ||
-      die_with_code "SBX-CONFIG-012" "Hysteria2 password is missing while ENABLE_HY2=1." \
+    [[ -n "${HY2_PASS:-}" ]] \
+      || die_with_code "SBX-CONFIG-012" "Hysteria2 password is missing while ENABLE_HY2=1." \
         "Ensure HY2_PASS is generated or provided before config generation." \
         "HY2_PASS=$(openssl rand -hex 16) bash install.sh"
+  fi
+
+  if [[ "${enable_tuic}" == "1" ]]; then
+    [[ -n "${TUIC_PORT_CHOSEN:-}" ]] \
+      || die_with_code "SBX-CONFIG-013" "TUIC port is missing while ENABLE_TUIC=1." \
+        "Set TUIC_PORT or keep automatic port allocation enabled." \
+        "TUIC_PORT=8445 bash install.sh"
+    [[ -n "${TUIC_PASS:-}" ]] \
+      || die_with_code "SBX-CONFIG-014" "TUIC password is missing while ENABLE_TUIC=1." \
+        "Ensure TUIC_PASS is generated or provided before config generation." \
+        "TUIC_PASS=\$(openssl rand -hex 16) bash install.sh"
+  fi
+
+  if [[ "${enable_trojan}" == "1" ]]; then
+    [[ -n "${TROJAN_PORT_CHOSEN:-}" ]] \
+      || die_with_code "SBX-CONFIG-015" "Trojan port is missing while ENABLE_TROJAN=1." \
+        "Set TROJAN_PORT or keep automatic port allocation enabled." \
+        "TROJAN_PORT=8446 bash install.sh"
+    [[ -n "${TROJAN_PASS:-}" ]] \
+      || die_with_code "SBX-CONFIG-016" "Trojan password is missing while ENABLE_TROJAN=1." \
+        "Ensure TROJAN_PASS is generated or provided before config generation." \
+        "TROJAN_PASS=\$(openssl rand -hex 16) bash install.sh"
   fi
 
   return 0
 }
 
 # Create all inbound configurations
-# Respects ENABLE_REALITY, ENABLE_WS, ENABLE_HY2 environment variables
+# Respects ENABLE_REALITY, ENABLE_WS, ENABLE_HY2, ENABLE_TUIC, ENABLE_TROJAN environment variables
 # Supports manual certificates (cert_fullchain/cert_key) and ACME modes
 _create_all_inbounds() {
   local base_config="$1"
@@ -542,22 +628,24 @@ _create_all_inbounds() {
   local cert_fullchain="${8:-}"
   local cert_key="${9:-}"
 
-  # Check which protocols are enabled (default to 1 if not set)
+  # Check which protocols are enabled
   local enable_reality="${ENABLE_REALITY:-1}"
   local enable_ws="${ENABLE_WS:-1}"
   local enable_hy2="${ENABLE_HY2:-1}"
+  local enable_tuic="${ENABLE_TUIC:-0}"
+  local enable_trojan="${ENABLE_TROJAN:-0}"
 
   # Add Reality inbound (if enabled and port is set)
   if [[ "${enable_reality}" == "1" && -n "${reality_port}" ]]; then
     local reality_config=''
     reality_config=$(create_reality_inbound "${uuid}" "${reality_port}" "${listen_addr}" \
-      "${sni}" "${priv_key}" "${short_id}") ||
-      _config_die "SBX-CONFIG-030" "Failed to create Reality inbound" \
+      "${sni}" "${priv_key}" "${short_id}") \
+      || _config_die "SBX-CONFIG-030" "Failed to create Reality inbound" \
         "Check Reality parameters (UUID/ports/keys/SNI) and retry."
 
     base_config=$(echo "${base_config}" | jq --argjson reality "${reality_config}" \
-      '.inbounds += [$reality]' 2>/dev/null) ||
-      _config_die "SBX-CONFIG-031" "Failed to add Reality configuration to base config" \
+      '.inbounds += [$reality]' 2> /dev/null) \
+      || _config_die "SBX-CONFIG-031" "Failed to add Reality configuration to base config" \
         "Verify generated Reality JSON is valid."
   fi
 
@@ -581,19 +669,19 @@ _create_all_inbounds() {
     if [[ "${enable_ws}" == "1" && -n "${WS_PORT_CHOSEN:-}" ]]; then
       local ws_tls=''
       ws_tls=$(_build_tls_block "${DOMAIN}" '["h2","http/1.1"]' \
-        "${cert_fullchain}" "${cert_key}" "${cert_mode}" "${CF_API_TOKEN:-}") ||
-        _config_die "SBX-CONFIG-032" "Failed to build WS TLS configuration" \
+        "${cert_fullchain}" "${cert_key}" "${cert_mode}" "${CF_API_TOKEN:-}") \
+        || _config_die "SBX-CONFIG-032" "Failed to build WS TLS configuration" \
           "Check certificate mode and TLS inputs."
 
       local ws_config=''
       ws_config=$(create_ws_inbound "${uuid}" "${WS_PORT_CHOSEN}" "${listen_addr}" \
-        "${DOMAIN}" "${ws_tls}") ||
-        _config_die "SBX-CONFIG-033" "Failed to create WS-TLS inbound" \
+        "${DOMAIN}" "${ws_tls}") \
+        || _config_die "SBX-CONFIG-033" "Failed to create WS-TLS inbound" \
           "Verify WS port/domain/TLS settings."
 
       base_config=$(echo "${base_config}" | jq --argjson ws "${ws_config}" \
-        '.inbounds += [$ws]' 2>/dev/null) ||
-        _config_die "SBX-CONFIG-034" "Failed to add WS-TLS configuration" \
+        '.inbounds += [$ws]' 2> /dev/null) \
+        || _config_die "SBX-CONFIG-034" "Failed to add WS-TLS configuration" \
           "Verify WS inbound JSON generation."
     fi
 
@@ -601,20 +689,60 @@ _create_all_inbounds() {
     if [[ "${enable_hy2}" == "1" && -n "${HY2_PORT_CHOSEN:-}" ]]; then
       local hy2_tls=''
       hy2_tls=$(_build_tls_block "${DOMAIN}" '["h3"]' \
-        "${cert_fullchain}" "${cert_key}" "${cert_mode}" "${CF_API_TOKEN:-}") ||
-        _config_die "SBX-CONFIG-035" "Failed to build Hysteria2 TLS configuration" \
+        "${cert_fullchain}" "${cert_key}" "${cert_mode}" "${CF_API_TOKEN:-}") \
+        || _config_die "SBX-CONFIG-035" "Failed to build Hysteria2 TLS configuration" \
           "Check certificate mode and TLS inputs."
 
       local hy2_config=''
       hy2_config=$(create_hysteria2_inbound "${HY2_PASS}" "${HY2_PORT_CHOSEN}" "${listen_addr}" \
-        "${hy2_tls}") ||
-        _config_die "SBX-CONFIG-036" "Failed to create Hysteria2 inbound" \
+        "${hy2_tls}") \
+        || _config_die "SBX-CONFIG-036" "Failed to create Hysteria2 inbound" \
           "Verify Hysteria2 password/port/TLS settings."
 
       base_config=$(echo "${base_config}" | jq --argjson hy2 "${hy2_config}" \
-        '.inbounds += [$hy2]' 2>/dev/null) ||
-        _config_die "SBX-CONFIG-037" "Failed to add Hysteria2 configuration" \
+        '.inbounds += [$hy2]' 2> /dev/null) \
+        || _config_die "SBX-CONFIG-037" "Failed to add Hysteria2 configuration" \
           "Verify Hysteria2 inbound JSON generation."
+    fi
+
+    # Add TUIC V5 inbound (if enabled and port is set)
+    if [[ "${enable_tuic}" == "1" && -n "${TUIC_PORT_CHOSEN:-}" ]]; then
+      local tuic_tls=''
+      tuic_tls=$(_build_tls_block "${DOMAIN}" '["h3"]' \
+        "${cert_fullchain}" "${cert_key}" "${cert_mode}" "${CF_API_TOKEN:-}") \
+        || _config_die "SBX-CONFIG-050" "Failed to build TUIC TLS configuration" \
+          "Check certificate mode and TLS inputs."
+
+      local tuic_config=''
+      tuic_config=$(create_tuic_inbound "${uuid}" "${TUIC_PASS}" "${TUIC_PORT_CHOSEN}" \
+        "${listen_addr}" "${tuic_tls}") \
+        || _config_die "SBX-CONFIG-051" "Failed to create TUIC inbound" \
+          "Verify TUIC uuid/password/port/TLS settings."
+
+      base_config=$(echo "${base_config}" | jq --argjson tuic "${tuic_config}" \
+        '.inbounds += [$tuic]' 2> /dev/null) \
+        || _config_die "SBX-CONFIG-052" "Failed to add TUIC configuration" \
+          "Verify TUIC inbound JSON generation."
+    fi
+
+    # Add Trojan inbound (if enabled and port is set)
+    if [[ "${enable_trojan}" == "1" && -n "${TROJAN_PORT_CHOSEN:-}" ]]; then
+      local trojan_tls=''
+      trojan_tls=$(_build_tls_block "${DOMAIN}" '["h2","http/1.1"]' \
+        "${cert_fullchain}" "${cert_key}" "${cert_mode}" "${CF_API_TOKEN:-}") \
+        || _config_die "SBX-CONFIG-053" "Failed to build Trojan TLS configuration" \
+          "Check certificate mode and TLS inputs."
+
+      local trojan_config=''
+      trojan_config=$(create_trojan_inbound "${TROJAN_PASS}" "${TROJAN_PORT_CHOSEN}" \
+        "${listen_addr}" "${trojan_tls}") \
+        || _config_die "SBX-CONFIG-054" "Failed to create Trojan inbound" \
+          "Verify Trojan password/port/TLS settings."
+
+      base_config=$(echo "${base_config}" | jq --argjson trojan "${trojan_config}" \
+        '.inbounds += [$trojan]' 2> /dev/null) \
+        || _config_die "SBX-CONFIG-055" "Failed to add Trojan configuration" \
+          "Verify Trojan inbound JSON generation."
     fi
   fi
 
@@ -663,14 +791,14 @@ _write_config_impl() {
 
   # Setup automatic cleanup on function exit/error
   cleanup_write_config() {
-    [[ -f "${temp_conf}" ]] && rm -f "${temp_conf}" 2>/dev/null || true
+    [[ -f "${temp_conf}" ]] && rm -f "${temp_conf}" 2> /dev/null || true
   }
   trap cleanup_write_config RETURN ERR EXIT INT TERM
 
   # Create base configuration
   local base_config=''
-  base_config=$(create_base_config "${ipv6_supported}" "${LOG_LEVEL:-warn}") ||
-    _config_die "SBX-CONFIG-040" "Failed to create base configuration" \
+  base_config=$(create_base_config "${ipv6_supported}" "${LOG_LEVEL:-warn}") \
+    || _config_die "SBX-CONFIG-040" "Failed to create base configuration" \
       "Check jq availability and base config template logic."
 
   # Create all inbounds (Reality + optional WS-TLS and Hysteria2)
@@ -682,15 +810,32 @@ _write_config_impl() {
   has_certs="${inbound_result%%|*}"
   base_config="${inbound_result#*|}"
 
+  # Build route inbound tag list from actually-enabled inbound configurations
+  local route_inbound_tags=()
+  [[ "${ENABLE_REALITY:-1}" == "1" && -n "${REALITY_PORT_CHOSEN:-}" ]] \
+    && route_inbound_tags+=("in-reality")
+  if [[ "${has_certs}" == "true" ]]; then
+    [[ "${ENABLE_WS:-1}" == "1" && -n "${WS_PORT_CHOSEN:-}" ]] \
+      && route_inbound_tags+=("in-ws")
+    [[ "${ENABLE_HY2:-1}" == "1" && -n "${HY2_PORT_CHOSEN:-}" ]] \
+      && route_inbound_tags+=("in-hy2")
+    [[ "${ENABLE_TUIC:-0}" == "1" && -n "${TUIC_PORT_CHOSEN:-}" ]] \
+      && route_inbound_tags+=("in-tuic")
+    [[ "${ENABLE_TROJAN:-0}" == "1" && -n "${TROJAN_PORT_CHOSEN:-}" ]] \
+      && route_inbound_tags+=("in-trojan")
+  fi
+  local route_inbounds_json=''
+  route_inbounds_json=$(printf '%s\n' "${route_inbound_tags[@]}" | jq -R . | jq -sc .)
+
   # Add route and outbound configurations
-  base_config=$(add_route_config "${base_config}" "${has_certs}") ||
-    _config_die "SBX-CONFIG-041" "Failed to add route configuration" \
+  base_config=$(add_route_config "${base_config}" "${route_inbounds_json}") \
+    || _config_die "SBX-CONFIG-041" "Failed to add route configuration" \
       "Verify route generation inputs and JSON integrity."
   base_config=$(add_outbound_config "${base_config}")
 
   # Write configuration to temporary file
-  echo "${base_config}" >"${temp_conf}" ||
-    _config_die "SBX-CONFIG-042" "Failed to write configuration to temporary file" \
+  echo "${base_config}" > "${temp_conf}" \
+    || _config_die "SBX-CONFIG-042" "Failed to write configuration to temporary file" \
       "Check filesystem writability for temporary directory."
 
   # Run comprehensive validation pipeline before applying
@@ -723,5 +868,6 @@ _write_config_impl() {
 
 export -f validate_config_vars create_base_config create_reality_inbound
 export -f create_ws_inbound create_hysteria2_inbound add_route_config
+export -f create_tuic_inbound create_trojan_inbound
 export -f add_outbound_config write_config
 # Note: _validate_certificate_config and _create_all_inbounds are private helpers (not exported)

--- a/lib/export.sh
+++ b/lib/export.sh
@@ -25,7 +25,7 @@ _export_die() {
   local resolution="${3:-}"
   local example="${4:-}"
 
-  if declare -f die_with_code >/dev/null 2>&1; then
+  if declare -f die_with_code > /dev/null 2>&1; then
     die_with_code "${code}" "${reason}" "${resolution}" "${example}"
   fi
 
@@ -39,8 +39,8 @@ _export_die() {
 # Load client info from saved configuration with strict validation
 load_client_info() {
   local client_info_file='' state_file='' resolved='' owner='' perm='' invalid_line=''
-  local ws_enabled_raw='' hy2_enabled_raw=''
-  local allowed_keys_regex="^(DOMAIN|UUID|PUBLIC_KEY|SHORT_ID|SNI|REALITY_PORT|WS_PORT|HY2_PORT|HY2_PASS|CERT_FULLCHAIN|CERT_KEY)$"
+  local ws_enabled_raw='' hy2_enabled_raw='' tuic_enabled_raw='' trojan_enabled_raw=''
+  local allowed_keys_regex="^(DOMAIN|UUID|PUBLIC_KEY|SHORT_ID|SNI|REALITY_PORT|WS_PORT|HY2_PORT|HY2_PASS|TUIC_PORT|TUIC_PASS|TROJAN_PORT|TROJAN_PASS|CERT_FULLCHAIN|CERT_KEY)$"
 
   # Prefer structured state file when available, with compatibility fallback.
   state_file="${TEST_STATE_FILE:-${STATE_FILE:-${SB_CONF_DIR}/state.json}}"
@@ -50,7 +50,7 @@ load_client_info() {
       "install -m 600 /dev/null /etc/sing-box/state.json"
     resolved=$(readlink -f "${state_file}") || _export_die "SBX-EXPORT-002" "Failed to resolve state path: ${state_file}" \
       "Ensure state path exists and is readable."
-    perm=$(stat -c '%a' "${resolved}" 2>/dev/null || stat -f '%Lp' "${resolved}" 2>/dev/null) || _export_die "SBX-EXPORT-003" "Unable to read state file permissions" \
+    perm=$(stat -c '%a' "${resolved}" 2> /dev/null || stat -f '%Lp' "${resolved}" 2> /dev/null) || _export_die "SBX-EXPORT-003" "Unable to read state file permissions" \
       "Check file permissions and stat command availability."
     [[ "${perm}" == "600" ]] || _export_die "SBX-EXPORT-004" "State file permissions must be 600 (found ${perm})" \
       "Restrict state file permissions to owner read/write only." \
@@ -59,17 +59,17 @@ load_client_info() {
       "Re-run install or restore state.json from backup."
 
     if [[ -z "${TEST_STATE_FILE:-}" ]]; then
-      owner=$(stat -c '%u' "${resolved}" 2>/dev/null || stat -f '%u' "${resolved}" 2>/dev/null) || _export_die "SBX-EXPORT-006" "Unable to read state file ownership" \
+      owner=$(stat -c '%u' "${resolved}" 2> /dev/null || stat -f '%u' "${resolved}" 2> /dev/null) || _export_die "SBX-EXPORT-006" "Unable to read state file ownership" \
         "Ensure stat command works and file metadata is accessible."
       [[ "${owner}" -eq 0 ]] || _export_die "SBX-EXPORT-007" "State file must be owned by root (uid 0)" \
         "Fix ownership to root:root." \
         "chown root:root /etc/sing-box/state.json"
     fi
 
-    command -v jq >/dev/null 2>&1 || _export_die "SBX-EXPORT-008" "jq is required to parse state file" \
+    command -v jq > /dev/null 2>&1 || _export_die "SBX-EXPORT-008" "jq is required to parse state file" \
       "Install jq, then retry export commands." \
       "apt install -y jq"
-    jq empty <"${resolved}" 2>/dev/null || _export_die "SBX-EXPORT-009" "State file is not valid JSON: ${resolved}" \
+    jq empty < "${resolved}" 2> /dev/null || _export_die "SBX-EXPORT-009" "State file is not valid JSON: ${resolved}" \
       "Repair or regenerate state.json."
 
     DOMAIN=$(jq -r '.server.domain // .server.ip // empty' "${resolved}")
@@ -81,10 +81,16 @@ load_client_info() {
     WS_PORT=$(jq -r '.protocols.ws_tls.port // empty' "${resolved}")
     HY2_PORT=$(jq -r '.protocols.hysteria2.port // empty' "${resolved}")
     HY2_PASS=$(jq -r '.protocols.hysteria2.password // empty' "${resolved}")
+    TUIC_PORT=$(jq -r '.protocols.tuic.port // empty' "${resolved}")
+    TUIC_PASS=$(jq -r '.protocols.tuic.password // empty' "${resolved}")
+    TROJAN_PORT=$(jq -r '.protocols.trojan.port // empty' "${resolved}")
+    TROJAN_PASS=$(jq -r '.protocols.trojan.password // empty' "${resolved}")
     CERT_FULLCHAIN=$(jq -r '.protocols.ws_tls.certificate // empty' "${resolved}")
     CERT_KEY=$(jq -r '.protocols.ws_tls.key // empty' "${resolved}")
     ws_enabled_raw=$(jq -r '.protocols.ws_tls.enabled // empty' "${resolved}")
     hy2_enabled_raw=$(jq -r '.protocols.hysteria2.enabled // empty' "${resolved}")
+    tuic_enabled_raw=$(jq -r '.protocols.tuic.enabled // empty' "${resolved}")
+    trojan_enabled_raw=$(jq -r '.protocols.trojan.enabled // empty' "${resolved}")
 
     case "${ws_enabled_raw}" in
       true | 1 | yes | on) WS_ENABLED="true" ;;
@@ -102,10 +108,28 @@ load_client_info() {
         ;;
     esac
 
+    case "${tuic_enabled_raw}" in
+      true | 1 | yes | on) TUIC_ENABLED="true" ;;
+      false | 0 | no | off) TUIC_ENABLED="false" ;;
+      *)
+        [[ -n "${TUIC_PORT:-}" || -n "${TUIC_PASS:-}" ]] && TUIC_ENABLED="true" || TUIC_ENABLED="false"
+        ;;
+    esac
+
+    case "${trojan_enabled_raw}" in
+      true | 1 | yes | on) TROJAN_ENABLED="true" ;;
+      false | 0 | no | off) TROJAN_ENABLED="false" ;;
+      *)
+        [[ -n "${TROJAN_PORT:-}" || -n "${TROJAN_PASS:-}" ]] && TROJAN_ENABLED="true" || TROJAN_ENABLED="false"
+        ;;
+    esac
+
     REALITY_PORT="${REALITY_PORT:-${REALITY_PORT_DEFAULT:-443}}"
     SNI="${SNI:-${SNI_DEFAULT:-www.microsoft.com}}"
     WS_PORT="${WS_PORT:-${WS_PORT_DEFAULT:-8444}}"
     HY2_PORT="${HY2_PORT:-${HY2_PORT_DEFAULT:-8443}}"
+    TUIC_PORT="${TUIC_PORT:-${TUIC_PORT_DEFAULT:-8445}}"
+    TROJAN_PORT="${TROJAN_PORT:-${TROJAN_PORT_DEFAULT:-8446}}"
     return 0
   fi
 
@@ -122,7 +146,7 @@ load_client_info() {
   resolved=$(readlink -f "${client_info_file}") || _export_die "SBX-EXPORT-023" "Failed to resolve client info path: ${client_info_file}" \
     "Ensure path exists and is readable."
   # Cross-platform stat: Linux uses -c, BSD/macOS uses -f
-  perm=$(stat -c '%a' "${resolved}" 2>/dev/null || stat -f '%Lp' "${resolved}" 2>/dev/null) || _export_die "SBX-EXPORT-024" "Unable to read client info permissions" \
+  perm=$(stat -c '%a' "${resolved}" 2> /dev/null || stat -f '%Lp' "${resolved}" 2> /dev/null) || _export_die "SBX-EXPORT-024" "Unable to read client info permissions" \
     "Ensure stat command works and file metadata is accessible."
   [[ "${perm}" == "600" ]] || _export_die "SBX-EXPORT-025" "Client info permissions must be 600 (found ${perm})" \
     "Restrict client-info.txt to owner read/write only." \
@@ -134,7 +158,7 @@ load_client_info() {
   # Skip this check in test mode (TEST_CLIENT_INFO set) to allow non-root CI
   if [[ -z "${TEST_CLIENT_INFO:-}" ]]; then
     # Cross-platform stat: Linux uses -c, BSD/macOS uses -f
-    owner=$(stat -c '%u' "${resolved}" 2>/dev/null || stat -f '%u' "${resolved}" 2>/dev/null) || _export_die "SBX-EXPORT-027" "Unable to read client info ownership" \
+    owner=$(stat -c '%u' "${resolved}" 2> /dev/null || stat -f '%u' "${resolved}" 2> /dev/null) || _export_die "SBX-EXPORT-027" "Unable to read client info ownership" \
       "Ensure stat command works and file metadata is accessible."
     [[ "${owner}" -eq 0 ]] || _export_die "SBX-EXPORT-028" "Client info must be owned by root (uid 0)" \
       "Fix ownership to root:root." \
@@ -173,7 +197,7 @@ load_client_info() {
       "Remove command substitutions/backticks from values."
 
     client_info_map["${key}"]="${value}"
-  done <"${resolved}"
+  done < "${resolved}"
 
   # Export parsed values into the environment
   for key in "${!client_info_map[@]}"; do
@@ -192,11 +216,25 @@ load_client_info() {
     HY2_ENABLED="false"
   fi
 
+  if [[ -v client_info_map[TUIC_PORT] || -v client_info_map[TUIC_PASS] ]]; then
+    TUIC_ENABLED="true"
+  else
+    TUIC_ENABLED="false"
+  fi
+
+  if [[ -v client_info_map[TROJAN_PORT] || -v client_info_map[TROJAN_PASS] ]]; then
+    TROJAN_ENABLED="true"
+  else
+    TROJAN_ENABLED="false"
+  fi
+
   # Set defaults for missing variables to ensure valid URIs
   REALITY_PORT="${REALITY_PORT:-${REALITY_PORT_DEFAULT:-443}}"
   SNI="${SNI:-${SNI_DEFAULT:-www.microsoft.com}}"
   WS_PORT="${WS_PORT:-${WS_PORT_DEFAULT:-8444}}"
   HY2_PORT="${HY2_PORT:-${HY2_PORT_DEFAULT:-8443}}"
+  TUIC_PORT="${TUIC_PORT:-${TUIC_PORT_DEFAULT:-8445}}"
+  TROJAN_PORT="${TROJAN_PORT:-${TROJAN_PORT_DEFAULT:-8446}}"
 }
 
 #==============================================================================
@@ -212,7 +250,7 @@ export_v2rayn_json() {
   case "${protocol}" in
     reality)
       config=$(
-        cat <<EOF
+        cat << EOF
 {
   "log": { "loglevel": "warning" },
   "inbounds": [{
@@ -252,7 +290,7 @@ EOF
       [[ -n "${WS_PORT}" ]] || _export_die "SBX-EXPORT-040" "WS-TLS not configured" \
         "Enable WS during install or export Reality only."
       config=$(
-        cat <<EOF
+        cat << EOF
 {
   "log": { "loglevel": "warning" },
   "inbounds": [{
@@ -306,7 +344,7 @@ EOF
 export_clash_yaml() {
   load_client_info
 
-  cat <<EOF
+  cat << EOF
 proxies:
   - name: "sbx-reality-${DOMAIN}"
     type: vless
@@ -324,7 +362,7 @@ proxies:
 EOF
 
   if [[ -n "${WS_PORT}" && -n "${CERT_FULLCHAIN}" ]]; then
-    cat <<EOF
+    cat << EOF
 
   - name: "sbx-ws-${DOMAIN}"
     type: vless
@@ -350,7 +388,38 @@ EOF
 EOF
   fi
 
-  cat <<EOF
+  if [[ "${TUIC_ENABLED:-false}" == "true" && -n "${TUIC_PORT:-}" && -n "${TUIC_PASS:-}" ]]; then
+    cat << EOF
+
+  - name: "sbx-tuic-${DOMAIN}"
+    type: tuic
+    server: ${DOMAIN}
+    port: ${TUIC_PORT}
+    uuid: ${UUID}
+    password: ${TUIC_PASS}
+    congestion-controller: bbr
+    alpn:
+      - h3
+    sni: ${DOMAIN}
+    skip-cert-verify: false
+EOF
+  fi
+
+  if [[ "${TROJAN_ENABLED:-false}" == "true" && -n "${TROJAN_PORT:-}" && -n "${TROJAN_PASS:-}" ]]; then
+    cat << EOF
+
+  - name: "sbx-trojan-${DOMAIN}"
+    type: trojan
+    server: ${DOMAIN}
+    port: ${TROJAN_PORT}
+    password: ${TROJAN_PASS}
+    sni: ${DOMAIN}
+    skip-cert-verify: false
+    client-fingerprint: ${REALITY_FINGERPRINT_DEFAULT}
+EOF
+  fi
+
+  cat << EOF
 
 proxy-groups:
   - name: "sbx-lite"
@@ -360,9 +429,21 @@ proxy-groups:
 EOF
 
   if [[ -n "${WS_PORT}" ]]; then
-    cat <<EOF
+    cat << EOF
       - "sbx-ws-${DOMAIN}"
       - "sbx-hysteria2-${DOMAIN}"
+EOF
+  fi
+
+  if [[ "${TUIC_ENABLED:-false}" == "true" ]]; then
+    cat << EOF
+      - "sbx-tuic-${DOMAIN}"
+EOF
+  fi
+
+  if [[ "${TROJAN_ENABLED:-false}" == "true" ]]; then
+    cat << EOF
+      - "sbx-trojan-${DOMAIN}"
 EOF
   fi
 }
@@ -390,14 +471,26 @@ export_uri() {
         "Enable Hysteria2 during install or export Reality only."
       echo "hysteria2://${HY2_PASS}@${DOMAIN}:${HY2_PORT}/?sni=${DOMAIN}&alpn=h3&insecure=0#Hysteria2-${DOMAIN}"
       ;;
+    tuic)
+      [[ -n "${TUIC_PORT:-}" && -n "${TUIC_PASS:-}" ]] || _export_die "SBX-EXPORT-046" "TUIC not configured" \
+        "Enable TUIC during install or export another protocol."
+      echo "tuic://${UUID}:${TUIC_PASS}@${DOMAIN}:${TUIC_PORT}?congestion_control=bbr&alpn=h3&sni=${DOMAIN}&udp_relay_mode=native#TUIC-${DOMAIN}"
+      ;;
+    trojan)
+      [[ -n "${TROJAN_PORT:-}" && -n "${TROJAN_PASS:-}" ]] || _export_die "SBX-EXPORT-047" "Trojan not configured" \
+        "Enable Trojan during install or export another protocol."
+      echo "trojan://${TROJAN_PASS}@${DOMAIN}:${TROJAN_PORT}?sni=${DOMAIN}&security=tls&type=tcp&fp=${REALITY_FINGERPRINT_DEFAULT}#Trojan-${DOMAIN}"
+      ;;
     all)
       export_uri reality
       [[ -n "${WS_PORT}" ]] && export_uri ws
       [[ -n "${HY2_PORT}" ]] && export_uri hy2
+      [[ "${TUIC_ENABLED:-false}" == "true" ]] && export_uri tuic
+      [[ "${TROJAN_ENABLED:-false}" == "true" ]] && export_uri trojan
       ;;
     *)
-      _export_die "SBX-EXPORT-043" "Invalid protocol: ${protocol} (use: reality, ws, hy2, all)" \
-        "Use one of: reality, ws, hy2, all."
+      _export_die "SBX-EXPORT-043" "Invalid protocol: ${protocol} (use: reality, ws, hy2, tuic, trojan, all)" \
+        "Use one of: reality, ws, hy2, tuic, trojan, all."
       ;;
   esac
 }
@@ -409,10 +502,10 @@ export_uri() {
 # Generate QR codes for configuration
 export_qr_codes() {
   local output_dir="${1:-./qr-codes}"
-  local reality_uri='' ws_uri='' hy2_uri=''
+  local reality_uri='' ws_uri='' hy2_uri='' tuic_uri='' trojan_uri=''
   load_client_info
 
-  command -v qrencode >/dev/null || _export_die "SBX-EXPORT-044" "qrencode not installed." \
+  command -v qrencode > /dev/null || _export_die "SBX-EXPORT-044" "qrencode not installed." \
     "Install qrencode then retry QR export." \
     "apt install -y qrencode"
 
@@ -434,6 +527,18 @@ export_qr_codes() {
     hy2_uri=$(export_uri hy2)
     qrencode -t PNG -o "${output_dir}/hy2-qr.png" "${hy2_uri}"
     success "  ✓ Hysteria2 QR code: ${output_dir}/hy2-qr.png"
+  fi
+
+  if [[ "${TUIC_ENABLED:-false}" == "true" ]]; then
+    tuic_uri=$(export_uri tuic)
+    qrencode -t PNG -o "${output_dir}/tuic-qr.png" "${tuic_uri}"
+    success "  ✓ TUIC QR code: ${output_dir}/tuic-qr.png"
+  fi
+
+  if [[ "${TROJAN_ENABLED:-false}" == "true" ]]; then
+    trojan_uri=$(export_uri trojan)
+    qrencode -t PNG -o "${output_dir}/trojan-qr.png" "${trojan_uri}"
+    success "  ✓ Trojan QR code: ${output_dir}/trojan-qr.png"
   fi
 
   info "QR codes saved to: ${output_dir}"
@@ -459,18 +564,26 @@ export_subscription() {
     uris+=$'\n'$(export_uri hy2)
   fi
 
+  if [[ "${TUIC_ENABLED:-false}" == "true" ]]; then
+    uris+=$'\n'$(export_uri tuic)
+  fi
+
+  if [[ "${TROJAN_ENABLED:-false}" == "true" ]]; then
+    uris+=$'\n'$(export_uri trojan)
+  fi
+
   # Base64 encode
   subscription=$(echo -n "${uris}" | base64 -w 0)
 
   # Save to file
   mkdir -p "$(dirname "${output_file}")"
-  echo "${subscription}" >"${output_file}"
+  echo "${subscription}" > "${output_file}"
   chmod 644 "${output_file}"
 
   success "Subscription link generated: ${output_file}"
 
   # Display access URL if web server detected
-  if systemctl is-active nginx >/dev/null 2>&1 || systemctl is-active apache2 >/dev/null 2>&1; then
+  if systemctl is-active nginx > /dev/null 2>&1 || systemctl is-active apache2 > /dev/null 2>&1; then
     sub_url="http://${DOMAIN}/$(basename "${output_file}")"
     info "Subscription URL: ${sub_url}"
   fi
@@ -513,7 +626,7 @@ export_config() {
 
   # Output to file or stdout
   if [[ -n "${output_file}" ]]; then
-    echo "${config}" >"${output_file}"
+    echo "${config}" > "${output_file}"
     success "Configuration exported to: ${output_file}"
   else
     echo "${config}"

--- a/lib/export.sh
+++ b/lib/export.sh
@@ -25,7 +25,7 @@ _export_die() {
   local resolution="${3:-}"
   local example="${4:-}"
 
-  if declare -f die_with_code > /dev/null 2>&1; then
+  if declare -f die_with_code >/dev/null 2>&1; then
     die_with_code "${code}" "${reason}" "${resolution}" "${example}"
   fi
 
@@ -50,7 +50,7 @@ load_client_info() {
       "install -m 600 /dev/null /etc/sing-box/state.json"
     resolved=$(readlink -f "${state_file}") || _export_die "SBX-EXPORT-002" "Failed to resolve state path: ${state_file}" \
       "Ensure state path exists and is readable."
-    perm=$(stat -c '%a' "${resolved}" 2> /dev/null || stat -f '%Lp' "${resolved}" 2> /dev/null) || _export_die "SBX-EXPORT-003" "Unable to read state file permissions" \
+    perm=$(stat -c '%a' "${resolved}" 2>/dev/null || stat -f '%Lp' "${resolved}" 2>/dev/null) || _export_die "SBX-EXPORT-003" "Unable to read state file permissions" \
       "Check file permissions and stat command availability."
     [[ "${perm}" == "600" ]] || _export_die "SBX-EXPORT-004" "State file permissions must be 600 (found ${perm})" \
       "Restrict state file permissions to owner read/write only." \
@@ -59,17 +59,17 @@ load_client_info() {
       "Re-run install or restore state.json from backup."
 
     if [[ -z "${TEST_STATE_FILE:-}" ]]; then
-      owner=$(stat -c '%u' "${resolved}" 2> /dev/null || stat -f '%u' "${resolved}" 2> /dev/null) || _export_die "SBX-EXPORT-006" "Unable to read state file ownership" \
+      owner=$(stat -c '%u' "${resolved}" 2>/dev/null || stat -f '%u' "${resolved}" 2>/dev/null) || _export_die "SBX-EXPORT-006" "Unable to read state file ownership" \
         "Ensure stat command works and file metadata is accessible."
       [[ "${owner}" -eq 0 ]] || _export_die "SBX-EXPORT-007" "State file must be owned by root (uid 0)" \
         "Fix ownership to root:root." \
         "chown root:root /etc/sing-box/state.json"
     fi
 
-    command -v jq > /dev/null 2>&1 || _export_die "SBX-EXPORT-008" "jq is required to parse state file" \
+    command -v jq >/dev/null 2>&1 || _export_die "SBX-EXPORT-008" "jq is required to parse state file" \
       "Install jq, then retry export commands." \
       "apt install -y jq"
-    jq empty < "${resolved}" 2> /dev/null || _export_die "SBX-EXPORT-009" "State file is not valid JSON: ${resolved}" \
+    jq empty <"${resolved}" 2>/dev/null || _export_die "SBX-EXPORT-009" "State file is not valid JSON: ${resolved}" \
       "Repair or regenerate state.json."
 
     DOMAIN=$(jq -r '.server.domain // .server.ip // empty' "${resolved}")
@@ -146,7 +146,7 @@ load_client_info() {
   resolved=$(readlink -f "${client_info_file}") || _export_die "SBX-EXPORT-023" "Failed to resolve client info path: ${client_info_file}" \
     "Ensure path exists and is readable."
   # Cross-platform stat: Linux uses -c, BSD/macOS uses -f
-  perm=$(stat -c '%a' "${resolved}" 2> /dev/null || stat -f '%Lp' "${resolved}" 2> /dev/null) || _export_die "SBX-EXPORT-024" "Unable to read client info permissions" \
+  perm=$(stat -c '%a' "${resolved}" 2>/dev/null || stat -f '%Lp' "${resolved}" 2>/dev/null) || _export_die "SBX-EXPORT-024" "Unable to read client info permissions" \
     "Ensure stat command works and file metadata is accessible."
   [[ "${perm}" == "600" ]] || _export_die "SBX-EXPORT-025" "Client info permissions must be 600 (found ${perm})" \
     "Restrict client-info.txt to owner read/write only." \
@@ -158,7 +158,7 @@ load_client_info() {
   # Skip this check in test mode (TEST_CLIENT_INFO set) to allow non-root CI
   if [[ -z "${TEST_CLIENT_INFO:-}" ]]; then
     # Cross-platform stat: Linux uses -c, BSD/macOS uses -f
-    owner=$(stat -c '%u' "${resolved}" 2> /dev/null || stat -f '%u' "${resolved}" 2> /dev/null) || _export_die "SBX-EXPORT-027" "Unable to read client info ownership" \
+    owner=$(stat -c '%u' "${resolved}" 2>/dev/null || stat -f '%u' "${resolved}" 2>/dev/null) || _export_die "SBX-EXPORT-027" "Unable to read client info ownership" \
       "Ensure stat command works and file metadata is accessible."
     [[ "${owner}" -eq 0 ]] || _export_die "SBX-EXPORT-028" "Client info must be owned by root (uid 0)" \
       "Fix ownership to root:root." \
@@ -197,7 +197,7 @@ load_client_info() {
       "Remove command substitutions/backticks from values."
 
     client_info_map["${key}"]="${value}"
-  done < "${resolved}"
+  done <"${resolved}"
 
   # Export parsed values into the environment
   for key in "${!client_info_map[@]}"; do
@@ -250,7 +250,7 @@ export_v2rayn_json() {
   case "${protocol}" in
     reality)
       config=$(
-        cat << EOF
+        cat <<EOF
 {
   "log": { "loglevel": "warning" },
   "inbounds": [{
@@ -290,7 +290,7 @@ EOF
       [[ -n "${WS_PORT}" ]] || _export_die "SBX-EXPORT-040" "WS-TLS not configured" \
         "Enable WS during install or export Reality only."
       config=$(
-        cat << EOF
+        cat <<EOF
 {
   "log": { "loglevel": "warning" },
   "inbounds": [{
@@ -344,7 +344,7 @@ EOF
 export_clash_yaml() {
   load_client_info
 
-  cat << EOF
+  cat <<EOF
 proxies:
   - name: "sbx-reality-${DOMAIN}"
     type: vless
@@ -362,7 +362,7 @@ proxies:
 EOF
 
   if [[ -n "${WS_PORT}" && -n "${CERT_FULLCHAIN}" ]]; then
-    cat << EOF
+    cat <<EOF
 
   - name: "sbx-ws-${DOMAIN}"
     type: vless
@@ -389,7 +389,7 @@ EOF
   fi
 
   if [[ "${TUIC_ENABLED:-false}" == "true" && -n "${TUIC_PORT:-}" && -n "${TUIC_PASS:-}" ]]; then
-    cat << EOF
+    cat <<EOF
 
   - name: "sbx-tuic-${DOMAIN}"
     type: tuic
@@ -406,7 +406,7 @@ EOF
   fi
 
   if [[ "${TROJAN_ENABLED:-false}" == "true" && -n "${TROJAN_PORT:-}" && -n "${TROJAN_PASS:-}" ]]; then
-    cat << EOF
+    cat <<EOF
 
   - name: "sbx-trojan-${DOMAIN}"
     type: trojan
@@ -419,7 +419,7 @@ EOF
 EOF
   fi
 
-  cat << EOF
+  cat <<EOF
 
 proxy-groups:
   - name: "sbx-lite"
@@ -429,20 +429,20 @@ proxy-groups:
 EOF
 
   if [[ -n "${WS_PORT}" ]]; then
-    cat << EOF
+    cat <<EOF
       - "sbx-ws-${DOMAIN}"
       - "sbx-hysteria2-${DOMAIN}"
 EOF
   fi
 
   if [[ "${TUIC_ENABLED:-false}" == "true" ]]; then
-    cat << EOF
+    cat <<EOF
       - "sbx-tuic-${DOMAIN}"
 EOF
   fi
 
   if [[ "${TROJAN_ENABLED:-false}" == "true" ]]; then
-    cat << EOF
+    cat <<EOF
       - "sbx-trojan-${DOMAIN}"
 EOF
   fi
@@ -505,7 +505,7 @@ export_qr_codes() {
   local reality_uri='' ws_uri='' hy2_uri='' tuic_uri='' trojan_uri=''
   load_client_info
 
-  command -v qrencode > /dev/null || _export_die "SBX-EXPORT-044" "qrencode not installed." \
+  command -v qrencode >/dev/null || _export_die "SBX-EXPORT-044" "qrencode not installed." \
     "Install qrencode then retry QR export." \
     "apt install -y qrencode"
 
@@ -577,13 +577,13 @@ export_subscription() {
 
   # Save to file
   mkdir -p "$(dirname "${output_file}")"
-  echo "${subscription}" > "${output_file}"
+  echo "${subscription}" >"${output_file}"
   chmod 644 "${output_file}"
 
   success "Subscription link generated: ${output_file}"
 
   # Display access URL if web server detected
-  if systemctl is-active nginx > /dev/null 2>&1 || systemctl is-active apache2 > /dev/null 2>&1; then
+  if systemctl is-active nginx >/dev/null 2>&1 || systemctl is-active apache2 >/dev/null 2>&1; then
     sub_url="http://${DOMAIN}/$(basename "${output_file}")"
     info "Subscription URL: ${sub_url}"
   fi
@@ -626,7 +626,7 @@ export_config() {
 
   # Output to file or stdout
   if [[ -n "${output_file}" ]]; then
-    echo "${config}" > "${output_file}"
+    echo "${config}" >"${output_file}"
     success "Configuration exported to: ${output_file}"
   else
     echo "${config}"

--- a/tests/unit/test_config_tuic_trojan.sh
+++ b/tests/unit/test_config_tuic_trojan.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Unit tests for TUIC V5 and Trojan inbound configuration generation
 # Tests: create_tuic_inbound(), create_trojan_inbound()
-set -uo pipefail
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
@@ -34,7 +34,7 @@ assert_json_valid() {
   local test_name="$1"
   local json="$2"
   TOTAL_TESTS=$((TOTAL_TESTS + 1))
-  if echo "${json}" | jq empty 2> /dev/null; then
+  if echo "${json}" | jq empty 2>/dev/null; then
     echo -e "${GREEN}✓${NC} ${test_name}"
     PASSED_TESTS=$((PASSED_TESTS + 1))
   else
@@ -50,7 +50,7 @@ assert_json_value_equals() {
   local expected="$4"
   TOTAL_TESTS=$((TOTAL_TESTS + 1))
   local actual
-  actual=$(echo "${json}" | jq -r "${key_path}" 2> /dev/null)
+  actual=$(echo "${json}" | jq -r "${key_path}" 2>/dev/null)
   if [[ "${actual}" == "${expected}" ]]; then
     echo -e "${GREEN}✓${NC} ${test_name}"
     PASSED_TESTS=$((PASSED_TESTS + 1))
@@ -66,7 +66,7 @@ assert_json_has_key() {
   local key_path="$3"
   TOTAL_TESTS=$((TOTAL_TESTS + 1))
   local value
-  value=$(echo "${json}" | jq -r "${key_path}" 2> /dev/null)
+  value=$(echo "${json}" | jq -r "${key_path}" 2>/dev/null)
   if [[ -n "${value}" && "${value}" != "null" ]]; then
     echo -e "${GREEN}✓${NC} ${test_name}"
     PASSED_TESTS=$((PASSED_TESTS + 1))
@@ -100,7 +100,7 @@ _make_test_tls() {
       alpn: $alpn,
       certificate_path: "/tmp/test-cert.pem",
       key_path: "/tmp/test-key.pem"
-    }' 2> /dev/null
+    }' 2>/dev/null
 }
 
 #==============================================================================
@@ -121,7 +121,7 @@ test_create_tuic_inbound_basic() {
 
   local config
   config=$(create_tuic_inbound "${test_uuid}" "${test_pass}" "${test_port}" \
-    "${test_listen}" "${test_tls}" 2> /dev/null)
+    "${test_listen}" "${test_tls}" 2>/dev/null)
 
   assert_json_valid "TUIC: generates valid JSON" "${config}"
   assert_json_value_equals "TUIC: type is tuic" "${config}" ".type" "tuic"
@@ -144,7 +144,7 @@ test_create_tuic_inbound_user_fields() {
 
   local config
   config=$(create_tuic_inbound "${test_uuid}" "${test_pass}" "8445" \
-    "::" "${test_tls}" 2> /dev/null)
+    "::" "${test_tls}" 2>/dev/null)
 
   assert_json_value_equals "TUIC: user uuid matches" "${config}" ".users[0].uuid" "${test_uuid}"
   assert_json_value_equals "TUIC: user password matches" "${config}" ".users[0].password" "${test_pass}"
@@ -159,11 +159,11 @@ test_create_tuic_inbound_protocol_fields() {
   test_tls=$(_make_test_tls '["h3"]')
 
   local config
-  config=$(create_tuic_inbound "uuid" "pass" "8445" "::" "${test_tls}" 2> /dev/null)
+  config=$(create_tuic_inbound "uuid" "pass" "8445" "::" "${test_tls}" 2>/dev/null)
 
   assert_json_value_equals "TUIC: congestion_control is bbr" "${config}" ".congestion_control" "bbr"
   local zrtt
-  zrtt=$(echo "${config}" | jq -r '.zero_rtt_handshake' 2> /dev/null)
+  zrtt=$(echo "${config}" | jq -r '.zero_rtt_handshake' 2>/dev/null)
   assert_true "TUIC: zero_rtt_handshake is false" "$([[ "${zrtt}" == "false" ]] && echo true || echo false)"
   assert_json_value_equals "TUIC: heartbeat is 10s" "${config}" ".heartbeat" "10s"
 }
@@ -177,11 +177,11 @@ test_create_tuic_inbound_tls_alpn() {
   test_tls=$(_make_test_tls '["h3"]')
 
   local config
-  config=$(create_tuic_inbound "uuid" "pass" "8445" "::" "${test_tls}" 2> /dev/null)
+  config=$(create_tuic_inbound "uuid" "pass" "8445" "::" "${test_tls}" 2>/dev/null)
 
   assert_json_value_equals "TUIC: TLS alpn[0] is h3" "${config}" ".tls.alpn[0]" "h3"
   local tls_enabled
-  tls_enabled=$(echo "${config}" | jq -r '.tls.enabled' 2> /dev/null)
+  tls_enabled=$(echo "${config}" | jq -r '.tls.enabled' 2>/dev/null)
   assert_true "TUIC: TLS enabled" "$([[ "${tls_enabled}" == "true" ]] && echo true || echo false)"
 }
 
@@ -202,7 +202,7 @@ test_create_trojan_inbound_basic() {
 
   local config
   config=$(create_trojan_inbound "${test_pass}" "${test_port}" \
-    "${test_listen}" "${test_tls}" 2> /dev/null)
+    "${test_listen}" "${test_tls}" 2>/dev/null)
 
   assert_json_valid "Trojan: generates valid JSON" "${config}"
   assert_json_value_equals "Trojan: type is trojan" "${config}" ".type" "trojan"
@@ -223,7 +223,7 @@ test_create_trojan_inbound_user_fields() {
   test_tls=$(_make_test_tls '["h2","http/1.1"]')
 
   local config
-  config=$(create_trojan_inbound "${test_pass}" "8446" "::" "${test_tls}" 2> /dev/null)
+  config=$(create_trojan_inbound "${test_pass}" "8446" "::" "${test_tls}" 2>/dev/null)
 
   assert_json_value_equals "Trojan: user password matches" "${config}" ".users[0].password" "${test_pass}"
 }
@@ -237,12 +237,12 @@ test_create_trojan_inbound_tls_alpn() {
   test_tls=$(_make_test_tls '["h2","http/1.1"]')
 
   local config
-  config=$(create_trojan_inbound "pass" "8446" "::" "${test_tls}" 2> /dev/null)
+  config=$(create_trojan_inbound "pass" "8446" "::" "${test_tls}" 2>/dev/null)
 
   assert_json_value_equals "Trojan: TLS alpn[0] is h2" "${config}" ".tls.alpn[0]" "h2"
   assert_json_value_equals "Trojan: TLS alpn[1] is http/1.1" "${config}" ".tls.alpn[1]" "http/1.1"
   local tls_enabled
-  tls_enabled=$(echo "${config}" | jq -r '.tls.enabled' 2> /dev/null)
+  tls_enabled=$(echo "${config}" | jq -r '.tls.enabled' 2>/dev/null)
   assert_true "Trojan: TLS enabled" "$([[ "${tls_enabled}" == "true" ]] && echo true || echo false)"
 }
 
@@ -298,7 +298,7 @@ test_function_exists() {
   echo "--------------------------"
 
   TOTAL_TESTS=$((TOTAL_TESTS + 1))
-  if declare -f create_tuic_inbound > /dev/null 2>&1; then
+  if declare -f create_tuic_inbound >/dev/null 2>&1; then
     echo -e "${GREEN}✓${NC} create_tuic_inbound is defined"
     PASSED_TESTS=$((PASSED_TESTS + 1))
   else
@@ -307,7 +307,7 @@ test_function_exists() {
   fi
 
   TOTAL_TESTS=$((TOTAL_TESTS + 1))
-  if declare -f create_trojan_inbound > /dev/null 2>&1; then
+  if declare -f create_trojan_inbound >/dev/null 2>&1; then
     echo -e "${GREEN}✓${NC} create_trojan_inbound is defined"
     PASSED_TESTS=$((PASSED_TESTS + 1))
   else

--- a/tests/unit/test_config_tuic_trojan.sh
+++ b/tests/unit/test_config_tuic_trojan.sh
@@ -1,0 +1,352 @@
+#!/usr/bin/env bash
+# Unit tests for TUIC V5 and Trojan inbound configuration generation
+# Tests: create_tuic_inbound(), create_trojan_inbound()
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
+export TERM="xterm"
+export SBX_TEST_MODE=1
+
+# Test statistics
+TOTAL_TESTS=0
+PASSED_TESTS=0
+FAILED_TESTS=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+# Load modules under test
+# shellcheck source=/dev/null
+source "${PROJECT_ROOT}/lib/common.sh"
+# shellcheck source=/dev/null
+source "${PROJECT_ROOT}/lib/network.sh"
+# shellcheck source=/dev/null
+source "${PROJECT_ROOT}/lib/validation.sh"
+# shellcheck source=/dev/null
+source "${PROJECT_ROOT}/lib/config.sh"
+
+trap - EXIT INT TERM
+
+# Helper functions
+assert_json_valid() {
+  local test_name="$1"
+  local json="$2"
+  TOTAL_TESTS=$((TOTAL_TESTS + 1))
+  if echo "${json}" | jq empty 2> /dev/null; then
+    echo -e "${GREEN}✓${NC} ${test_name}"
+    PASSED_TESTS=$((PASSED_TESTS + 1))
+  else
+    echo -e "${RED}✗${NC} ${test_name} (invalid JSON)"
+    FAILED_TESTS=$((FAILED_TESTS + 1))
+  fi
+}
+
+assert_json_value_equals() {
+  local test_name="$1"
+  local json="$2"
+  local key_path="$3"
+  local expected="$4"
+  TOTAL_TESTS=$((TOTAL_TESTS + 1))
+  local actual
+  actual=$(echo "${json}" | jq -r "${key_path}" 2> /dev/null)
+  if [[ "${actual}" == "${expected}" ]]; then
+    echo -e "${GREEN}✓${NC} ${test_name}"
+    PASSED_TESTS=$((PASSED_TESTS + 1))
+  else
+    echo -e "${RED}✗${NC} ${test_name} (expected '${expected}', got '${actual}')"
+    FAILED_TESTS=$((FAILED_TESTS + 1))
+  fi
+}
+
+assert_json_has_key() {
+  local test_name="$1"
+  local json="$2"
+  local key_path="$3"
+  TOTAL_TESTS=$((TOTAL_TESTS + 1))
+  local value
+  value=$(echo "${json}" | jq -r "${key_path}" 2> /dev/null)
+  if [[ -n "${value}" && "${value}" != "null" ]]; then
+    echo -e "${GREEN}✓${NC} ${test_name}"
+    PASSED_TESTS=$((PASSED_TESTS + 1))
+  else
+    echo -e "${RED}✗${NC} ${test_name} (key '${key_path}' not found or null)"
+    FAILED_TESTS=$((FAILED_TESTS + 1))
+  fi
+}
+
+assert_true() {
+  local test_name="$1"
+  local result="$2"
+  TOTAL_TESTS=$((TOTAL_TESTS + 1))
+  if [[ "${result}" == "true" ]]; then
+    echo -e "${GREEN}✓${NC} ${test_name}"
+    PASSED_TESTS=$((PASSED_TESTS + 1))
+  else
+    echo -e "${RED}✗${NC} ${test_name} (expected true, got '${result}')"
+    FAILED_TESTS=$((FAILED_TESTS + 1))
+  fi
+}
+
+# ── Minimal TLS block for tests (manual cert mode with dummy paths) ──────────
+_make_test_tls() {
+  local alpn_json="$1"
+  jq -n \
+    --argjson alpn "${alpn_json}" \
+    '{
+      enabled: true,
+      server_name: "test.example.com",
+      alpn: $alpn,
+      certificate_path: "/tmp/test-cert.pem",
+      key_path: "/tmp/test-key.pem"
+    }' 2> /dev/null
+}
+
+#==============================================================================
+# TUIC V5 Tests
+#==============================================================================
+
+test_create_tuic_inbound_basic() {
+  echo ""
+  echo "Testing create_tuic_inbound() - Basic Functionality"
+  echo "----------------------------------------------------"
+
+  local test_uuid="123e4567-e89b-12d3-a456-426614174000"
+  local test_pass="deadbeefcafebabe0102030405060708"
+  local test_port="8445"
+  local test_listen="::"
+  local test_tls
+  test_tls=$(_make_test_tls '["h3"]')
+
+  local config
+  config=$(create_tuic_inbound "${test_uuid}" "${test_pass}" "${test_port}" \
+    "${test_listen}" "${test_tls}" 2> /dev/null)
+
+  assert_json_valid "TUIC: generates valid JSON" "${config}"
+  assert_json_value_equals "TUIC: type is tuic" "${config}" ".type" "tuic"
+  assert_json_value_equals "TUIC: tag is in-tuic" "${config}" ".tag" "in-tuic"
+  assert_json_value_equals "TUIC: listen is ::" "${config}" ".listen" "::"
+  assert_json_value_equals "TUIC: port is 8445" "${config}" ".listen_port" "8445"
+  assert_json_has_key "TUIC: has users array" "${config}" ".users"
+  assert_json_has_key "TUIC: has tls section" "${config}" ".tls"
+}
+
+test_create_tuic_inbound_user_fields() {
+  echo ""
+  echo "Testing create_tuic_inbound() - User Fields"
+  echo "--------------------------------------------"
+
+  local test_uuid="123e4567-e89b-12d3-a456-426614174000"
+  local test_pass="deadbeefcafebabe0102030405060708"
+  local test_tls
+  test_tls=$(_make_test_tls '["h3"]')
+
+  local config
+  config=$(create_tuic_inbound "${test_uuid}" "${test_pass}" "8445" \
+    "::" "${test_tls}" 2> /dev/null)
+
+  assert_json_value_equals "TUIC: user uuid matches" "${config}" ".users[0].uuid" "${test_uuid}"
+  assert_json_value_equals "TUIC: user password matches" "${config}" ".users[0].password" "${test_pass}"
+}
+
+test_create_tuic_inbound_protocol_fields() {
+  echo ""
+  echo "Testing create_tuic_inbound() - Protocol Fields"
+  echo "------------------------------------------------"
+
+  local test_tls
+  test_tls=$(_make_test_tls '["h3"]')
+
+  local config
+  config=$(create_tuic_inbound "uuid" "pass" "8445" "::" "${test_tls}" 2> /dev/null)
+
+  assert_json_value_equals "TUIC: congestion_control is bbr" "${config}" ".congestion_control" "bbr"
+  local zrtt
+  zrtt=$(echo "${config}" | jq -r '.zero_rtt_handshake' 2> /dev/null)
+  assert_true "TUIC: zero_rtt_handshake is false" "$([[ "${zrtt}" == "false" ]] && echo true || echo false)"
+  assert_json_value_equals "TUIC: heartbeat is 10s" "${config}" ".heartbeat" "10s"
+}
+
+test_create_tuic_inbound_tls_alpn() {
+  echo ""
+  echo "Testing create_tuic_inbound() - TLS ALPN"
+  echo "-----------------------------------------"
+
+  local test_tls
+  test_tls=$(_make_test_tls '["h3"]')
+
+  local config
+  config=$(create_tuic_inbound "uuid" "pass" "8445" "::" "${test_tls}" 2> /dev/null)
+
+  assert_json_value_equals "TUIC: TLS alpn[0] is h3" "${config}" ".tls.alpn[0]" "h3"
+  local tls_enabled
+  tls_enabled=$(echo "${config}" | jq -r '.tls.enabled' 2> /dev/null)
+  assert_true "TUIC: TLS enabled" "$([[ "${tls_enabled}" == "true" ]] && echo true || echo false)"
+}
+
+#==============================================================================
+# Trojan Tests
+#==============================================================================
+
+test_create_trojan_inbound_basic() {
+  echo ""
+  echo "Testing create_trojan_inbound() - Basic Functionality"
+  echo "------------------------------------------------------"
+
+  local test_pass="deadbeefcafebabe0102030405060708"
+  local test_port="8446"
+  local test_listen="::"
+  local test_tls
+  test_tls=$(_make_test_tls '["h2","http/1.1"]')
+
+  local config
+  config=$(create_trojan_inbound "${test_pass}" "${test_port}" \
+    "${test_listen}" "${test_tls}" 2> /dev/null)
+
+  assert_json_valid "Trojan: generates valid JSON" "${config}"
+  assert_json_value_equals "Trojan: type is trojan" "${config}" ".type" "trojan"
+  assert_json_value_equals "Trojan: tag is in-trojan" "${config}" ".tag" "in-trojan"
+  assert_json_value_equals "Trojan: listen is ::" "${config}" ".listen" "::"
+  assert_json_value_equals "Trojan: port is 8446" "${config}" ".listen_port" "8446"
+  assert_json_has_key "Trojan: has users array" "${config}" ".users"
+  assert_json_has_key "Trojan: has tls section" "${config}" ".tls"
+}
+
+test_create_trojan_inbound_user_fields() {
+  echo ""
+  echo "Testing create_trojan_inbound() - User Fields"
+  echo "----------------------------------------------"
+
+  local test_pass="deadbeefcafebabe0102030405060708"
+  local test_tls
+  test_tls=$(_make_test_tls '["h2","http/1.1"]')
+
+  local config
+  config=$(create_trojan_inbound "${test_pass}" "8446" "::" "${test_tls}" 2> /dev/null)
+
+  assert_json_value_equals "Trojan: user password matches" "${config}" ".users[0].password" "${test_pass}"
+}
+
+test_create_trojan_inbound_tls_alpn() {
+  echo ""
+  echo "Testing create_trojan_inbound() - TLS ALPN"
+  echo "-------------------------------------------"
+
+  local test_tls
+  test_tls=$(_make_test_tls '["h2","http/1.1"]')
+
+  local config
+  config=$(create_trojan_inbound "pass" "8446" "::" "${test_tls}" 2> /dev/null)
+
+  assert_json_value_equals "Trojan: TLS alpn[0] is h2" "${config}" ".tls.alpn[0]" "h2"
+  assert_json_value_equals "Trojan: TLS alpn[1] is http/1.1" "${config}" ".tls.alpn[1]" "http/1.1"
+  local tls_enabled
+  tls_enabled=$(echo "${config}" | jq -r '.tls.enabled' 2> /dev/null)
+  assert_true "Trojan: TLS enabled" "$([[ "${tls_enabled}" == "true" ]] && echo true || echo false)"
+}
+
+#==============================================================================
+# Port constants tests
+#==============================================================================
+
+test_port_constants() {
+  echo ""
+  echo "Testing port constants"
+  echo "----------------------"
+
+  TOTAL_TESTS=$((TOTAL_TESTS + 1))
+  if [[ -n "${TUIC_PORT_DEFAULT:-}" && "${TUIC_PORT_DEFAULT}" -gt 0 ]]; then
+    echo -e "${GREEN}✓${NC} TUIC_PORT_DEFAULT is defined (${TUIC_PORT_DEFAULT})"
+    PASSED_TESTS=$((PASSED_TESTS + 1))
+  else
+    echo -e "${RED}✗${NC} TUIC_PORT_DEFAULT not defined or invalid"
+    FAILED_TESTS=$((FAILED_TESTS + 1))
+  fi
+
+  TOTAL_TESTS=$((TOTAL_TESTS + 1))
+  if [[ -n "${TROJAN_PORT_DEFAULT:-}" && "${TROJAN_PORT_DEFAULT}" -gt 0 ]]; then
+    echo -e "${GREEN}✓${NC} TROJAN_PORT_DEFAULT is defined (${TROJAN_PORT_DEFAULT})"
+    PASSED_TESTS=$((PASSED_TESTS + 1))
+  else
+    echo -e "${RED}✗${NC} TROJAN_PORT_DEFAULT not defined or invalid"
+    FAILED_TESTS=$((FAILED_TESTS + 1))
+  fi
+
+  TOTAL_TESTS=$((TOTAL_TESTS + 1))
+  if [[ -n "${TUIC_PORT_FALLBACK:-}" && "${TUIC_PORT_FALLBACK}" -gt 0 ]]; then
+    echo -e "${GREEN}✓${NC} TUIC_PORT_FALLBACK is defined (${TUIC_PORT_FALLBACK})"
+    PASSED_TESTS=$((PASSED_TESTS + 1))
+  else
+    echo -e "${RED}✗${NC} TUIC_PORT_FALLBACK not defined or invalid"
+    FAILED_TESTS=$((FAILED_TESTS + 1))
+  fi
+
+  TOTAL_TESTS=$((TOTAL_TESTS + 1))
+  if [[ -n "${TROJAN_PORT_FALLBACK:-}" && "${TROJAN_PORT_FALLBACK}" -gt 0 ]]; then
+    echo -e "${GREEN}✓${NC} TROJAN_PORT_FALLBACK is defined (${TROJAN_PORT_FALLBACK})"
+    PASSED_TESTS=$((PASSED_TESTS + 1))
+  else
+    echo -e "${RED}✗${NC} TROJAN_PORT_FALLBACK not defined or invalid"
+    FAILED_TESTS=$((FAILED_TESTS + 1))
+  fi
+}
+
+test_function_exists() {
+  echo ""
+  echo "Testing function existence"
+  echo "--------------------------"
+
+  TOTAL_TESTS=$((TOTAL_TESTS + 1))
+  if declare -f create_tuic_inbound > /dev/null 2>&1; then
+    echo -e "${GREEN}✓${NC} create_tuic_inbound is defined"
+    PASSED_TESTS=$((PASSED_TESTS + 1))
+  else
+    echo -e "${RED}✗${NC} create_tuic_inbound not defined"
+    FAILED_TESTS=$((FAILED_TESTS + 1))
+  fi
+
+  TOTAL_TESTS=$((TOTAL_TESTS + 1))
+  if declare -f create_trojan_inbound > /dev/null 2>&1; then
+    echo -e "${GREEN}✓${NC} create_trojan_inbound is defined"
+    PASSED_TESTS=$((PASSED_TESTS + 1))
+  else
+    echo -e "${RED}✗${NC} create_trojan_inbound not defined"
+    FAILED_TESTS=$((FAILED_TESTS + 1))
+  fi
+}
+
+#==============================================================================
+# Main
+#==============================================================================
+
+echo "=========================================="
+echo "TUIC V5 and Trojan Configuration Tests"
+echo "=========================================="
+
+test_function_exists
+test_port_constants
+test_create_tuic_inbound_basic
+test_create_tuic_inbound_user_fields
+test_create_tuic_inbound_protocol_fields
+test_create_tuic_inbound_tls_alpn
+test_create_trojan_inbound_basic
+test_create_trojan_inbound_user_fields
+test_create_trojan_inbound_tls_alpn
+
+echo ""
+echo "=========================================="
+echo "Test Summary"
+echo "=========================================="
+echo "Total:  ${TOTAL_TESTS}"
+echo "Passed: ${PASSED_TESTS}"
+echo "Failed: ${FAILED_TESTS}"
+echo ""
+
+if [[ ${FAILED_TESTS} -eq 0 ]]; then
+  echo "✓ All tests passed!"
+  exit 0
+else
+  echo "✗ ${FAILED_TESTS} test(s) failed"
+  exit 1
+fi


### PR DESCRIPTION
- lib/common.sh: add TUIC_PORT_DEFAULT/FALLBACK, TROJAN_PORT_DEFAULT/FALLBACK,
  and TUIC_PASS/TROJAN_PASS/TUIC_PORT_CHOSEN/TROJAN_PORT_CHOSEN global vars
- install.sh (early constants): add TUIC_PORT_DEFAULT=8445, TROJAN_PORT_DEFAULT=8446
- lib/config.sh:
  - create_tuic_inbound(): TUIC V5 inbound with BBR congestion control, h3 ALPN
  - create_trojan_inbound(): Trojan inbound with h2/http/1.1 ALPN
  - _validate_certificate_config(): validate TUIC/Trojan port+password when enabled
  - _create_all_inbounds(): add TUIC/Trojan inbound creation in TLS-available path
  - _write_config_impl(): build route inbound tag list dynamically (only include
    actually-enabled inbounds, fixes latent over-inclusion for all protocols)
  - add_route_config(): signature changed to accept inbounds JSON array directly
- lib/export.sh:
  - load_client_info(): read TUIC/Trojan from state.json and client-info.txt;
    set TUIC_ENABLED/TROJAN_ENABLED flags
  - export_uri(): add tuic and trojan cases; update all to include new protocols
  - export_clash_yaml(): add TUIC/Trojan proxy blocks and proxy-group entries
  - export_qr_codes(): generate QR codes for TUIC and Trojan when enabled
  - export_subscription(): include TUIC/Trojan URIs in base64 subscription
- install.sh:
  - _configure_cloudflare_mode(): default ENABLE_TUIC/ENABLE_TROJAN=0 in CF mode
    and non-CF mode (opt-in, not enabled by default)
  - _validate_protocol_config(): include TUIC/Trojan in "at least one" check
  - _generate_credentials(): generate TUIC_PASS and TROJAN_PASS when enabled
  - _allocate_ports(): allocate TUIC/Trojan ports with dedicated fallbacks
  - save_client_info(): persist TUIC_PORT/TUIC_PASS/TROJAN_PORT/TROJAN_PASS
  - save_state_info(): add tuic and trojan blocks to protocols in state.json
  - open_firewall(): open TUIC (UDP+TCP) and Trojan (TCP) ports when enabled
  - print_summary()/dry_run_flow(): display TUIC/Trojan in protocol list and URIs
- tests/unit/test_config_tuic_trojan.sh: 31 unit tests covering function
  existence, port constants, TUIC inbound (JSON validity, type/tag/port/users/
  TLS/protocol fields), Trojan inbound (JSON validity, type/tag/port/users/TLS)

All 31 new tests pass; existing test suite unaffected.

Closes #96

https://claude.ai/code/session_01CLNrbtFEA4YzNzhHNqJxRp