### PR TITLE
Fix ACME TLS config and expose TUIC in sbx-manager

### DIFF
--- a/bin/sbx-manager.sh
+++ b/bin/sbx-manager.sh
@@ -67,7 +67,7 @@ ${B}Backup & Restore:${N}
 ${B}Configuration Export:${N}
   export v2rayn [protocol] [file]   Export v2rayN config (reality|ws)
   export clash [file]               Export Clash YAML config
-  export uri [protocol]             Export share URIs (reality|ws|hy2|all)
+  export uri [protocol]             Export share URIs (reality|ws|hy2|tuic|all)
   export qr [output-dir]            Generate QR code images
   export subscription [file]        Generate subscription link
 
@@ -88,7 +88,7 @@ EOF
 
 CLIENT_INFO_PATH="${CLIENT_INFO:-/etc/sing-box/client-info.txt}"
 STATE_INFO_PATH="${STATE_FILE:-/etc/sing-box/state.json}"
-CLIENT_INFO_ALLOWED_KEYS_REGEX="^(DOMAIN|UUID|PUBLIC_KEY|SHORT_ID|SNI|REALITY_PORT|WS_PORT|HY2_PORT|HY2_PASS|CERT_FULLCHAIN|CERT_KEY)$"
+CLIENT_INFO_ALLOWED_KEYS_REGEX="^(DOMAIN|UUID|PUBLIC_KEY|SHORT_ID|SNI|REALITY_PORT|WS_PORT|HY2_PORT|HY2_PASS|TUIC_PORT|TUIC_PASS|CERT_FULLCHAIN|CERT_KEY)$"
 SBX_BIN="${SBX_BIN:-${SB_BIN:-/usr/local/bin/sing-box}}"
 SBX_CONFIG_PATH="${SBX_CONFIG_PATH:-${SB_CONF:-/etc/sing-box/config.json}}"
 HEALTH_CERT_WARNING_DAYS="${HEALTH_CERT_WARNING_DAYS:-30}"
@@ -199,21 +199,29 @@ parse_client_info_file() {
     HY2_ENABLED="false"
   fi
 
+  if [[ -v client_info_map[TUIC_PORT] || -v client_info_map[TUIC_PASS] ]]; then
+    TUIC_ENABLED="true"
+  else
+    TUIC_ENABLED="false"
+  fi
+
   # Set defaults for missing variables
   local default_reality="${REALITY_PORT_DEFAULT:-443}"
   local default_sni="${SNI_DEFAULT:-www.microsoft.com}"
   local default_ws="${WS_PORT_DEFAULT:-8444}"
   local default_hy2="${HY2_PORT_DEFAULT:-8443}"
+  local default_tuic="${TUIC_PORT_DEFAULT:-8445}"
 
   REALITY_PORT="${REALITY_PORT:-$default_reality}"
   SNI="${SNI:-$default_sni}"
   WS_PORT="${WS_PORT:-$default_ws}"
   HY2_PORT="${HY2_PORT:-$default_hy2}"
+  TUIC_PORT="${TUIC_PORT:-$default_tuic}"
 }
 
 parse_state_info_file() {
   local file="$1"
-  local ws_enabled_raw='' hy2_enabled_raw=''
+  local ws_enabled_raw='' hy2_enabled_raw='' tuic_enabled_raw=''
 
   DOMAIN=$(jq -r '.server.domain // .server.ip // empty' "$file")
   UUID=$(jq -r '.protocols.reality.uuid // empty' "$file")
@@ -224,10 +232,13 @@ parse_state_info_file() {
   WS_PORT=$(jq -r '.protocols.ws_tls.port // empty' "$file")
   HY2_PORT=$(jq -r '.protocols.hysteria2.port // empty' "$file")
   HY2_PASS=$(jq -r '.protocols.hysteria2.password // empty' "$file")
+  TUIC_PORT=$(jq -r '.protocols.tuic.port // empty' "$file")
+  TUIC_PASS=$(jq -r '.protocols.tuic.password // empty' "$file")
   CERT_FULLCHAIN=$(jq -r '.protocols.ws_tls.certificate // empty' "$file")
   CERT_KEY=$(jq -r '.protocols.ws_tls.key // empty' "$file")
   ws_enabled_raw=$(jq -r '.protocols.ws_tls.enabled // empty' "$file")
   hy2_enabled_raw=$(jq -r '.protocols.hysteria2.enabled // empty' "$file")
+  tuic_enabled_raw=$(jq -r '.protocols.tuic.enabled // empty' "$file")
 
   case "${ws_enabled_raw}" in
     true | 1 | yes | on) WS_ENABLED="true" ;;
@@ -245,15 +256,25 @@ parse_state_info_file() {
       ;;
   esac
 
+  case "${tuic_enabled_raw}" in
+    true | 1 | yes | on) TUIC_ENABLED="true" ;;
+    false | 0 | no | off) TUIC_ENABLED="false" ;;
+    *)
+      [[ -n "${TUIC_PORT:-}" || -n "${TUIC_PASS:-}" ]] && TUIC_ENABLED="true" || TUIC_ENABLED="false"
+      ;;
+  esac
+
   local default_reality="${REALITY_PORT_DEFAULT:-443}"
   local default_sni="${SNI_DEFAULT:-www.microsoft.com}"
   local default_ws="${WS_PORT_DEFAULT:-8444}"
   local default_hy2="${HY2_PORT_DEFAULT:-8443}"
