### PR TITLE
Print ACME-managed links in sbx info

### DIFF
--- a/bin/sbx-manager.sh
+++ b/bin/sbx-manager.sh
@@ -830,43 +830,70 @@ case "${1:-}" in
       echo -e "  ${R}⚠ WARNING:${N} URI has empty parameters and cannot be used"
     fi
 
-    # WebSocket (if cert exists)
+    has_ws_in_info=false
+    has_hy2_in_info=false
+    has_tuic_in_info=false
+    cert_label=''
+
+    if [[ "${WS_ENABLED:-false}" == "true" ]]; then
+      has_ws_in_info=true
+    elif [[ -n "${CERT_FULLCHAIN:-}" && -n "${CERT_KEY:-}" ]]; then
+      has_ws_in_info=true
+    fi
+
+    if [[ "${HY2_ENABLED:-false}" == "true" ]]; then
+      has_hy2_in_info=true
+    elif [[ -n "${CERT_FULLCHAIN:-}" && -n "${CERT_KEY:-}" ]]; then
+      has_hy2_in_info=true
+    fi
+
+    if [[ "${TUIC_ENABLED:-false}" == "true" ]]; then
+      [[ -n "${TUIC_PASS:-}" ]] && has_tuic_in_info=true
+    elif [[ -n "${TUIC_PORT:-}" && -n "${TUIC_PASS:-}" ]]; then
+      has_tuic_in_info=true
+    fi
+
     if [[ -n "${CERT_FULLCHAIN:-}" && -n "${CERT_KEY:-}" ]]; then
-      has_tuic_in_info=false
+      cert_label="${CERT_FULLCHAIN}"
+    elif [[ "${has_ws_in_info}" == "true" || "${has_hy2_in_info}" == "true" || "${has_tuic_in_info}" == "true" ]]; then
+      cert_label="ACME-managed"
+    fi
+
+    if [[ "${has_ws_in_info}" == "true" || "${has_hy2_in_info}" == "true" || "${has_tuic_in_info}" == "true" ]]; then
       WS_PORT="${WS_PORT:-8444}"
       HY2_PORT="${HY2_PORT:-8443}"
       HY2_PASS="${HY2_PASS:-}"
-      if [[ "${TUIC_ENABLED:-false}" == "true" ]]; then
-        [[ -n "${TUIC_PASS:-}" ]] && has_tuic_in_info=true
-      elif [[ -n "${TUIC_PORT:-}" && -n "${TUIC_PASS:-}" ]]; then
-        has_tuic_in_info=true
-      fi
       echo
-      echo "INBOUND   : VLESS-WS-TLS   ${WS_PORT}/tcp"
-      echo "  CERT     = ${CERT_FULLCHAIN}"
-      # Use export_uri() if available (DRY), otherwise generate inline
-      if command -v export_uri >/dev/null 2>&1; then
-        URI_WS=$(export_uri ws)
-      else
-        URI_WS="vless://${UUID:-}@${DOMAIN:-}:${WS_PORT}?encryption=none&security=tls&type=ws&host=${DOMAIN:-}&path=/ws&sni=${DOMAIN:-}&fp=chrome#WS-TLS-${DOMAIN:-}"
+      if [[ "${has_ws_in_info}" == "true" ]]; then
+        echo "INBOUND   : VLESS-WS-TLS   ${WS_PORT}/tcp"
+        echo "  CERT     = ${cert_label}"
+        # Use export_uri() if available (DRY), otherwise generate inline
+        if command -v export_uri >/dev/null 2>&1; then
+          URI_WS=$(export_uri ws)
+        else
+          URI_WS="vless://${UUID:-}@${DOMAIN:-}:${WS_PORT}?encryption=none&security=tls&type=ws&host=${DOMAIN:-}&path=/ws&sni=${DOMAIN:-}&fp=chrome#WS-TLS-${DOMAIN:-}"
+        fi
+        echo "  URI      = ${URI_WS}"
       fi
-      echo "  URI      = ${URI_WS}"
-      echo
-      echo "INBOUND   : Hysteria2      ${HY2_PORT}/udp"
-      echo "  CERT     = ${CERT_FULLCHAIN}"
-      if command -v export_uri >/dev/null 2>&1; then
-        URI_HY2=$(export_uri hy2)
-      else
-        URI_HY2="hysteria2://${HY2_PASS}@${DOMAIN:-}:${HY2_PORT}/?sni=${DOMAIN:-}&alpn=h3&insecure=0#Hysteria2-${DOMAIN:-}"
+
+      if [[ "${has_hy2_in_info}" == "true" ]]; then
+        echo
+        echo "INBOUND   : Hysteria2      ${HY2_PORT}/udp"
+        echo "  CERT     = ${cert_label}"
+        if command -v export_uri >/dev/null 2>&1; then
+          URI_HY2=$(export_uri hy2)
+        else
+          URI_HY2="hysteria2://${HY2_PASS}@${DOMAIN:-}:${HY2_PORT}/?sni=${DOMAIN:-}&alpn=h3&insecure=0#Hysteria2-${DOMAIN:-}"
+        fi
+        echo "  URI      = ${URI_HY2}"
       fi
-      echo "  URI      = ${URI_HY2}"
 
       if [[ "${has_tuic_in_info}" == "true" ]]; then
         tuic_port_info="${TUIC_PORT:-8445}"
         tuic_pass_info="${TUIC_PASS:-}"
         echo
         echo "INBOUND   : TUIC V5        ${tuic_port_info}/udp"
-        echo "  CERT     = ${CERT_FULLCHAIN}"
+        echo "  CERT     = ${cert_label}"
         if command -v export_uri >/dev/null 2>&1; then
           URI_TUIC=$(export_uri tuic)
         else

--- a/tests/unit/test_sbx_manager_uri.sh
+++ b/tests/unit/test_sbx_manager_uri.sh
@@ -106,6 +106,27 @@ EOF
   chmod 600 "$path"
 }
 
+create_acme_client_info() {
+  local path="$1"
+  cat >"$path" <<'EOF'
+DOMAIN="example.com"
+UUID="11111111-2222-3333-4444-555555555555"
+PUBLIC_KEY="pubkey123"
+SHORT_ID="abcd1234"
+REALITY_PORT="443"
+SNI="www.microsoft.com"
+WS_PORT="8444"
+HY2_PORT="8443"
+HY2_PASS="pass123"
+TUIC_PORT="8445"
+TUIC_PASS="tuicpass123"
+WS_ENABLED="true"
+HY2_ENABLED="true"
+TUIC_ENABLED="true"
+EOF
+  chmod 600 "$path"
+}
+
 test_stubbed_export_uri_used_in_info_and_qr() {
   echo ""
   echo "Test: sbx-manager uses export_uri hook"
@@ -182,6 +203,38 @@ test_info_skips_tuic_when_not_configured() {
   fi
 }
 
+test_info_prints_acme_managed_protocols() {
+  echo ""
+  echo "Test: sbx-manager info prints ACME-managed protocol URIs"
+
+  local client_info="$TEST_TMP_DIR/client-info-acme.txt"
+  create_acme_client_info "$client_info"
+
+  local stub_lib="$TEST_TMP_DIR/lib-acme"
+  create_stub_lib "$stub_lib"
+
+  local info_output
+  info_output=$(LIB_DIR="$stub_lib" TEST_CLIENT_INFO="$client_info" bash "$PROJECT_ROOT/bin/sbx-manager.sh" info)
+
+  if echo "$info_output" | grep -q "stub-ws"; then
+    pass "info command prints WS URI for ACME-managed setup"
+  else
+    fail "info command should print WS URI for ACME-managed setup" "$info_output"
+  fi
+
+  if echo "$info_output" | grep -q "stub-hy2"; then
+    pass "info command prints Hysteria2 URI for ACME-managed setup"
+  else
+    fail "info command should print Hysteria2 URI for ACME-managed setup" "$info_output"
+  fi
+
+  if echo "$info_output" | grep -q "stub-tuic"; then
+    pass "info command prints TUIC URI for ACME-managed setup"
+  else
+    fail "info command should print TUIC URI for ACME-managed setup" "$info_output"
+  fi
+}
+
 test_cli_uri_matches_export_module() {
   echo ""
   echo "Test: sbx-manager URIs match lib/export.sh"
@@ -229,6 +282,7 @@ echo "=========================================="
 test_stubbed_export_uri_used_in_info_and_qr
 test_help_lists_tuic_export_protocol
 test_info_skips_tuic_when_not_configured
+test_info_prints_acme_managed_protocols
 test_cli_uri_matches_export_module
 
 echo ""


### PR DESCRIPTION
## Summary
- print WS-TLS, Hysteria2, and TUIC links in `sbx info` for ACME-managed installs
- label those entries as `ACME-managed` when no manual certificate paths are present
- add a regression test covering the ACME text-output path

## Why
`sbx info` currently only prints the Reality URI on ACME-managed deployments because the text output path is gated on `CERT_FULLCHAIN` / `CERT_KEY`. In real ACME installs those fields are unset in state, even though the protocols are enabled and exportable.

This follow-up keeps the JSON path unchanged and makes the text output match the actual configured links.

## Verification
- `bash tests/unit/test_sbx_manager_uri.sh`
- `bash tests/unit/test_sbx_manager_json.sh`

Follow-up to #113