+  local default_tuic="${TUIC_PORT_DEFAULT:-8445}"
 
   REALITY_PORT="${REALITY_PORT:-$default_reality}"
   SNI="${SNI:-$default_sni}"
   WS_PORT="${WS_PORT:-$default_ws}"
   HY2_PORT="${HY2_PORT:-$default_hy2}"
+  TUIC_PORT="${TUIC_PORT:-$default_tuic}"
 }
 
 fallback_load_client_info() {
@@ -550,7 +571,8 @@ output_info_json() {
   local warnings_json='[]'
   local has_ws=false
   local has_hy2=false
-  local uri_real='' uri_ws='' uri_hy2=''
+  local has_tuic=false
+  local uri_real='' uri_ws='' uri_hy2='' uri_tuic=''
 
   ensure_client_info_loaded
 
@@ -569,15 +591,19 @@ output_info_json() {
   WS_PORT="${WS_PORT:-8444}"
   HY2_PORT="${HY2_PORT:-8443}"
   HY2_PASS="${HY2_PASS:-}"
+  TUIC_PORT="${TUIC_PORT:-8445}"
+  TUIC_PASS="${TUIC_PASS:-}"
 
   if command -v export_uri >/dev/null 2>&1; then
     uri_real=$(export_uri reality)
     uri_ws=$(export_uri ws 2>/dev/null || true)
     uri_hy2=$(export_uri hy2 2>/dev/null || true)
+    uri_tuic=$(export_uri tuic 2>/dev/null || true)
   else
     uri_real="vless://${UUID:-}@${DOMAIN:-}:${REALITY_PORT}?encryption=none&security=reality&flow=xtls-rprx-vision&sni=${SNI}&pbk=${PUBLIC_KEY:-}&sid=${SHORT_ID:-}&type=tcp&fp=chrome#Reality-${DOMAIN:-}"
     uri_ws="vless://${UUID:-}@${DOMAIN:-}:${WS_PORT}?encryption=none&security=tls&type=ws&host=${DOMAIN:-}&path=/ws&sni=${DOMAIN:-}&fp=chrome#WS-TLS-${DOMAIN:-}"
     uri_hy2="hysteria2://${HY2_PASS}@${DOMAIN:-}:${HY2_PORT}/?sni=${DOMAIN:-}&alpn=h3&insecure=0#Hysteria2-${DOMAIN:-}"
+    uri_tuic="tuic://${UUID:-}:${TUIC_PASS}@${DOMAIN:-}:${TUIC_PORT}?congestion_control=bbr&alpn=h3&sni=${DOMAIN:-}&udp_relay_mode=native#TUIC-${DOMAIN:-}"
   fi
 
   if [[ "${WS_ENABLED:-false}" == "true" ]]; then
@@ -590,6 +616,12 @@ output_info_json() {
     has_hy2=true
   elif [[ -n "${CERT_FULLCHAIN:-}" && -n "${CERT_KEY:-}" ]]; then
     has_hy2=true
+  fi
+
+  if [[ "${TUIC_ENABLED:-false}" == "true" ]]; then
+    has_tuic=true
+  elif [[ -n "${TUIC_PORT:-}" || -n "${TUIC_PASS:-}" ]]; then
+    has_tuic=true
   fi
 
   if echo "${uri_real}" | grep -qE 'pbk=&|pbk=$|@:|//:'; then
@@ -616,10 +648,14 @@ output_info_json() {
     --arg hy2_port "${HY2_PORT}" \
     --arg hy2_pass "${HY2_PASS}" \
     --arg uri_hy2 "${uri_hy2}" \
+    --arg tuic_port "${TUIC_PORT}" \
+    --arg tuic_pass "${TUIC_PASS}" \
+    --arg uri_tuic "${uri_tuic}" \
     --arg cert_fullchain "${CERT_FULLCHAIN:-}" \
     --arg cert_key "${CERT_KEY:-}" \
     --argjson ws_enabled "${has_ws}" \
     --argjson hy2_enabled "${has_hy2}" \
+    --argjson tuic_enabled "${has_tuic}" \
     --argjson warnings "${warnings_json}" \
     '{
         command: $command,
@@ -648,6 +684,12 @@ output_info_json() {
             port: ($hy2_port | tonumber? // null),
             password: (if $hy2_enabled and $hy2_pass != "" then $hy2_pass else null end),
             uri: (if $hy2_enabled then $uri_hy2 else null end)
+          },
+          tuic: {
+            enabled: $tuic_enabled,
+            port: ($tuic_port | tonumber? // null),
+            password: (if $tuic_enabled and $tuic_pass != "" then $tuic_pass else null end),
+            uri: (if $tuic_enabled then $uri_tuic else null end)
           }
         }
       }'
@@ -785,6 +827,8 @@ case "${1:-}" in
       WS_PORT="${WS_PORT:-8444}"
       HY2_PORT="${HY2_PORT:-8443}"
       HY2_PASS="${HY2_PASS:-}"
+      TUIC_PORT="${TUIC_PORT:-8445}"
+      TUIC_PASS="${TUIC_PASS:-}"
       echo
       echo "INBOUND   : VLESS-WS-TLS   ${WS_PORT}/tcp"
       echo "  CERT     = ${CERT_FULLCHAIN}"
@@ -804,9 +848,21 @@ case "${1:-}" in
         URI_HY2="hysteria2://${HY2_PASS}@${DOMAIN:-}:${HY2_PORT}/?sni=${DOMAIN:-}&alpn=h3&insecure=0#Hysteria2-${DOMAIN:-}"
       fi
       echo "  URI      = ${URI_HY2}"
+
+      if [[ "${TUIC_ENABLED:-false}" == "true" || -n "${TUIC_PORT:-}" || -n "${TUIC_PASS:-}" ]]; then
+        echo
+        echo "INBOUND   : TUIC V5        ${TUIC_PORT}/udp"
+        echo "  CERT     = ${CERT_FULLCHAIN}"
+        if command -v export_uri >/dev/null 2>&1; then
+          URI_TUIC=$(export_uri tuic)
+        else
+          URI_TUIC="tuic://${UUID:-}:${TUIC_PASS}@${DOMAIN:-}:${TUIC_PORT}?congestion_control=bbr&alpn=h3&sni=${DOMAIN:-}&udp_relay_mode=native#TUIC-${DOMAIN:-}"
+        fi
+        echo "  URI      = ${URI_TUIC}"
+      fi
     fi
     echo
-    echo -e "${Y}Notes${N}: Reality/Hy2 suggest gray cloud; WS-TLS can use gray/orange cloud."
+    echo -e "${Y}Notes${N}: Reality/Hy2/TUIC suggest gray cloud; WS-TLS can use gray/orange cloud."
 
     # Optional: Generate QR codes
     if command -v qrencode >/dev/null 2>&1; then
@@ -938,7 +994,7 @@ case "${1:-}" in
         echo -e "${Y}Usage:${N}"
         echo "  sbx export v2rayn [reality|ws] [file]  - Export v2rayN config"
         echo "  sbx export clash [file]                - Export Clash config"
-        echo "  sbx export uri [protocol]              - Export share URIs"
+        echo "  sbx export uri [protocol]              - Export share URIs (reality|ws|hy2|tuic|all)"
         echo "  sbx export qr [output-dir]             - Generate QR codes"
         echo "  sbx export subscription [file]         - Generate subscription"
         exit 1

--- a/bin/sbx-manager.sh
+++ b/bin/sbx-manager.sh
@@ -572,6 +572,7 @@ output_info_json() {
   local has_ws=false
   local has_hy2=false
   local has_tuic=false
+  local tuic_port_out='' tuic_pass_out=''
   local uri_real='' uri_ws='' uri_hy2='' uri_tuic=''
 
   ensure_client_info_loaded
@@ -591,20 +592,6 @@ output_info_json() {
   WS_PORT="${WS_PORT:-8444}"
   HY2_PORT="${HY2_PORT:-8443}"
   HY2_PASS="${HY2_PASS:-}"
-  TUIC_PORT="${TUIC_PORT:-8445}"
-  TUIC_PASS="${TUIC_PASS:-}"
-
-  if command -v export_uri >/dev/null 2>&1; then
-    uri_real=$(export_uri reality)
-    uri_ws=$(export_uri ws 2>/dev/null || true)
-    uri_hy2=$(export_uri hy2 2>/dev/null || true)
-    uri_tuic=$(export_uri tuic 2>/dev/null || true)
-  else
-    uri_real="vless://${UUID:-}@${DOMAIN:-}:${REALITY_PORT}?encryption=none&security=reality&flow=xtls-rprx-vision&sni=${SNI}&pbk=${PUBLIC_KEY:-}&sid=${SHORT_ID:-}&type=tcp&fp=chrome#Reality-${DOMAIN:-}"
-    uri_ws="vless://${UUID:-}@${DOMAIN:-}:${WS_PORT}?encryption=none&security=tls&type=ws&host=${DOMAIN:-}&path=/ws&sni=${DOMAIN:-}&fp=chrome#WS-TLS-${DOMAIN:-}"
-    uri_hy2="hysteria2://${HY2_PASS}@${DOMAIN:-}:${HY2_PORT}/?sni=${DOMAIN:-}&alpn=h3&insecure=0#Hysteria2-${DOMAIN:-}"
-    uri_tuic="tuic://${UUID:-}:${TUIC_PASS}@${DOMAIN:-}:${TUIC_PORT}?congestion_control=bbr&alpn=h3&sni=${DOMAIN:-}&udp_relay_mode=native#TUIC-${DOMAIN:-}"
-  fi
 
   if [[ "${WS_ENABLED:-false}" == "true" ]]; then
     has_ws=true
@@ -619,9 +606,30 @@ output_info_json() {
   fi
 
   if [[ "${TUIC_ENABLED:-false}" == "true" ]]; then
+    [[ -n "${TUIC_PASS:-}" ]] && has_tuic=true
+  elif [[ -n "${TUIC_PORT:-}" && -n "${TUIC_PASS:-}" ]]; then
     has_tuic=true
-  elif [[ -n "${TUIC_PORT:-}" || -n "${TUIC_PASS:-}" ]]; then
-    has_tuic=true
+  fi
+
+  if [[ "${has_tuic}" == "true" ]]; then
+    tuic_port_out="${TUIC_PORT:-8445}"
+    tuic_pass_out="${TUIC_PASS:-}"
+  fi
+
+  if command -v export_uri >/dev/null 2>&1; then
+    uri_real=$(export_uri reality)
+    uri_ws=$(export_uri ws 2>/dev/null || true)
+    uri_hy2=$(export_uri hy2 2>/dev/null || true)
+    if [[ "${has_tuic}" == "true" ]]; then
+      uri_tuic=$(export_uri tuic)
+    fi
+  else
+    uri_real="vless://${UUID:-}@${DOMAIN:-}:${REALITY_PORT}?encryption=none&security=reality&flow=xtls-rprx-vision&sni=${SNI}&pbk=${PUBLIC_KEY:-}&sid=${SHORT_ID:-}&type=tcp&fp=chrome#Reality-${DOMAIN:-}"
+    uri_ws="vless://${UUID:-}@${DOMAIN:-}:${WS_PORT}?encryption=none&security=tls&type=ws&host=${DOMAIN:-}&path=/ws&sni=${DOMAIN:-}&fp=chrome#WS-TLS-${DOMAIN:-}"
+    uri_hy2="hysteria2://${HY2_PASS}@${DOMAIN:-}:${HY2_PORT}/?sni=${DOMAIN:-}&alpn=h3&insecure=0#Hysteria2-${DOMAIN:-}"
+    if [[ "${has_tuic}" == "true" ]]; then
+      uri_tuic="tuic://${UUID:-}:${tuic_pass_out}@${DOMAIN:-}:${tuic_port_out}?congestion_control=bbr&alpn=h3&sni=${DOMAIN:-}&udp_relay_mode=native#TUIC-${DOMAIN:-}"
+    fi
   fi
 
   if echo "${uri_real}" | grep -qE 'pbk=&|pbk=$|@:|//:'; then
@@ -648,8 +656,8 @@ output_info_json() {
     --arg hy2_port "${HY2_PORT}" \
     --arg hy2_pass "${HY2_PASS}" \
     --arg uri_hy2 "${uri_hy2}" \
-    --arg tuic_port "${TUIC_PORT}" \
-    --arg tuic_pass "${TUIC_PASS}" \
+    --arg tuic_port "${tuic_port_out}" \
+    --arg tuic_pass "${tuic_pass_out}" \
     --arg uri_tuic "${uri_tuic}" \
     --arg cert_fullchain "${CERT_FULLCHAIN:-}" \
     --arg cert_key "${CERT_KEY:-}" \
@@ -824,11 +832,15 @@ case "${1:-}" in
 
     # WebSocket (if cert exists)
     if [[ -n "${CERT_FULLCHAIN:-}" && -n "${CERT_KEY:-}" ]]; then
+      has_tuic_in_info=false
       WS_PORT="${WS_PORT:-8444}"
       HY2_PORT="${HY2_PORT:-8443}"
       HY2_PASS="${HY2_PASS:-}"
-      TUIC_PORT="${TUIC_PORT:-8445}"
-      TUIC_PASS="${TUIC_PASS:-}"
+      if [[ "${TUIC_ENABLED:-false}" == "true" ]]; then
+        [[ -n "${TUIC_PASS:-}" ]] && has_tuic_in_info=true
+      elif [[ -n "${TUIC_PORT:-}" && -n "${TUIC_PASS:-}" ]]; then
+        has_tuic_in_info=true
+      fi
       echo
       echo "INBOUND   : VLESS-WS-TLS   ${WS_PORT}/tcp"
       echo "  CERT     = ${CERT_FULLCHAIN}"
@@ -849,14 +861,16 @@ case "${1:-}" in
       fi
       echo "  URI      = ${URI_HY2}"
 
-      if [[ "${TUIC_ENABLED:-false}" == "true" || -n "${TUIC_PORT:-}" || -n "${TUIC_PASS:-}" ]]; then
+      if [[ "${has_tuic_in_info}" == "true" ]]; then
+        tuic_port_info="${TUIC_PORT:-8445}"
+        tuic_pass_info="${TUIC_PASS:-}"
         echo
-        echo "INBOUND   : TUIC V5        ${TUIC_PORT}/udp"
+        echo "INBOUND   : TUIC V5        ${tuic_port_info}/udp"
         echo "  CERT     = ${CERT_FULLCHAIN}"
         if command -v export_uri >/dev/null 2>&1; then
           URI_TUIC=$(export_uri tuic)
         else
-          URI_TUIC="tuic://${UUID:-}:${TUIC_PASS}@${DOMAIN:-}:${TUIC_PORT}?congestion_control=bbr&alpn=h3&sni=${DOMAIN:-}&udp_relay_mode=native#TUIC-${DOMAIN:-}"
+          URI_TUIC="tuic://${UUID:-}:${tuic_pass_info}@${DOMAIN:-}:${tuic_port_info}?congestion_control=bbr&alpn=h3&sni=${DOMAIN:-}&udp_relay_mode=native#TUIC-${DOMAIN:-}"
         fi
         echo "  URI      = ${URI_TUIC}"
       fi

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -306,8 +306,7 @@ _build_tls_block() {
       enabled: true,
       server_name: $domain,
       alpn: $alpn,
-      acme: $acme,
-      certificate: { store: "chrome" }
+      acme: $acme
     }' 2>/dev/null); then
     err "Failed to build ACME TLS block"
     return 1

--- a/tests/unit/test_config_generation.sh
+++ b/tests/unit/test_config_generation.sh
@@ -497,8 +497,17 @@ test_build_tls_block_acme_http01() {
     FAILED_TESTS=$((FAILED_TESTS + 1))
   fi
 
-  # Chrome Root Store must be set in ACME mode
-  assert_json_value_equals "Chrome Root Store in ACME HTTP-01" "$tls_block" ".certificate.store" "chrome"
+  # ACME mode must not emit a legacy certificate block
+  TOTAL_TESTS=$((TOTAL_TESTS + 1))
+  local has_cert_block
+  has_cert_block=$(echo "$tls_block" | jq 'has("certificate")' 2> /dev/null)
+  if [[ "$has_cert_block" == "false" ]]; then
+    echo -e "${GREEN}✓${NC} No certificate block in ACME HTTP-01 mode"
+    PASSED_TESTS=$((PASSED_TESTS + 1))
+  else
+    echo -e "${RED}✗${NC} Unexpected certificate block in ACME HTTP-01 mode"
+    FAILED_TESTS=$((FAILED_TESTS + 1))
+  fi
 }
 
 test_build_tls_block_acme_dns01() {
@@ -526,8 +535,17 @@ test_build_tls_block_acme_dns01() {
   assert_json_value_equals "DNS provider is cloudflare" "$tls_block" ".acme.dns01_challenge.provider" "cloudflare"
   assert_json_value_equals "API token passed" "$tls_block" ".acme.dns01_challenge.api_token" "fake-cf-api-token-1234567890"
 
-  # Chrome Root Store must be set in DNS-01 ACME mode
-  assert_json_value_equals "Chrome Root Store in ACME DNS-01" "$tls_block" ".certificate.store" "chrome"
+  # ACME DNS-01 mode must not emit a legacy certificate block
+  TOTAL_TESTS=$((TOTAL_TESTS + 1))
+  local has_cert_block
+  has_cert_block=$(echo "$tls_block" | jq 'has("certificate")' 2> /dev/null)
+  if [[ "$has_cert_block" == "false" ]]; then
+    echo -e "${GREEN}✓${NC} No certificate block in ACME DNS-01 mode"
+    PASSED_TESTS=$((PASSED_TESTS + 1))
+  else
+    echo -e "${RED}✗${NC} Unexpected certificate block in ACME DNS-01 mode"
+    FAILED_TESTS=$((FAILED_TESTS + 1))
+  fi
 }
 
 test_build_tls_block_caddy_compat() {

--- a/tests/unit/test_sbx_manager_json.sh
+++ b/tests/unit/test_sbx_manager_json.sh
@@ -29,6 +29,8 @@ REALITY_PORT="443"
 WS_PORT="8444"
 HY2_PORT="8443"
 HY2_PASS="hy2pass123"
+TUIC_PORT="8445"
+TUIC_PASS="tuicpass123"
 CERT_FULLCHAIN="/tmp/fake-fullchain.pem"
 CERT_KEY="/tmp/fake-key.pem"
 EOF
@@ -56,7 +58,7 @@ cat >"${LIB_DIR_STUB}/export.sh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 load_client_info() {
-  unset WS_ENABLED HY2_ENABLED WS_PORT HY2_PORT HY2_PASS CERT_FULLCHAIN CERT_KEY
+  unset WS_ENABLED HY2_ENABLED TUIC_ENABLED WS_PORT HY2_PORT HY2_PASS TUIC_PORT TUIC_PASS CERT_FULLCHAIN CERT_KEY
   source "${TEST_CLIENT_INFO:?}"
   if [[ -n "${WS_PORT+x}" ]]; then
     WS_ENABLED="true"
@@ -68,16 +70,23 @@ load_client_info() {
   else
     HY2_ENABLED="false"
   fi
+  if [[ -n "${TUIC_PORT+x}" || -n "${TUIC_PASS+x}" ]]; then
+    TUIC_ENABLED="true"
+  else
+    TUIC_ENABLED="false"
+  fi
   REALITY_PORT="${REALITY_PORT:-443}"
   SNI="${SNI:-www.microsoft.com}"
   WS_PORT="${WS_PORT:-8444}"
   HY2_PORT="${HY2_PORT:-8443}"
+  TUIC_PORT="${TUIC_PORT:-8445}"
 }
 export_uri() {
   case "${1:-all}" in
     reality) echo "vless://reality-uri" ;;
     ws) echo "vless://ws-uri" ;;
     hy2) echo "hysteria2://hy2-uri" ;;
+    tuic) echo "tuic://tuic-uri" ;;
     *) echo "vless://all-uri" ;;
   esac
 }
@@ -186,6 +195,10 @@ test_json_output_commands() {
     assert_success "printf '%s' \"\$info_json\" | jq empty" "info --json returns valid JSON"
     assert_equals "info" "$(echo "$info_json" | jq -r '.command')" "info --json includes command field"
     assert_equals "vless://reality-uri" "$(echo "$info_json" | jq -r '.protocols.reality.uri')" "info --json includes reality URI"
+    assert_equals "true" "$(echo "$info_json" | jq -r '.protocols.tuic.enabled')" "info --json marks tuic enabled"
+    assert_equals "8445" "$(echo "$info_json" | jq -r '.protocols.tuic.port')" "info --json includes tuic port"
+    assert_equals "tuicpass123" "$(echo "$info_json" | jq -r '.protocols.tuic.password')" "info --json includes tuic password"
+    assert_equals "tuic://tuic-uri" "$(echo "$info_json" | jq -r '.protocols.tuic.uri')" "info --json includes tuic URI"
 
     # --json status (global flag form)
     status_json=$(run_sbx_json --json status 2>/dev/null)

--- a/tests/unit/test_sbx_manager_json.sh
+++ b/tests/unit/test_sbx_manager_json.sh
@@ -86,7 +86,10 @@ export_uri() {
     reality) echo "vless://reality-uri" ;;
     ws) echo "vless://ws-uri" ;;
     hy2) echo "hysteria2://hy2-uri" ;;
-    tuic) echo "tuic://tuic-uri" ;;
+    tuic)
+      [[ -n "${TUIC_PORT:-}" && -n "${TUIC_PASS:-}" ]] || return 46
+      echo "tuic://tuic-uri"
+      ;;
     *) echo "vless://all-uri" ;;
   esac
 }
@@ -243,6 +246,10 @@ EOF
     assert_equals "true" "$(echo "$info_json_acme" | jq -r '.protocols.hysteria2.enabled')" "info --json ACME marks hy2 enabled"
     assert_equals "vless://ws-uri" "$(echo "$info_json_acme" | jq -r '.protocols.ws_tls.uri')" "info --json ACME includes ws URI"
     assert_equals "hysteria2://hy2-uri" "$(echo "$info_json_acme" | jq -r '.protocols.hysteria2.uri')" "info --json ACME includes hy2 URI"
+    assert_equals "false" "$(echo "$info_json_acme" | jq -r '.protocols.tuic.enabled')" "info --json ACME marks tuic disabled"
+    assert_equals "null" "$(echo "$info_json_acme" | jq -r '.protocols.tuic.port')" "info --json ACME omits tuic port"
+    assert_equals "null" "$(echo "$info_json_acme" | jq -r '.protocols.tuic.password')" "info --json ACME omits tuic password"
+    assert_equals "null" "$(echo "$info_json_acme" | jq -r '.protocols.tuic.uri')" "info --json ACME omits tuic URI"
 }
 
 main() {

--- a/tests/unit/test_sbx_manager_uri.sh
+++ b/tests/unit/test_sbx_manager_uri.sh
@@ -68,7 +68,15 @@ EOF
 #!/usr/bin/env bash
 set -euo pipefail
 export_uri() {
-  echo "stub-${1:-all}"
+  case "${1:-all}" in
+    tuic)
+      [[ -n "${TUIC_PORT:-}" && -n "${TUIC_PASS:-}" ]] || return 46
+      echo "stub-tuic"
+      ;;
+    *)
+      echo "stub-${1:-all}"
+      ;;
+  esac
 }
 load_client_info() {
   source "${TEST_CLIENT_INFO:?}"
@@ -78,6 +86,24 @@ load_client_info() {
   HY2_PORT="${HY2_PORT:-8443}"
 }
 EOF
+}
+
+create_non_tuic_client_info() {
+  local path="$1"
+  cat >"$path" <<'EOF'
+DOMAIN="example.com"
+UUID="11111111-2222-3333-4444-555555555555"
+PUBLIC_KEY="pubkey123"
+SHORT_ID="abcd1234"
+REALITY_PORT="443"
+SNI="www.microsoft.com"
+WS_PORT="8444"
+HY2_PORT="8443"
+HY2_PASS="pass123"
+CERT_FULLCHAIN="/tmp/fullchain.pem"
+CERT_KEY="/tmp/key.pem"
+EOF
+  chmod 600 "$path"
 }
 
 test_stubbed_export_uri_used_in_info_and_qr() {
@@ -136,6 +162,26 @@ test_help_lists_tuic_export_protocol() {
   fi
 }
 
+test_info_skips_tuic_when_not_configured() {
+  echo ""
+  echo "Test: sbx-manager info skips TUIC when not configured"
+
+  local client_info="$TEST_TMP_DIR/client-info-no-tuic.txt"
+  create_non_tuic_client_info "$client_info"
+
+  local stub_lib="$TEST_TMP_DIR/lib-no-tuic"
+  create_stub_lib "$stub_lib"
+
+  local info_output
+  info_output=$(LIB_DIR="$stub_lib" TEST_CLIENT_INFO="$client_info" bash "$PROJECT_ROOT/bin/sbx-manager.sh" info)
+
+  if echo "$info_output" | grep -q "INBOUND   : TUIC V5"; then
+    fail "info command should not print TUIC section when disabled" "$info_output"
+  else
+    pass "info command skips TUIC section when disabled"
+  fi
+}
+
 test_cli_uri_matches_export_module() {
   echo ""
   echo "Test: sbx-manager URIs match lib/export.sh"
@@ -182,6 +228,7 @@ echo "=========================================="
 
 test_stubbed_export_uri_used_in_info_and_qr
 test_help_lists_tuic_export_protocol
+test_info_skips_tuic_when_not_configured
 test_cli_uri_matches_export_module
 
 echo ""

--- a/tests/unit/test_sbx_manager_uri.sh
+++ b/tests/unit/test_sbx_manager_uri.sh
@@ -47,6 +47,8 @@ SNI="www.microsoft.com"
 WS_PORT="8444"
 HY2_PORT="8443"
 HY2_PASS="pass123"
+TUIC_PORT="8445"
+TUIC_PASS="tuicpass123"
 CERT_FULLCHAIN="/tmp/fullchain.pem"
 CERT_KEY="/tmp/key.pem"
 EOF
@@ -105,12 +107,32 @@ EOF
     fail "info command should delegate to export_uri" "$info_output"
   fi
 
+  if echo "$info_output" | grep -q "stub-tuic"; then
+    pass "info command prints TUIC URI when configured"
+  else
+    fail "info command should print TUIC URI" "$info_output"
+  fi
+
   LIB_DIR="$stub_lib" TEST_CLIENT_INFO="$client_info" PATH="$TEST_TMP_DIR/bin:$PATH" bash "$PROJECT_ROOT/bin/sbx-manager.sh" qr >/dev/null 2>&1 || true
 
   if [[ -f "$QR_LOG" ]] && grep -q "stub-reality" "$QR_LOG"; then
     pass "qr command uses export_uri path"
   else
     fail "qr command should delegate to export_uri" "qrencode log missing stub URI"
+  fi
+}
+
+test_help_lists_tuic_export_protocol() {
+  echo ""
+  echo "Test: sbx-manager help lists TUIC export support"
+
+  local help_output
+  help_output=$(bash "$PROJECT_ROOT/bin/sbx-manager.sh" help)
+
+  if echo "$help_output" | grep -q "reality|ws|hy2|tuic|all"; then
+    pass "help output lists TUIC for export uri"
+  else
+    fail "help output should list TUIC for export uri" "$help_output"
   fi
 }
 
@@ -159,6 +181,7 @@ echo "Running test suite: sbx-manager URI paths"
 echo "=========================================="
 
 test_stubbed_export_uri_used_in_info_and_qr
+test_help_lists_tuic_export_protocol
 test_cli_uri_matches_export_module
 
 echo ""

--- a/tests/unit/test_state_json_compat.sh
+++ b/tests/unit/test_state_json_compat.sh
@@ -47,6 +47,11 @@ setup_state_fixture() {
       "enabled": true,
       "port": 8443,
       "password": "hy2pass123"
+    },
+    "tuic": {
+      "enabled": true,
+      "port": 8445,
+      "password": "tuicpass123"
     }
   }
 }
@@ -82,6 +87,7 @@ test_sbx_manager_reads_state_json() {
     assert_equals "0" "${rc}" "sbx-manager info works with state.json fallback"
     assert_contains "${output}" "Domain    : example.com" "state.json provides domain"
     assert_contains "${output}" "PublicKey = pubkey123" "state.json provides reality public key"
+    assert_contains "${output}" "INBOUND   : TUIC V5        8445/udp" "state.json provides tuic inbound"
 }
 
 test_export_reads_state_json() {
@@ -94,6 +100,16 @@ test_export_reads_state_json() {
     assert_equals "0" "${rc}" "export_uri works with state.json fallback"
     assert_contains "${uri}" "vless://" "state.json export returns reality URI"
     assert_contains "${uri}" "pbk=pubkey123" "state.json export includes public key"
+
+    local tuic_uri=''
+    set +e
+    tuic_uri=$(TEST_STATE_FILE="${STATE_FILE}" TEST_CLIENT_INFO="${TEST_TMP}/missing-client-info.txt" \
+      bash -c "source \"${PROJECT_ROOT}/lib/export.sh\"; export_uri tuic" 2>&1)
+    rc=$?
+
+    assert_equals "0" "${rc}" "tuic export works with state.json fallback"
+    assert_contains "${tuic_uri}" "tuic://" "state.json export returns tuic URI"
+    assert_contains "${tuic_uri}" "tuicpass123" "state.json export includes tuic password"
 }
 
 main() {


### PR DESCRIPTION
## Summary
- remove the invalid legacy `tls.certificate` object from ACME-generated TLS blocks
- expose TUIC in `sbx info`, `sbx info --json`, and `sbx export uri` help text
- extend state/client-info compatibility tests to cover TUIC

## Why
The ACME installer currently generates a `tls.certificate` object that is rejected by `sing-box v1.13.x`. I verified this against the latest official sing-box repo and docs, where inbound TLS uses `certificate_path`/`key_path` for manual certs and ACME configuration without the legacy object.

I also found that `lib/export.sh` already supports TUIC, but `sbx-manager` did not surface TUIC consistently in text output, JSON output, or usage strings.

## Verification
- `bash tests/unit/test_sbx_manager_json.sh`
- `bash tests/unit/test_sbx_manager_uri.sh`
- `bash tests/unit/test_state_json_compat.sh`
- `bash tests/unit/test_config_generation.sh`

Fixes #112