### PR TITLE
[codex] Add Telegram bot remote management

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ See [REALITY_TROUBLESHOOTING.md](docs/REALITY_TROUBLESHOOTING.md) for more solut
 | [Troubleshooting](docs/REALITY_TROUBLESHOOTING.md) | Connection & installation issues |
 | [Best Practices](docs/REALITY_BEST_PRACTICES.md) | Security & performance tips |
 | [Advanced Options](docs/ADVANCED.md) | Environment variables & customization |
+| [Telegram Bot](docs/TELEGRAM_BOT.md) | Remote management via Telegram commands |
 | [Architecture Diagrams](docs/ARCHITECTURE_DIAGRAMS.md) | Module structure & installation flowcharts |
 | [Contributing](CONTRIBUTING.md) | Developer setup & guidelines |
 

--- a/bin/sbx-manager.sh
+++ b/bin/sbx-manager.sh
@@ -34,6 +34,8 @@ if [[ -d "$LIB_DIR" ]]; then
   [[ -f "$LIB_DIR/subscription.sh" ]] && source "$LIB_DIR/subscription.sh"
   # shellcheck source=/dev/null
   [[ -f "$LIB_DIR/cloudflare_tunnel.sh" ]] && source "$LIB_DIR/cloudflare_tunnel.sh"
+  # shellcheck source=/dev/null
+  [[ -f "$LIB_DIR/telegram_bot.sh" ]] && source "$LIB_DIR/telegram_bot.sh"
 fi
 
 # Simple logo for management tool
@@ -103,6 +105,17 @@ ${B}Cloudflare Tunnel:${N}
   tunnel disable                  Stop and disable the tunnel service
   tunnel status                   Show tunnel binary/service/hostname
   tunnel hostname                 Print the active tunnel hostname
+
+${B}Telegram Bot:${N}
+  sbx telegram {setup|enable|disable|status|logs|admin ...}
+  telegram setup                  Configure bot token + initial admin chat ID
+  telegram enable                 Install and start the bot service
+  telegram disable                Stop and disable the bot service
+  telegram status                 Show bot binary/service/admin status
+  telegram logs                   Show live Telegram bot logs
+  telegram admin add <chat_id>    Add an allowed Telegram chat ID
+  telegram admin remove <chat_id> Remove an allowed Telegram chat ID
+  telegram admin list             List allowed Telegram chat IDs
 
 ${B}System:${N}
   uninstall|remove    Complete uninstall (requires root)
@@ -1173,6 +1186,13 @@ case "${1:-}" in
     echo
     echo -e "${G}[*]${N} Stopping and disabling sing-box service..."
     systemctl disable --now sing-box 2>/dev/null || true
+    if declare -f telegram_bot_disable >/dev/null 2>&1; then
+      telegram_bot_disable 2>/dev/null || true
+    else
+      systemctl disable --now sbx-telegram-bot 2>/dev/null || true
+      rm -f /etc/systemd/system/sbx-telegram-bot.service
+      systemctl daemon-reload 2>/dev/null || true
+    fi
 
     # Wait for service to stop
     retry=0
@@ -1182,7 +1202,9 @@ case "${1:-}" in
     done
 
     echo -e "${G}[*]${N} Removing files..."
-    rm -f "$SB_BIN" "$SB_SVC" "/usr/local/bin/sbx-manager" "/usr/local/bin/sbx"
+    rm -f "$SB_BIN" "$SB_SVC" "/usr/local/bin/sbx-manager" "/usr/local/bin/sbx" \
+      "/usr/local/bin/sbx-telegram-bot" "/etc/sing-box/telegram.env"
+    rm -rf "/var/lib/sbx-telegram-bot"
     rm -rf "$SB_CONF_DIR" "$CERT_DIR_BASE" "$LIB_DIR"
 
     systemctl daemon-reload
@@ -1378,6 +1400,65 @@ case "${1:-}" in
         echo "  sbx tunnel disable                   Stop tunnel service"
         echo "  sbx tunnel status                    Show tunnel status"
         echo "  sbx tunnel hostname                  Print active tunnel hostname"
+        exit 1
+        ;;
+    esac
+    ;;
+
+  telegram)
+    if ! declare -f telegram_bot_status >/dev/null 2>&1; then
+      echo -e "${R}[ERR]${N} Telegram bot module not loaded. Please reinstall sbx-lite."
+      exit 1
+    fi
+
+    case "${2:-status}" in
+      setup)
+        need_root || exit 1
+        telegram_bot_setup
+        ;;
+      enable)
+        need_root || exit 1
+        telegram_bot_enable
+        ;;
+      disable)
+        need_root || exit 1
+        telegram_bot_disable
+        ;;
+      status | "")
+        telegram_bot_status
+        ;;
+      logs)
+        telegram_bot_logs
+        ;;
+      admin)
+        case "${3:-list}" in
+          add)
+            need_root || exit 1
+            [[ -n "${4:-}" ]] || {
+              echo -e "${R}[ERR]${N} Usage: sbx telegram admin add <chat_id>"
+              exit 1
+            }
+            telegram_bot_admin_add "${4}"
+            ;;
+          remove)
+            need_root || exit 1
+            [[ -n "${4:-}" ]] || {
+              echo -e "${R}[ERR]${N} Usage: sbx telegram admin remove <chat_id>"
+              exit 1
+            }
+            telegram_bot_admin_remove "${4}"
+            ;;
+          list | "")
+            telegram_bot_admin_list
+            ;;
+          *)
+            echo -e "${Y}Usage:${N} sbx telegram admin {add|remove|list} [chat_id]"
+            exit 1
+            ;;
+        esac
+        ;;
+      *)
+        echo -e "${Y}Usage:${N} sbx telegram {setup|enable|disable|status|logs|admin ...}"
         exit 1
         ;;
     esac

--- a/bin/sbx-telegram-bot
+++ b/bin/sbx-telegram-bot
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# sbx-telegram-bot - Telegram bot daemon entrypoint
+
+set -euo pipefail
+
+LIB_DIR="${LIB_DIR:-/usr/local/lib/sbx}"
+
+# shellcheck source=/dev/null
+source "${LIB_DIR}/telegram_bot.sh"
+
+trap '_tg_save_offset "${TG_LAST_OFFSET:-0}" || true; exit 0' TERM INT
+
+telegram_bot_run

--- a/docs/TELEGRAM_BOT.md
+++ b/docs/TELEGRAM_BOT.md
@@ -1,0 +1,122 @@
+# Telegram Bot Remote Management
+
+`sbx` can run a lightweight Telegram Bot daemon for remote sing-box operations.
+The bot uses Telegram Bot API long polling, keeps a whitelist of allowed
+`chat_id`s in `state.json`, and runs as a separate systemd service:
+
+- Unit: `sbx-telegram-bot.service`
+- Launcher: `/usr/local/bin/sbx-telegram-bot`
+- Token env file: `/etc/sing-box/telegram.env`
+- Offset state: `/var/lib/sbx-telegram-bot/offset`
+
+## What It Can Do
+
+Supported Telegram commands:
+
+- `/status` - show whether `sing-box` is active
+- `/users` - list configured users
+- `/adduser <name>` - add a user, sync config, restart `sing-box`
+- `/removeuser <name|uuid>` - remove a user, sync config, restart `sing-box`
+- `/restart` - restart `sing-box`
+- `/help` - show command list
+
+Non-whitelisted chats get a silent drop. The bot does not reply at all, which
+avoids leaking whether a given chat ID is authorized.
+
+## BotFather Setup
+
+1. Open Telegram and talk to [@BotFather](https://t.me/BotFather).
+2. Run `/newbot` and complete the prompts.
+3. Copy the generated bot token. It should look like:
+
+```text
+123456789:AAEhBP0av28FrI51bX4nFxxxxxxxxxxxxxxxxxx
+```
+
+4. Send a message to your new bot from the account or group that should manage
+   the server.
+5. Obtain the numeric `chat_id` you want to authorize.
+
+Notes:
+
+- Personal chats use a positive integer `chat_id`.
+- Groups and supergroups usually use a negative integer such as
+  `-1001234567890`.
+
+## CLI Workflow
+
+Initial setup:
+
+```bash
+sbx telegram setup
+sbx telegram enable
+sbx telegram status
+```
+
+Ongoing operations:
+
+```bash
+sbx telegram logs
+sbx telegram admin list
+sbx telegram admin add 123456789
+sbx telegram admin remove 123456789
+sbx telegram disable
+```
+
+`sbx telegram setup` prompts for:
+
+- Bot token
+- Initial admin `chat_id`
+
+During setup, `sbx` calls Telegram `getMe` to validate the token before writing
+anything to disk.
+
+## Permission Model
+
+The bot runs as `root` because the delegated operations already require root:
+
+- mutating users in `state.json`
+- regenerating sing-box config
+- restarting `sing-box`
+
+Authorization is separate from Unix permissions:
+
+- The service may run as `root`
+- Only `chat_id`s listed in `.telegram.admin_chat_ids` are allowed to issue
+  bot commands
+
+State tracked in `state.json`:
+
+- `.telegram.enabled`
+- `.telegram.username`
+- `.telegram.admin_chat_ids`
+
+The bot token is kept in `/etc/sing-box/telegram.env` instead of being placed
+on the systemd command line.
+
+## Troubleshooting
+
+Check service status and logs:
+
+```bash
+sbx telegram status
+sbx telegram logs
+journalctl -u sbx-telegram-bot -n 80 --no-pager
+```
+
+Common issues:
+
+- `setup` fails immediately: the token format is invalid or `getMe` rejected it
+- `enable` fails: `/usr/local/bin/sbx-telegram-bot` or
+  `/etc/sing-box/telegram.env` is missing
+- bot receives messages but does nothing: the sending chat is not present in
+  `admin_chat_ids`
+- `/adduser` or `/removeuser` succeeds in Telegram but clients do not refresh:
+  inspect `sbx telegram logs` and `journalctl -u sing-box`
+
+## Security Notes
+
+- Files written by the Telegram feature are root-owned
+- The token env file is written with mode `600`
+- Offset/state writes use atomic replace patterns
+- The command dispatcher never `eval`s Telegram input

--- a/install.sh
+++ b/install.sh
@@ -506,7 +506,7 @@ _download_and_validate_manager_script() {
 _load_modules() {
   local github_repo="https://raw.githubusercontent.com/xrf9268-hue/sbx/main"
   # Module loading order: colors first (required by common and logging), then common loads logging and generators, tools after common
-  local modules=(colors common logging generators tools retry download network validation checksum version certificate caddy_cleanup config config_validator schema_validator service ui backup export messages users port_hopping subscription cloudflare_tunnel)
+  local modules=(colors common logging generators tools retry download network validation checksum version certificate caddy_cleanup config config_validator schema_validator service ui backup export messages users port_hopping subscription cloudflare_tunnel telegram_bot)
   local temp_lib_dir=""
 
   # Check if lib directory exists
@@ -658,6 +658,7 @@ _verify_module_apis() {
     ["port_hopping"]="validate_port_range apply_port_hopping_rules remove_port_hopping_rules show_port_hopping_status"
     ["subscription"]="subscription_render subscription_enable subscription_disable subscription_status subscription_url subscription_ensure_state_block"
     ["cloudflare_tunnel"]="cloudflared_install cloudflared_enable_token cloudflared_disable cloudflared_status cloudflared_update_state"
+    ["telegram_bot"]="telegram_bot_setup telegram_bot_enable telegram_bot_disable telegram_bot_status telegram_bot_run"
   )
 
   # Verify each module's API contract

--- a/install.sh
+++ b/install.sh
@@ -559,7 +559,7 @@ _load_modules() {
 
     _download_and_validate_manager_script "${github_repo}" "${SCRIPT_DIR}" || exit 1
 
-    # Download subscription runtime assets (server.py + launcher)
+    # Download subscription / telegram runtime assets
     mkdir -p "${SCRIPT_DIR}/lib/subscription"
     local _sub_base="${github_repo}/lib/subscription"
     local _bin_base="${github_repo}/bin"
@@ -570,11 +570,22 @@ _load_modules() {
       curl -fsSL --connect-timeout "${DOWNLOAD_CONNECT_TIMEOUT_SEC}" \
         --max-time "${DOWNLOAD_MAX_TIMEOUT_SEC}" \
         "${_bin_base}/sbx-sub-server" -o "${SCRIPT_DIR}/bin/sbx-sub-server" 2>/dev/null || true
+      if ! curl -fsSL --connect-timeout "${DOWNLOAD_CONNECT_TIMEOUT_SEC}" \
+        --max-time "${DOWNLOAD_MAX_TIMEOUT_SEC}" \
+        "${_bin_base}/sbx-telegram-bot" -o "${SCRIPT_DIR}/bin/sbx-telegram-bot" 2>/dev/null; then
+        echo "ERROR: Failed to download sbx-telegram-bot from ${_bin_base}/sbx-telegram-bot"
+        exit 1
+      fi
     elif command -v wget >/dev/null 2>&1; then
       wget -q --timeout="${DOWNLOAD_MAX_TIMEOUT_SEC}" \
         "${_sub_base}/server.py" -O "${SCRIPT_DIR}/lib/subscription/server.py" 2>/dev/null || true
       wget -q --timeout="${DOWNLOAD_MAX_TIMEOUT_SEC}" \
         "${_bin_base}/sbx-sub-server" -O "${SCRIPT_DIR}/bin/sbx-sub-server" 2>/dev/null || true
+      if ! wget -q --timeout="${DOWNLOAD_MAX_TIMEOUT_SEC}" \
+        "${_bin_base}/sbx-telegram-bot" -O "${SCRIPT_DIR}/bin/sbx-telegram-bot" 2>/dev/null; then
+        echo "ERROR: Failed to download sbx-telegram-bot from ${_bin_base}/sbx-telegram-bot"
+        exit 1
+      fi
     fi
 
     # Remember the generated directory so shared cleanup can purge it later
@@ -1711,6 +1722,9 @@ install_manager_script() {
     if [[ -f "${SCRIPT_DIR}/bin/sbx-sub-server" ]]; then
       install -m 755 "${SCRIPT_DIR}/bin/sbx-sub-server" /usr/local/bin/sbx-sub-server
     fi
+    if [[ -f "${SCRIPT_DIR}/bin/sbx-telegram-bot" ]]; then
+      install -m 755 "${SCRIPT_DIR}/bin/sbx-telegram-bot" /usr/local/bin/sbx-telegram-bot
+    fi
 
     # Create unprivileged system user for the subscription HTTP listener.
     # Idempotent: skipped if the user already exists.
@@ -2155,6 +2169,9 @@ uninstall_flow() {
     systemctl daemon-reload 2>/dev/null || true
   fi
   rm -f /usr/local/bin/sbx-sub-server
+  rm -f /usr/local/bin/sbx-telegram-bot
+  rm -f /etc/sing-box/telegram.env
+  rm -rf /var/lib/sbx-telegram-bot
   rm -rf "${SUBSCRIPTION_CACHE_DIR}"
   if id -u "${SUBSCRIPTION_SYSTEM_USER}" >/dev/null 2>&1; then
     if have userdel; then

--- a/lib/telegram_bot.sh
+++ b/lib/telegram_bot.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# lib/telegram_bot.sh - Telegram Bot remote management integration
+# Part of sbx-lite modular architecture
+#
+# Implements a long-polling Telegram Bot daemon for remote sing-box management.
+# Supports /status, /users, /adduser, /removeuser, /restart, /help commands
+# restricted to an admin chat_id whitelist persisted in state.json.
+#
+# Runs as an independent systemd unit (sbx-telegram-bot.service) alongside
+# sing-box. Uses pure bash + curl + jq — no extra language runtime.
+#
+# Modes: long-polling only (no webhook); reuses lib/users.sh and lib/service.sh
+# for all CRUD and service operations.
+#
+# Upstream docs:
+#   https://core.telegram.org/bots/api
+#   https://core.telegram.org/bots#botfather
+
+set -euo pipefail
+
+# Prevent multiple sourcing
+[[ -n "${_SBX_TELEGRAM_BOT_LOADED:-}" ]] && return 0
+readonly _SBX_TELEGRAM_BOT_LOADED=1
+
+# Source dependencies
+_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+[[ -z "${_SBX_COMMON_LOADED:-}" ]] && source "${_LIB_DIR}/common.sh"
+# shellcheck source=/dev/null
+[[ -z "${_SBX_VALIDATION_LOADED:-}" ]] && source "${_LIB_DIR}/validation.sh"
+# shellcheck source=/dev/null
+[[ -z "${_SBX_USERS_LOADED:-}" ]] && source "${_LIB_DIR}/users.sh"
+# shellcheck source=/dev/null
+[[ -z "${_SBX_SERVICE_LOADED:-}" ]] && source "${_LIB_DIR}/service.sh"
+
+#==============================================================================
+# Constants
+#==============================================================================
+
+# Paths and tunables are overridable via environment for testability.
+: "${SBX_TG_BIN:=/usr/local/bin/sbx-telegram-bot}"
+: "${SBX_TG_SVC:=/etc/systemd/system/sbx-telegram-bot.service}"
+: "${SBX_TG_ENV_FILE:=/etc/sing-box/telegram.env}"
+: "${SBX_TG_OFFSET_DIR:=/var/lib/sbx-telegram-bot}"
+: "${SBX_TG_OFFSET_FILE:=${SBX_TG_OFFSET_DIR}/offset}"
+: "${SBX_TG_API_BASE:=https://api.telegram.org}"
+: "${SBX_TG_POLL_TIMEOUT:=30}"
+: "${SBX_TG_SERVICE_NAME:=sbx-telegram-bot}"
+
+#==============================================================================
+# Public API (stubs — to be implemented in subsequent steps)
+#==============================================================================
+
+# telegram_bot_setup
+# Interactive bootstrap: prompts for bot token, verifies via getMe,
+# persists to state.json + EnvironmentFile.
+telegram_bot_setup() {
+  err "telegram_bot_setup: not implemented yet"
+  return 1
+}
+
+# telegram_bot_enable
+# Writes systemd unit, daemon-reload, enable --now.
+telegram_bot_enable() {
+  err "telegram_bot_enable: not implemented yet"
+  return 1
+}
+
+# telegram_bot_disable
+# Stop + disable + remove systemd unit; update state.json.
+telegram_bot_disable() {
+  err "telegram_bot_disable: not implemented yet"
+  return 1
+}
+
+# telegram_bot_status
+# Show systemd status, whitelist size, bot username.
+telegram_bot_status() {
+  err "telegram_bot_status: not implemented yet"
+  return 1
+}
+
+# telegram_bot_logs
+# Tail journalctl for the service unit.
+telegram_bot_logs() {
+  err "telegram_bot_logs: not implemented yet"
+  return 1
+}
+
+# telegram_bot_admin_add <chat_id>
+telegram_bot_admin_add() {
+  err "telegram_bot_admin_add: not implemented yet"
+  return 1
+}
+
+# telegram_bot_admin_remove <chat_id>
+telegram_bot_admin_remove() {
+  err "telegram_bot_admin_remove: not implemented yet"
+  return 1
+}
+
+# telegram_bot_admin_list
+telegram_bot_admin_list() {
+  err "telegram_bot_admin_list: not implemented yet"
+  return 1
+}
+
+# telegram_bot_run
+# Main loop invoked by the systemd unit (ExecStart target).
+telegram_bot_run() {
+  err "telegram_bot_run: not implemented yet"
+  return 1
+}
+
+#==============================================================================
+# Internal helpers (stubs — to be implemented in subsequent steps)
+#==============================================================================
+
+# _tg_validate_token <token>
+# Returns 0 iff token matches ^[0-9]{8,10}:[A-Za-z0-9_-]{35}$
+_tg_validate_token() {
+  return 1
+}
+
+# _tg_verify_token_live <token>
+# Calls Bot API getMe; returns 0 iff response .ok == true.
+_tg_verify_token_live() {
+  return 1
+}
+
+# _tg_is_authorized <chat_id>
+# Checks admin_chat_ids whitelist in state.json.
+_tg_is_authorized() {
+  return 1
+}
+
+# _tg_load_offset
+# Echoes last-seen update_id (0 if missing).
+_tg_load_offset() {
+  echo "0"
+}
+
+# _tg_save_offset <n>
+# Atomically persists offset.
+_tg_save_offset() {
+  return 0
+}
+
+# _tg_get_updates <offset>
+# Calls getUpdates with long-poll timeout; exponential backoff on failure.
+_tg_get_updates() {
+  return 1
+}
+
+# _tg_send_message <chat_id> <text>
+# Sends a message; handles 429 retry_after.
+_tg_send_message() {
+  return 1
+}
+
+# _tg_parse_command <text>
+# Splits leading /cmd from args; emits on stdout.
+_tg_parse_command() {
+  return 1
+}
+
+# _tg_dispatch_command <chat_id> <cmd> [args...]
+# Pure case-based dispatch to _tg_handle_* functions.
+_tg_dispatch_command() {
+  return 1
+}
+
+# _tg_handle_status <chat_id>
+_tg_handle_status() {
+  return 1
+}
+
+# _tg_handle_users <chat_id>
+_tg_handle_users() {
+  return 1
+}
+
+# _tg_handle_adduser <chat_id> <name>
+_tg_handle_adduser() {
+  return 1
+}
+
+# _tg_handle_removeuser <chat_id> <name_or_uuid>
+_tg_handle_removeuser() {
+  return 1
+}
+
+# _tg_handle_restart <chat_id>
+_tg_handle_restart() {
+  return 1
+}
+
+# _tg_handle_help <chat_id>
+_tg_handle_help() {
+  return 1
+}
+
+# _tg_update_state <key>=<value>...
+# Atomically merges bot state into state.json (mktemp→jq→chmod→mv).
+_tg_update_state() {
+  return 1
+}
+
+#==============================================================================
+# Export public functions
+#==============================================================================
+
+export -f telegram_bot_setup
+export -f telegram_bot_enable
+export -f telegram_bot_disable
+export -f telegram_bot_status
+export -f telegram_bot_logs
+export -f telegram_bot_admin_add
+export -f telegram_bot_admin_remove
+export -f telegram_bot_admin_list
+export -f telegram_bot_run

--- a/lib/telegram_bot.sh
+++ b/lib/telegram_bot.sh
@@ -118,8 +118,12 @@ telegram_bot_run() {
 
 # _tg_validate_token <token>
 # Returns 0 iff token matches ^[0-9]{8,10}:[A-Za-z0-9_-]{35}$
+# Telegram bot tokens have shape: <bot_id>:<35-char_secret>
+# where bot_id is 8-10 digits and the secret half is base64url-ish
+# (alphanumeric + '-' + '_'), exactly 35 characters long.
 _tg_validate_token() {
-  return 1
+  local token="${1:-}"
+  [[ "${token}" =~ ^[0-9]{8,10}:[A-Za-z0-9_-]{35}$ ]]
 }
 
 # _tg_verify_token_live <token>
@@ -128,22 +132,66 @@ _tg_verify_token_live() {
   return 1
 }
 
+# _tg_state_file
+# Resolves the active state.json path, honoring TEST_STATE_FILE for tests.
+_tg_state_file() {
+  echo "${TEST_STATE_FILE:-${STATE_FILE:-${SB_CONF_DIR:-/etc/sing-box}/state.json}}"
+}
+
 # _tg_is_authorized <chat_id>
-# Checks admin_chat_ids whitelist in state.json.
+# Returns 0 iff <chat_id> appears in .telegram.admin_chat_ids[] of state.json.
+# Empty whitelist, missing block, missing file or missing jq all reject.
+# This is the security boundary for every Telegram-driven action — be strict.
 _tg_is_authorized() {
-  return 1
+  local chat_id="${1:-}"
+  [[ -n "${chat_id}" ]] || return 1
+  command -v jq >/dev/null 2>&1 || return 1
+
+  local state_file=""
+  state_file=$(_tg_state_file)
+  [[ -f "${state_file}" ]] || return 1
+
+  local match=""
+  match=$(jq -r --arg id "${chat_id}" \
+    '(.telegram.admin_chat_ids // []) | map(tostring) | index($id) // empty' \
+    "${state_file}" 2>/dev/null) || return 1
+  [[ -n "${match}" ]]
 }
 
 # _tg_load_offset
-# Echoes last-seen update_id (0 if missing).
+# Echoes the last-seen update_id from SBX_TG_OFFSET_FILE.
+# Defaults to "0" if the file is missing or contains non-integer garbage,
+# which causes the next getUpdates call to fetch from the beginning.
 _tg_load_offset() {
+  if [[ -f "${SBX_TG_OFFSET_FILE}" ]]; then
+    local v=""
+    v=$(tr -d '[:space:]' <"${SBX_TG_OFFSET_FILE}" 2>/dev/null) || true
+    if [[ "${v}" =~ ^-?[0-9]+$ ]]; then
+      echo "${v}"
+      return 0
+    fi
+  fi
   echo "0"
 }
 
 # _tg_save_offset <n>
-# Atomically persists offset.
+# Atomically persists <n> to SBX_TG_OFFSET_FILE (mktemp + rename).
+# Rejects non-integer input. Creates SBX_TG_OFFSET_DIR on first call.
+# File is chmod'd to 0600 — offsets aren't sensitive, but the bot is root-only.
 _tg_save_offset() {
-  return 0
+  local n="${1:-}"
+  [[ "${n}" =~ ^-?[0-9]+$ ]] || return 1
+
+  mkdir -p "${SBX_TG_OFFSET_DIR}" 2>/dev/null || return 1
+
+  local tmp=""
+  tmp=$(mktemp "${SBX_TG_OFFSET_DIR}/.offset.XXXXXX") || return 1
+  printf '%s\n' "${n}" >"${tmp}" || {
+    rm -f "${tmp}"
+    return 1
+  }
+  chmod 600 "${tmp}" 2>/dev/null || true
+  mv -f "${tmp}" "${SBX_TG_OFFSET_FILE}"
 }
 
 # _tg_get_updates <offset>
@@ -159,9 +207,27 @@ _tg_send_message() {
 }
 
 # _tg_parse_command <text>
-# Splits leading /cmd from args; emits on stdout.
+# Splits a Telegram message body into "<cmd> [args...]" tokens.
+# Strips the "/" prefix and an optional "@botname" suffix
+# (Telegram appends @botname when commands are sent in groups).
+# Returns nonzero (no stdout) for empty input, lone "/", or any text
+# that doesn't begin with /<letter|underscore><identifier>.
+# stdout format: a single space-separated line; the dispatcher word-splits.
 _tg_parse_command() {
-  return 1
+  local text="${1:-}"
+  [[ -n "${text}" ]] || return 1
+  # Anchored regex: leading "/", required identifier, optional @botname,
+  # optional whitespace + arg tail.
+  [[ "${text}" =~ ^/([a-zA-Z_][a-zA-Z0-9_]*)(@[A-Za-z0-9_]+)?([[:space:]]+(.*))?$ ]] || return 1
+  local cmd="${BASH_REMATCH[1]}"
+  local rest="${BASH_REMATCH[4]:-}"
+  # Trim trailing whitespace from rest so "/cmd   " doesn't leak spaces.
+  rest="${rest%"${rest##*[![:space:]]}"}"
+  if [[ -n "${rest}" ]]; then
+    printf '%s %s\n' "${cmd}" "${rest}"
+  else
+    printf '%s\n' "${cmd}"
+  fi
 }
 
 # _tg_dispatch_command <chat_id> <cmd> [args...]

--- a/lib/telegram_bot.sh
+++ b/lib/telegram_bot.sh
@@ -48,72 +48,7 @@ _LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 : "${SBX_TG_SERVICE_NAME:=sbx-telegram-bot}"
 
 #==============================================================================
-# Public API (stubs — to be implemented in subsequent steps)
-#==============================================================================
-
-# telegram_bot_setup
-# Interactive bootstrap: prompts for bot token, verifies via getMe,
-# persists to state.json + EnvironmentFile.
-telegram_bot_setup() {
-  err "telegram_bot_setup: not implemented yet"
-  return 1
-}
-
-# telegram_bot_enable
-# Writes systemd unit, daemon-reload, enable --now.
-telegram_bot_enable() {
-  err "telegram_bot_enable: not implemented yet"
-  return 1
-}
-
-# telegram_bot_disable
-# Stop + disable + remove systemd unit; update state.json.
-telegram_bot_disable() {
-  err "telegram_bot_disable: not implemented yet"
-  return 1
-}
-
-# telegram_bot_status
-# Show systemd status, whitelist size, bot username.
-telegram_bot_status() {
-  err "telegram_bot_status: not implemented yet"
-  return 1
-}
-
-# telegram_bot_logs
-# Tail journalctl for the service unit.
-telegram_bot_logs() {
-  err "telegram_bot_logs: not implemented yet"
-  return 1
-}
-
-# telegram_bot_admin_add <chat_id>
-telegram_bot_admin_add() {
-  err "telegram_bot_admin_add: not implemented yet"
-  return 1
-}
-
-# telegram_bot_admin_remove <chat_id>
-telegram_bot_admin_remove() {
-  err "telegram_bot_admin_remove: not implemented yet"
-  return 1
-}
-
-# telegram_bot_admin_list
-telegram_bot_admin_list() {
-  err "telegram_bot_admin_list: not implemented yet"
-  return 1
-}
-
-# telegram_bot_run
-# Main loop invoked by the systemd unit (ExecStart target).
-telegram_bot_run() {
-  err "telegram_bot_run: not implemented yet"
-  return 1
-}
-
-#==============================================================================
-# Internal helpers (stubs — to be implemented in subsequent steps)
+# Public API
 #==============================================================================
 
 # _tg_validate_token <token>
@@ -129,13 +64,132 @@ _tg_validate_token() {
 # _tg_verify_token_live <token>
 # Calls Bot API getMe; returns 0 iff response .ok == true.
 _tg_verify_token_live() {
-  return 1
+  local token="${1:-}"
+  _tg_validate_token "${token}" || return 1
+  command -v jq >/dev/null 2>&1 || return 1
+
+  local curl_cmd="${SBX_TG_CURL_CMD:-curl}"
+  local response_file=""
+  response_file=$(create_temp_file "tg-getme") || return 1
+  # shellcheck disable=SC2064
+  trap "rm -f '${response_file}'" RETURN
+
+  if ! "${curl_cmd}" -fsS \
+    --max-time 20 \
+    --connect-timeout 10 \
+    -o "${response_file}" \
+    "${SBX_TG_API_BASE}/bot${token}/getMe" \
+    2>/dev/null; then
+    return 1
+  fi
+
+  local ok="false"
+  ok=$(jq -r '.ok // false' "${response_file}" 2>/dev/null) || return 1
+  [[ "${ok}" == "true" ]] || return 1
+
+  jq -r '.result.username // empty' "${response_file}" 2>/dev/null || true
 }
 
 # _tg_state_file
 # Resolves the active state.json path, honoring TEST_STATE_FILE for tests.
 _tg_state_file() {
   echo "${TEST_STATE_FILE:-${STATE_FILE:-${SB_CONF_DIR:-/etc/sing-box}/state.json}}"
+}
+
+# _tg_write_env_file <token>
+# Persists BOT_TOKEN for systemd EnvironmentFile consumption.
+_tg_write_env_file() {
+  local token="${1:-}"
+  [[ -n "${token}" ]] || {
+    err "_tg_write_env_file: token is required"
+    return 1
+  }
+
+  local env_dir=""
+  env_dir="$(dirname "${SBX_TG_ENV_FILE}")"
+  mkdir -p "${env_dir}" || return 1
+
+  local tmp=""
+  tmp=$(create_temp_file_in_dir "${env_dir}" "telegram.env") || return 1
+  {
+    echo "# Managed by sbx — do not edit by hand."
+    echo "BOT_TOKEN=${token}"
+  } >"${tmp}"
+  chmod 600 "${tmp}" 2>/dev/null || true
+  mv -f "${tmp}" "${SBX_TG_ENV_FILE}"
+  chmod 600 "${SBX_TG_ENV_FILE}" 2>/dev/null || true
+}
+
+# _tg_write_service_file
+# Writes the systemd unit consumed by telegram_bot_enable.
+_tg_write_service_file() {
+  local svc_dir=""
+  svc_dir="$(dirname "${SBX_TG_SVC}")"
+  mkdir -p "${svc_dir}" || return 1
+
+  cat >"${SBX_TG_SVC}" <<EOF
+[Unit]
+Description=sbx-lite Telegram Bot
+After=network-online.target sing-box.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=${SBX_TG_BIN}
+EnvironmentFile=-${SBX_TG_ENV_FILE}
+Restart=on-failure
+RestartSec=5s
+User=root
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+ReadWritePaths=/etc/sing-box ${SBX_TG_OFFSET_DIR}
+
+[Install]
+WantedBy=multi-user.target
+EOF
+  chmod 644 "${SBX_TG_SVC}" 2>/dev/null || true
+}
+
+# _tg_state_admin_ids_json
+# Emits the current admin_chat_ids array as compact JSON.
+_tg_state_admin_ids_json() {
+  local state_file=""
+  state_file="$(_tg_state_file)"
+  if [[ -f "${state_file}" ]] && command -v jq >/dev/null 2>&1; then
+    jq -c '(.telegram.admin_chat_ids // []) | map(tonumber? // .)' \
+      "${state_file}" 2>/dev/null || echo "[]"
+  else
+    echo "[]"
+  fi
+}
+
+# _tg_state_get <field> [default]
+# Reads a Telegram field from state.json, returning default on absence.
+_tg_state_get() {
+  local field="${1:-}"
+  local default_value="${2:-}"
+  local state_file=""
+  state_file="$(_tg_state_file)"
+
+  if [[ -z "${field}" ]] || [[ ! -f "${state_file}" ]] ||
+    ! command -v jq >/dev/null 2>&1; then
+    echo "${default_value}"
+    return 0
+  fi
+
+  local value=""
+  value=$(jq -r ".telegram.${field} // empty" "${state_file}" 2>/dev/null) || {
+    echo "${default_value}"
+    return 0
+  }
+
+  if [[ -n "${value}" ]]; then
+    echo "${value}"
+  else
+    echo "${default_value}"
+  fi
 }
 
 # _tg_is_authorized <chat_id>
@@ -540,6 +594,310 @@ _tg_update_state() {
 
   mv -f "${tmp}" "${state_file}"
   chmod "${SECURE_FILE_PERMISSIONS:-600}" "${state_file}" 2>/dev/null || true
+}
+
+# _tg_process_updates_file <file> <offset_var_name>
+# Parses getUpdates JSON, dispatches commands, and advances the offset.
+_tg_process_updates_file() {
+  local updates_file="${1:-}"
+  local offset_var_name="${2:-}"
+  [[ -n "${updates_file}" && -n "${offset_var_name}" ]] || return 1
+  command -v jq >/dev/null 2>&1 || return 1
+
+  local current_offset="0"
+  current_offset="${!offset_var_name}"
+
+  local update_json=""
+  while IFS= read -r update_json; do
+    [[ -n "${update_json}" ]] || continue
+
+    local update_id=""
+    local chat_id=""
+    local text=""
+    update_id=$(jq -r '.update_id // empty' <<<"${update_json}" 2>/dev/null) || continue
+    [[ "${update_id}" =~ ^[0-9]+$ ]] || continue
+
+    current_offset="$((update_id + 1))"
+    printf -v "${offset_var_name}" '%s' "${current_offset}"
+    TG_LAST_OFFSET="${current_offset}"
+    _tg_save_offset "${current_offset}" || true
+
+    chat_id=$(jq -r '.message.chat.id // empty' <<<"${update_json}" 2>/dev/null) || true
+    text=$(jq -r '.message.text // empty' <<<"${update_json}" 2>/dev/null) || true
+    [[ -n "${chat_id}" && -n "${text}" ]] || continue
+
+    local parsed=""
+    parsed=$(_tg_parse_command "${text}" 2>/dev/null || true)
+    [[ -n "${parsed}" ]] || continue
+
+    local parts=()
+    read -r -a parts <<<"${parsed}"
+    _tg_dispatch_command "${chat_id}" "${parts[@]}" || true
+  done < <(jq -c '.result[]?' "${updates_file}" 2>/dev/null)
+}
+
+# _tg_discard_bootstrap_updates <file> <offset_var_name>
+# First startup uses offset=-1 to discard backlog. We still need to advance
+# the saved offset to the newest observed update_id, but MUST NOT dispatch any
+# historical commands from that bootstrap response.
+_tg_discard_bootstrap_updates() {
+  local updates_file="${1:-}"
+  local offset_var_name="${2:-}"
+  [[ -n "${updates_file}" && -n "${offset_var_name}" ]] || return 1
+  command -v jq >/dev/null 2>&1 || return 1
+
+  local next_offset="0"
+  next_offset=$(jq -r '
+    (.result // []) |
+    if length == 0 then 0 else ((.[-1].update_id // -1) + 1) end
+  ' "${updates_file}" 2>/dev/null) || return 1
+  [[ "${next_offset}" =~ ^[0-9]+$ ]] || next_offset=0
+
+  printf -v "${offset_var_name}" '%s' "${next_offset}"
+  TG_LAST_OFFSET="${next_offset}"
+  _tg_save_offset "${next_offset}" || return 1
+}
+
+#==============================================================================
+# Public API
+#==============================================================================
+
+# telegram_bot_setup
+# Interactive bootstrap: prompts for bot token, verifies via getMe,
+# persists to state.json + EnvironmentFile.
+telegram_bot_setup() {
+  need_root || return 1
+
+  local token=""
+  local admin_chat_id=""
+  local username=""
+
+  read -r -p "Telegram bot token: " token || return 1
+  if ! _tg_validate_token "${token}"; then
+    err "Invalid Telegram bot token format"
+    return 1
+  fi
+
+  username="$(_tg_verify_token_live "${token}")" || {
+    err "Telegram getMe verification failed for the provided token"
+    return 1
+  }
+
+  read -r -p "Initial admin chat ID: " admin_chat_id || return 1
+  if ! [[ "${admin_chat_id}" =~ ^-?[0-9]+$ ]]; then
+    err "Admin chat ID must be an integer"
+    return 1
+  fi
+
+  _tg_write_env_file "${token}" || return 1
+  _tg_update_state \
+    "enabled=false" \
+    "username=${username}" \
+    "admin_chat_ids=[${admin_chat_id}]" || return 1
+
+  success "  ✓ Telegram bot configured for @${username}"
+}
+
+# telegram_bot_enable
+# Writes systemd unit, daemon-reload, enable --now.
+telegram_bot_enable() {
+  need_root || return 1
+
+  [[ -x "${SBX_TG_BIN}" ]] || {
+    err "Telegram bot launcher not installed: ${SBX_TG_BIN}"
+    return 1
+  }
+  [[ -f "${SBX_TG_ENV_FILE}" ]] || {
+    err "Telegram env file not found: ${SBX_TG_ENV_FILE}"
+    return 1
+  }
+
+  mkdir -p "${SBX_TG_OFFSET_DIR}" || return 1
+  chmod 700 "${SBX_TG_OFFSET_DIR}" 2>/dev/null || true
+
+  _tg_write_service_file || return 1
+  systemctl daemon-reload || {
+    err "systemctl daemon-reload failed"
+    return 1
+  }
+  systemctl enable --now "${SBX_TG_SERVICE_NAME}" || {
+    err "Failed to start ${SBX_TG_SERVICE_NAME} service"
+    err "Inspect: journalctl -u ${SBX_TG_SERVICE_NAME} -n 80 --no-pager"
+    return 1
+  }
+
+  _tg_update_state "enabled=true" || return 1
+  success "  ✓ Telegram bot enabled"
+}
+
+# telegram_bot_disable
+# Stop + disable + remove systemd unit; update state.json.
+telegram_bot_disable() {
+  need_root || return 1
+
+  systemctl disable --now "${SBX_TG_SERVICE_NAME}" 2>/dev/null || true
+  rm -f "${SBX_TG_SVC}"
+  systemctl daemon-reload 2>/dev/null || true
+
+  _tg_update_state "enabled=false" || return 1
+  success "  ✓ Telegram bot disabled"
+}
+
+# telegram_bot_status
+# Show systemd status, whitelist size, bot username.
+telegram_bot_status() {
+  local username=""
+  local enabled="false"
+  local admin_count="0"
+
+  username="$(_tg_state_get username "(unknown)")"
+  enabled="$(_tg_state_get enabled "false")"
+  if command -v jq >/dev/null 2>&1 && [[ -f "$(_tg_state_file)" ]]; then
+    admin_count=$(jq -r '(.telegram.admin_chat_ids // []) | length' \
+      "$(_tg_state_file)" 2>/dev/null || echo "0")
+  fi
+
+  echo "=== Telegram Bot Status ==="
+  if [[ -x "${SBX_TG_BIN}" ]]; then
+    echo "Binary   : ${SBX_TG_BIN}"
+  else
+    echo "Binary   : (not installed)"
+  fi
+  echo "Enabled  : ${enabled}"
+  echo "Username : ${username}"
+  echo "Admins   : ${admin_count}"
+  echo "Env file : ${SBX_TG_ENV_FILE}"
+  systemctl status "${SBX_TG_SERVICE_NAME}" --no-pager || true
+}
+
+# telegram_bot_logs
+# Tail journalctl for the service unit.
+telegram_bot_logs() {
+  journalctl -u "${SBX_TG_SERVICE_NAME}" -f
+}
+
+# telegram_bot_admin_add <chat_id>
+telegram_bot_admin_add() {
+  need_root || return 1
+
+  local chat_id="${1:-}"
+  [[ "${chat_id}" =~ ^-?[0-9]+$ ]] || {
+    err "Usage: telegram_bot_admin_add <chat_id>"
+    return 1
+  }
+
+  local state_file=""
+  state_file="$(_tg_state_file)"
+  [[ -f "${state_file}" ]] || {
+    err "state.json not found: ${state_file}"
+    return 1
+  }
+  command -v jq >/dev/null 2>&1 || {
+    err "jq is required to modify Telegram admin_chat_ids"
+    return 1
+  }
+
+  local admins_json=""
+  admins_json=$(jq -c --argjson id "${chat_id}" \
+    '(.telegram.admin_chat_ids // []) | map(tonumber? // .) |
+     if index($id) == null then . + [$id] else . end' \
+    "${state_file}" 2>/dev/null) || return 1
+
+  _tg_update_state "admin_chat_ids=${admins_json}" || return 1
+  success "  ✓ Added Telegram admin chat ID: ${chat_id}"
+}
+
+# telegram_bot_admin_remove <chat_id>
+telegram_bot_admin_remove() {
+  need_root || return 1
+
+  local chat_id="${1:-}"
+  [[ "${chat_id}" =~ ^-?[0-9]+$ ]] || {
+    err "Usage: telegram_bot_admin_remove <chat_id>"
+    return 1
+  }
+
+  local state_file=""
+  state_file="$(_tg_state_file)"
+  [[ -f "${state_file}" ]] || {
+    err "state.json not found: ${state_file}"
+    return 1
+  }
+  command -v jq >/dev/null 2>&1 || {
+    err "jq is required to modify Telegram admin_chat_ids"
+    return 1
+  }
+
+  local admins_json=""
+  admins_json=$(jq -c --argjson id "${chat_id}" \
+    '(.telegram.admin_chat_ids // []) | map(tonumber? // .) |
+     map(select(. != $id))' \
+    "${state_file}" 2>/dev/null) || return 1
+
+  _tg_update_state "admin_chat_ids=${admins_json}" || return 1
+  success "  ✓ Removed Telegram admin chat ID: ${chat_id}"
+}
+
+# telegram_bot_admin_list
+telegram_bot_admin_list() {
+  local admins_json=""
+  admins_json="$(_tg_state_admin_ids_json)"
+
+  echo "Configured Telegram admin chat IDs:"
+  if [[ "${admins_json}" == "[]" ]]; then
+    echo "(none)"
+    return 0
+  fi
+
+  jq -r '.[]' <<<"${admins_json}" 2>/dev/null || true
+}
+
+# telegram_bot_run
+# Main loop invoked by the systemd unit (ExecStart target).
+telegram_bot_run() {
+  [[ -n "${BOT_TOKEN:-}" ]] || {
+    err "BOT_TOKEN is required in the environment"
+    return 1
+  }
+  command -v jq >/dev/null 2>&1 || {
+    err "jq is required for telegram_bot_run"
+    return 1
+  }
+
+  local offset="0"
+  if [[ -f "${SBX_TG_OFFSET_FILE}" ]]; then
+    offset="$(_tg_load_offset)"
+  else
+    offset="-1"
+  fi
+
+  while :; do
+    local updates_file=""
+    updates_file=$(create_temp_file "tg-updates") || return 1
+
+    if ! _tg_get_updates "${offset}" "${updates_file}"; then
+      rm -f "${updates_file}"
+      return 1
+    fi
+
+    if [[ "${offset}" == "-1" ]]; then
+      _tg_discard_bootstrap_updates "${updates_file}" offset || {
+        rm -f "${updates_file}"
+        return 1
+      }
+    else
+      _tg_process_updates_file "${updates_file}" offset || {
+        rm -f "${updates_file}"
+        return 1
+      }
+    fi
+
+    rm -f "${updates_file}"
+
+    if [[ "${SBX_TG_RUN_ONCE:-0}" == "1" ]]; then
+      break
+    fi
+  done
 }
 
 #==============================================================================

--- a/lib/telegram_bot.sh
+++ b/lib/telegram_bot.sh
@@ -451,10 +451,95 @@ _tg_handle_help() {
   _tg_send_message "${chat_id}" "${reply}"
 }
 
-# _tg_update_state <key>=<value>...
-# Atomically merges bot state into state.json (mktemp→jq→chmod→mv).
+# _tg_update_state <key>=<value> [<key>=<value> ...]
+# Atomically merges each pair into state.json's .telegram object using a
+# single jq invocation (mktemp → jq → chmod → mv), mirroring the
+# cloudflared_update_state pattern at lib/cloudflare_tunnel.sh:317-359.
+#
+# Allowed keys (allowlist — keeps state shape predictable, prevents typos
+# from polluting the file): enabled, username, admin_chat_ids.
+#
+# Value typing is auto-detected:
+#   true / false / null / <integer>    → JSON literal (--argjson)
+#   leading [ or {                     → JSON literal (--argjson)
+#   anything else                      → JSON string  (--arg)
+#
+# Missing state file is a warn-and-skip (return 0) so the bot doesn't
+# explode on a fresh install where state.json was wiped — matches
+# cloudflared_update_state semantics.
 _tg_update_state() {
-  return 1
+  local state_file=""
+  state_file=$(_tg_state_file)
+
+  if [[ ! -f "${state_file}" ]]; then
+    warn "State file not found (${state_file}); skipping telegram state update"
+    return 0
+  fi
+
+  command -v jq >/dev/null 2>&1 || {
+    err "jq is required to update telegram state"
+    return 1
+  }
+
+  [[ $# -ge 1 ]] || {
+    err "_tg_update_state: no key=value pairs given"
+    return 1
+  }
+
+  local jq_args=()
+  local merge="(.telegram // {})"
+  local n=0
+  local kv key val arg
+  for kv in "$@"; do
+    [[ "${kv}" == *"="* ]] || {
+      err "_tg_update_state: '${kv}' is not key=value"
+      return 1
+    }
+    key="${kv%%=*}"
+    val="${kv#*=}"
+
+    [[ "${key}" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]] || {
+      err "_tg_update_state: invalid key '${key}'"
+      return 1
+    }
+
+    case "${key}" in
+      enabled | username | admin_chat_ids) ;;
+      *)
+        err "_tg_update_state: key '${key}' not in allowlist"
+        return 1
+        ;;
+    esac
+
+    n=$((n + 1))
+    arg="a${n}"
+
+    if [[ "${val}" == "true" || "${val}" == "false" || "${val}" == "null" ||
+      "${val}" =~ ^-?[0-9]+$ ||
+      "${val}" =~ ^\[ ||
+      "${val}" =~ ^\{ ]]; then
+      jq_args+=(--argjson "${arg}" "${val}")
+    else
+      jq_args+=(--arg "${arg}" "${val}")
+    fi
+
+    merge="${merge} + {${key}: \$${arg}}"
+  done
+
+  local filter=". + {telegram: (${merge})}"
+
+  local tmp=""
+  tmp=$(mktemp "${state_file}.XXXXXX") || return 1
+  # shellcheck disable=SC2064
+  trap "rm -f '${tmp}'" RETURN
+
+  if ! jq "${jq_args[@]}" "${filter}" "${state_file}" >"${tmp}" 2>/dev/null; then
+    err "_tg_update_state: jq filter failed"
+    return 1
+  fi
+
+  mv -f "${tmp}" "${state_file}"
+  chmod "${SECURE_FILE_PERMISSIONS:-600}" "${state_file}" 2>/dev/null || true
 }
 
 #==============================================================================

--- a/lib/telegram_bot.sh
+++ b/lib/telegram_bot.sh
@@ -315,39 +315,140 @@ _tg_parse_command() {
 }
 
 # _tg_dispatch_command <chat_id> <cmd> [args...]
-# Pure case-based dispatch to _tg_handle_* functions.
+# Pure case-based dispatch to _tg_handle_* functions. NEVER `eval` chat input.
+# Authorization is enforced HERE, not per-handler: non-whitelisted senders
+# get silent drop (no reply at all) so the bot can't be used to fingerprint
+# the admin list. Unknown commands fall through to /help.
 _tg_dispatch_command() {
-  return 1
+  local chat_id="${1:-}"
+  local cmd="${2:-}"
+  shift 2 2>/dev/null || true
+
+  [[ -n "${chat_id}" && -n "${cmd}" ]] || return 1
+
+  # Security boundary — fail closed and silent.
+  _tg_is_authorized "${chat_id}" || return 0
+
+  case "${cmd}" in
+    status) _tg_handle_status "${chat_id}" ;;
+    users) _tg_handle_users "${chat_id}" ;;
+    adduser) _tg_handle_adduser "${chat_id}" "${1:-}" ;;
+    removeuser) _tg_handle_removeuser "${chat_id}" "${1:-}" ;;
+    restart) _tg_handle_restart "${chat_id}" ;;
+    help | start) _tg_handle_help "${chat_id}" ;;
+    *) _tg_handle_help "${chat_id}" ;;
+  esac
 }
 
 # _tg_handle_status <chat_id>
+# Reports sing-box service activity using the existing service.sh helper.
 _tg_handle_status() {
-  return 1
+  local chat_id="${1:-}"
+  local reply=""
+  if check_service_status; then
+    reply="✅ sing-box: active"
+  else
+    reply="❌ sing-box: inactive"
+  fi
+  _tg_send_message "${chat_id}" "${reply}"
 }
 
 # _tg_handle_users <chat_id>
+# Forwards the user_list table verbatim. Output is small enough to fit in
+# Telegram's 4096-char message limit for any realistic deployment.
 _tg_handle_users() {
-  return 1
+  local chat_id="${1:-}"
+  local out=""
+  if out=$(user_list 2>&1); then
+    _tg_send_message "${chat_id}" "${out}"
+  else
+    _tg_send_message "${chat_id}" "❌ Failed to list users:
+${out}"
+  fi
 }
 
 # _tg_handle_adduser <chat_id> <name>
+# Defense-in-depth: trim whitespace and re-validate the name before delegating
+# to user_add (which already enforces ^[a-zA-Z0-9_-]+$). On success, mirror
+# the sbx-manager.sh `user add` flow: sync_users_to_config + restart sing-box.
 _tg_handle_adduser() {
-  return 1
+  local chat_id="${1:-}"
+  local name="${2:-}"
+
+  # Trim leading/trailing whitespace.
+  name="${name#"${name%%[![:space:]]*}"}"
+  name="${name%"${name##*[![:space:]]}"}"
+
+  if [[ -z "${name}" ]]; then
+    _tg_send_message "${chat_id}" "Usage: /adduser <name>"
+    return 0
+  fi
+
+  if ! [[ "${name}" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+    _tg_send_message "${chat_id}" \
+      "❌ Invalid name '${name}': use alphanumerics, _, - only"
+    return 0
+  fi
+
+  local out=""
+  if out=$(user_add --name "${name}" 2>&1); then
+    sync_users_to_config 2>/dev/null || true
+    systemctl restart sing-box 2>/dev/null || true
+    _tg_send_message "${chat_id}" "✅ ${out}"
+  else
+    _tg_send_message "${chat_id}" "❌ ${out}"
+  fi
 }
 
 # _tg_handle_removeuser <chat_id> <name_or_uuid>
 _tg_handle_removeuser() {
-  return 1
+  local chat_id="${1:-}"
+  local id="${2:-}"
+
+  id="${id#"${id%%[![:space:]]*}"}"
+  id="${id%"${id##*[![:space:]]}"}"
+
+  if [[ -z "${id}" ]]; then
+    _tg_send_message "${chat_id}" "Usage: /removeuser <name|uuid>"
+    return 0
+  fi
+
+  local out=""
+  if out=$(user_remove "${id}" 2>&1); then
+    sync_users_to_config 2>/dev/null || true
+    systemctl restart sing-box 2>/dev/null || true
+    _tg_send_message "${chat_id}" "✅ ${out}"
+  else
+    _tg_send_message "${chat_id}" "❌ ${out}"
+  fi
 }
 
 # _tg_handle_restart <chat_id>
+# Delegates to restart_service (already flock-protected by service.sh).
 _tg_handle_restart() {
-  return 1
+  local chat_id="${1:-}"
+  local out=""
+  if out=$(restart_service 2>&1); then
+    _tg_send_message "${chat_id}" "✅ sing-box restarted"
+  else
+    _tg_send_message "${chat_id}" "❌ Restart failed:
+${out}"
+  fi
 }
 
 # _tg_handle_help <chat_id>
 _tg_handle_help() {
-  return 1
+  local chat_id="${1:-}"
+  local reply
+  reply="sbx-lite Telegram Bot — available commands:
+
+/status — show sing-box service status
+/users — list configured users
+/adduser <name> — add a new user
+/removeuser <name|uuid> — remove a user
+/restart — restart sing-box service
+/help — show this help"
+  _tg_send_message "${chat_id}" "${reply}"
 }
 
 # _tg_update_state <key>=<value>...

--- a/lib/telegram_bot.sh
+++ b/lib/telegram_bot.sh
@@ -194,15 +194,99 @@ _tg_save_offset() {
   mv -f "${tmp}" "${SBX_TG_OFFSET_FILE}"
 }
 
-# _tg_get_updates <offset>
-# Calls getUpdates with long-poll timeout; exponential backoff on failure.
+# _tg_get_updates <offset> <output_file>
+# POSTs to Bot API getUpdates with long-poll timeout; on transient curl
+# failure (network blip, DNS hiccup, 5xx) sleeps with exponential backoff
+# (1→2→4→8→16→30s, capped at 30s) and retries indefinitely. Tests can
+# bound the loop with SBX_TG_BACKOFF_MAX_ATTEMPTS=N (0 = unlimited).
+# Curl and sleep are injectable via SBX_TG_CURL_CMD / SBX_TG_SLEEP_CMD
+# so unit tests can stub them without touching the real network or clock.
+# BOT_TOKEN MUST be set in the environment (loaded by EnvironmentFile).
 _tg_get_updates() {
-  return 1
+  local offset="${1:-0}"
+  local output_file="${2:-}"
+  [[ -n "${output_file}" ]] || return 1
+  [[ -n "${BOT_TOKEN:-}" ]] || return 1
+
+  local curl_cmd="${SBX_TG_CURL_CMD:-curl}"
+  local sleep_cmd="${SBX_TG_SLEEP_CMD:-sleep}"
+  local max_attempts="${SBX_TG_BACKOFF_MAX_ATTEMPTS:-0}"
+  local backoff=1
+  local attempts=0
+
+  while :; do
+    attempts=$((attempts + 1))
+    if "${curl_cmd}" -fsS \
+      --max-time "$((SBX_TG_POLL_TIMEOUT + 10))" \
+      --connect-timeout 10 \
+      -o "${output_file}" \
+      --data-urlencode "offset=${offset}" \
+      --data-urlencode "timeout=${SBX_TG_POLL_TIMEOUT}" \
+      "${SBX_TG_API_BASE}/bot${BOT_TOKEN}/getUpdates" \
+      2>/dev/null; then
+      return 0
+    fi
+
+    if [[ ${max_attempts} -gt 0 && ${attempts} -ge ${max_attempts} ]]; then
+      return 1
+    fi
+
+    "${sleep_cmd}" "${backoff}" || true
+    backoff=$((backoff * 2))
+    [[ ${backoff} -gt 30 ]] && backoff=30
+  done
 }
 
 # _tg_send_message <chat_id> <text>
-# Sends a message; handles 429 retry_after.
+# POSTs to Bot API sendMessage. On HTTP 429 (rate limit) parses
+# .parameters.retry_after from the response body and sleeps once before
+# retrying — at most one retry, so a sustained 429 storm doesn't loop us.
+# All other non-2xx responses are reported as failure (caller may log them
+# and continue; we don't want to spam-retry on permanent errors like 400).
+# Curl and sleep are injectable for testability (see _tg_get_updates).
 _tg_send_message() {
+  local chat_id="${1:-}"
+  local text="${2:-}"
+  [[ -n "${chat_id}" && -n "${text}" ]] || return 1
+  [[ -n "${BOT_TOKEN:-}" ]] || return 1
+
+  local curl_cmd="${SBX_TG_CURL_CMD:-curl}"
+  local sleep_cmd="${SBX_TG_SLEEP_CMD:-sleep}"
+
+  local body_file=""
+  body_file=$(mktemp -t sbx-tg-send.XXXXXX) || return 1
+  # shellcheck disable=SC2064
+  trap "rm -f '${body_file}'" RETURN
+
+  local attempts=0
+  local max_attempts=2 # initial + at most one 429 retry
+  while [[ ${attempts} -lt ${max_attempts} ]]; do
+    attempts=$((attempts + 1))
+    local http_code=""
+    http_code=$("${curl_cmd}" -sS \
+      -o "${body_file}" \
+      -w '%{http_code}' \
+      --max-time 30 \
+      --connect-timeout 10 \
+      --data-urlencode "chat_id=${chat_id}" \
+      --data-urlencode "text=${text}" \
+      "${SBX_TG_API_BASE}/bot${BOT_TOKEN}/sendMessage" \
+      2>/dev/null) || http_code="000"
+
+    if [[ "${http_code}" == "200" ]]; then
+      return 0
+    fi
+
+    if [[ "${http_code}" == "429" ]] && command -v jq >/dev/null 2>&1; then
+      local retry_after=""
+      retry_after=$(jq -r '.parameters.retry_after // 1' "${body_file}" 2>/dev/null)
+      [[ "${retry_after}" =~ ^[0-9]+$ ]] || retry_after=1
+      "${sleep_cmd}" "${retry_after}" || true
+      continue
+    fi
+
+    return 1
+  done
   return 1
 }
 

--- a/tests/unit/test_module_download.sh
+++ b/tests/unit/test_module_download.sh
@@ -240,7 +240,17 @@ else
 fi
 
 #==============================================================================
-# Test 8: Regex parsing of download results
+# Test 8: Telegram launcher download is mandatory
+#==============================================================================
+test_start "Telegram launcher download failures are not ignored"
+if rg -n 'sbx-telegram-bot.*\|\| true' "$SCRIPT_DIR/install.sh" >/dev/null 2>&1; then
+    test_fail "sbx-telegram-bot download still uses || true"
+else
+    test_pass
+fi
+
+#==============================================================================
+# Test 9: Regex parsing of download results
 #==============================================================================
 test_start "Download result regex parsing works correctly"
 result=$(bash -c '

--- a/tests/unit/test_sbx_manager_telegram.sh
+++ b/tests/unit/test_sbx_manager_telegram.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# tests/unit/test_sbx_manager_telegram.sh - Validate sbx-manager telegram routing
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../test_framework.sh"
+
+setup_manager_telegram_mock() {
+  TEST_TMP_DIR="$(mktemp -d /tmp/sbx-manager-telegram.XXXXXX)"
+  STUB_LIB="${TEST_TMP_DIR}/lib"
+  INVOCATION_LOG="${TEST_TMP_DIR}/invocations.log"
+
+  mkdir -p "${STUB_LIB}"
+  : >"${INVOCATION_LOG}"
+
+  cat >"${STUB_LIB}/common.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+need_root() { echo "need_root" >>"${INVOCATION_LOG}"; return 0; }
+EOF
+
+  cat >"${STUB_LIB}/telegram_bot.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+telegram_bot_setup() { echo "telegram_bot_setup" >>"${INVOCATION_LOG}"; }
+telegram_bot_enable() { echo "telegram_bot_enable" >>"${INVOCATION_LOG}"; }
+telegram_bot_disable() { echo "telegram_bot_disable" >>"${INVOCATION_LOG}"; }
+telegram_bot_status() { echo "telegram_bot_status" >>"${INVOCATION_LOG}"; }
+telegram_bot_logs() { echo "telegram_bot_logs" >>"${INVOCATION_LOG}"; }
+telegram_bot_admin_add() { echo "telegram_bot_admin_add $*" >>"${INVOCATION_LOG}"; }
+telegram_bot_admin_remove() { echo "telegram_bot_admin_remove $*" >>"${INVOCATION_LOG}"; }
+telegram_bot_admin_list() { echo "telegram_bot_admin_list" >>"${INVOCATION_LOG}"; }
+EOF
+}
+
+teardown_manager_telegram_mock() {
+  [[ -n "${TEST_TMP_DIR:-}" && -d "${TEST_TMP_DIR}" ]] && rm -rf "${TEST_TMP_DIR}"
+}
+
+test_help_lists_telegram_commands() {
+  echo "Testing sbx-manager help includes telegram commands..."
+
+  local output=""
+  output="$(LIB_DIR="${STUB_LIB}" INVOCATION_LOG="${INVOCATION_LOG}" \
+    bash "${PROJECT_ROOT}/bin/sbx-manager.sh" help 2>&1)"
+
+  assert_contains "${output}" "Telegram Bot" "help output lists Telegram Bot section"
+  assert_contains "${output}" "sbx telegram {setup|enable|disable|status|logs|admin ...}" \
+    "help output shows telegram usage"
+}
+
+test_telegram_status_routes_to_module() {
+  echo "Testing sbx-manager telegram status routing..."
+
+  local rc=0
+  LIB_DIR="${STUB_LIB}" INVOCATION_LOG="${INVOCATION_LOG}" \
+    bash "${PROJECT_ROOT}/bin/sbx-manager.sh" telegram status >/dev/null 2>&1 || rc=$?
+
+  assert_equals "0" "${rc}" "telegram status exits successfully"
+  assert_contains "$(cat "${INVOCATION_LOG}")" "telegram_bot_status" \
+    "telegram status dispatches to telegram_bot_status"
+}
+
+test_telegram_admin_add_routes_to_module() {
+  echo "Testing sbx-manager telegram admin add routing..."
+
+  : >"${INVOCATION_LOG}"
+  local rc=0
+  LIB_DIR="${STUB_LIB}" INVOCATION_LOG="${INVOCATION_LOG}" \
+    bash "${PROJECT_ROOT}/bin/sbx-manager.sh" telegram admin add 12345 >/dev/null 2>&1 || rc=$?
+
+  assert_equals "0" "${rc}" "telegram admin add exits successfully"
+  assert_contains "$(cat "${INVOCATION_LOG}")" "need_root" \
+    "telegram admin add enforces need_root"
+  assert_contains "$(cat "${INVOCATION_LOG}")" "telegram_bot_admin_add 12345" \
+    "telegram admin add dispatches to telegram_bot_admin_add"
+}
+
+main() {
+  set +e
+  run_test_suite \
+    "sbx-manager telegram command routing" \
+    setup_manager_telegram_mock \
+    test_help_lists_telegram_commands \
+    test_telegram_status_routes_to_module \
+    test_telegram_admin_add_routes_to_module \
+    teardown_manager_telegram_mock
+  print_test_summary
+}
+
+main "$@"

--- a/tests/unit/test_sbx_telegram_bot_launcher.sh
+++ b/tests/unit/test_sbx_telegram_bot_launcher.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# tests/unit/test_sbx_telegram_bot_launcher.sh - Validate bot launcher entrypoint
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../test_framework.sh"
+
+setup_launcher_mock() {
+  TEST_TMP_DIR="$(mktemp -d /tmp/sbx-telegram-launcher.XXXXXX)"
+  STUB_LIB="${TEST_TMP_DIR}/lib"
+  INVOCATION_LOG="${TEST_TMP_DIR}/launcher.log"
+
+  mkdir -p "${STUB_LIB}"
+  : >"${INVOCATION_LOG}"
+
+  cat >"${STUB_LIB}/telegram_bot.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+telegram_bot_run() {
+  echo "telegram_bot_run" >>"${INVOCATION_LOG}"
+}
+EOF
+}
+
+teardown_launcher_mock() {
+  [[ -n "${TEST_TMP_DIR:-}" && -d "${TEST_TMP_DIR}" ]] && rm -rf "${TEST_TMP_DIR}"
+}
+
+test_launcher_executes_telegram_bot_run() {
+  echo "Testing sbx-telegram-bot launcher..."
+
+  local rc=0
+  LIB_DIR="${STUB_LIB}" INVOCATION_LOG="${INVOCATION_LOG}" \
+    bash "${PROJECT_ROOT}/bin/sbx-telegram-bot" >/dev/null 2>&1 || rc=$?
+
+  assert_equals "0" "${rc}" "launcher exits successfully"
+  assert_contains "$(cat "${INVOCATION_LOG}")" "telegram_bot_run" \
+    "launcher delegates to telegram_bot_run"
+}
+
+main() {
+  set +e
+  run_test_suite \
+    "sbx-telegram-bot launcher" \
+    setup_launcher_mock \
+    test_launcher_executes_telegram_bot_run \
+    teardown_launcher_mock
+  print_test_summary
+}
+
+main "$@"

--- a/tests/unit/test_telegram_bot.sh
+++ b/tests/unit/test_telegram_bot.sh
@@ -1,0 +1,331 @@
+#!/usr/bin/env bash
+# tests/unit/test_telegram_bot.sh - Unit tests for lib/telegram_bot.sh
+#
+# Covers the pure helpers used by the long-poll daemon:
+#   _tg_validate_token / _tg_is_authorized / _tg_parse_command
+#   _tg_load_offset / _tg_save_offset
+# Plus install.sh registration assertions (module array + contracts map),
+# mirroring tests/unit/test_cloudflare_tunnel.sh:298-309.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# Per-run sandbox so tests never touch /etc/sing-box or /var/lib.
+TEST_TMP_DIR=$(mktemp -d -t sbx-tg-bot-test-XXXXXX)
+
+# Override every state-bearing path before sourcing the lib so its
+# `: "${VAR:=default}"` lines pick up the test fixtures.
+export SBX_TG_OFFSET_DIR="${TEST_TMP_DIR}/var-lib"
+export SBX_TG_OFFSET_FILE="${SBX_TG_OFFSET_DIR}/offset"
+export SBX_TG_ENV_FILE="${TEST_TMP_DIR}/telegram.env"
+export SBX_TG_SVC="${TEST_TMP_DIR}/sbx-telegram-bot.service"
+export SBX_TG_BIN="${TEST_TMP_DIR}/sbx-telegram-bot"
+export TEST_STATE_FILE="${TEST_TMP_DIR}/state.json"
+
+source "${PROJECT_ROOT}/lib/common.sh" 2>/dev/null || {
+  echo "ERROR: Failed to load lib/common.sh"
+  exit 1
+}
+source "${PROJECT_ROOT}/lib/validation.sh" 2>/dev/null || true
+source "${PROJECT_ROOT}/lib/users.sh" 2>/dev/null || true
+source "${PROJECT_ROOT}/lib/service.sh" 2>/dev/null || true
+source "${PROJECT_ROOT}/lib/telegram_bot.sh" 2>/dev/null || {
+  echo "ERROR: Failed to source lib/telegram_bot.sh"
+  exit 1
+}
+
+# Disarm strict mode and any inherited EXIT trap so negative-path
+# assertions don't kill the harness.
+set +eu
+set -o pipefail
+trap - EXIT INT TERM
+trap 'rm -rf "${TEST_TMP_DIR}"' EXIT
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+test_result() {
+  local name="$1"
+  local result="$2"
+  TESTS_RUN=$((TESTS_RUN + 1))
+  if [[ "${result}" == "pass" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo "  ✓ ${name}"
+  else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo "  ✗ ${name}"
+  fi
+}
+
+assert_eq() {
+  local name="$1"
+  local expected="$2"
+  local actual="$3"
+  if [[ "${expected}" == "${actual}" ]]; then
+    test_result "${name}" "pass"
+  else
+    test_result "${name}" "fail"
+    echo "      expected: ${expected}"
+    echo "      actual:   ${actual}"
+  fi
+}
+
+assert_zero() {
+  local name="$1"
+  local rc="$2"
+  if [[ "${rc}" -eq 0 ]]; then
+    test_result "${name}" "pass"
+  else
+    test_result "${name}" "fail"
+    echo "      rc=${rc}"
+  fi
+}
+
+assert_nonzero() {
+  local name="$1"
+  local rc="$2"
+  if [[ "${rc}" -ne 0 ]]; then
+    test_result "${name}" "pass"
+  else
+    test_result "${name}" "fail"
+    echo "      rc=${rc} (expected nonzero)"
+  fi
+}
+
+echo "=== Telegram Bot Module Unit Tests ==="
+
+#==============================================================================
+# _tg_validate_token: accepts canonical Telegram bot tokens, rejects garbage.
+#==============================================================================
+echo ""
+echo "Testing _tg_validate_token..."
+
+# 9-digit id + 35-char secret (canonical shape from BotFather)
+_tg_validate_token "123456789:AAEhBP0av28FrI51bX4nF12345678901234"
+assert_zero "valid 9-digit id token" "$?"
+
+_tg_validate_token "12345678:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi"
+assert_zero "valid 8-digit id token (lower bound)" "$?"
+
+_tg_validate_token "1234567890:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi"
+assert_zero "valid 10-digit id token (upper bound)" "$?"
+
+# Underscore + dash allowed in the secret half per Telegram spec.
+_tg_validate_token "123456789:AA-_BP0av28FrI51bX4nF12345678901234"
+assert_zero "secret with - and _ accepted" "$?"
+
+_tg_validate_token ""
+assert_nonzero "empty token rejected" "$?"
+
+_tg_validate_token "not-a-token"
+assert_nonzero "no colon rejected" "$?"
+
+_tg_validate_token "1234567:AAEhBP0av28FrI51bX4nF12345678901234"
+assert_nonzero "7-digit id rejected (too short)" "$?"
+
+_tg_validate_token "12345678901:AAEhBP0av28FrI51bX4nF12345678901234"
+assert_nonzero "11-digit id rejected (too long)" "$?"
+
+_tg_validate_token "123456789:AAEhBP0av28FrI51bX4nF1234567890123"
+assert_nonzero "34-char secret rejected (too short)" "$?"
+
+_tg_validate_token "123456789:AAEhBP0av28FrI51bX4nF123456789012345"
+assert_nonzero "36-char secret rejected (too long)" "$?"
+
+_tg_validate_token "123456789:AAEhBP0av28FrI51bX4nF1234567890123!"
+assert_nonzero "invalid char in secret rejected" "$?"
+
+#==============================================================================
+# _tg_is_authorized: chat_id whitelist lookup against state.json.
+#==============================================================================
+echo ""
+echo "Testing _tg_is_authorized..."
+
+if command -v jq >/dev/null 2>&1; then
+  # Case 1: state file missing → reject.
+  rm -f "${TEST_STATE_FILE}"
+  _tg_is_authorized "12345"
+  assert_nonzero "missing state.json rejects everyone" "$?"
+
+  # Case 2: empty whitelist → reject.
+  cat >"${TEST_STATE_FILE}" <<'JSON'
+{
+  "version": "1.0",
+  "telegram": {"enabled": false, "admin_chat_ids": []}
+}
+JSON
+  _tg_is_authorized "12345"
+  assert_nonzero "empty whitelist rejects everyone" "$?"
+
+  # Case 3: telegram block missing entirely → reject.
+  cat >"${TEST_STATE_FILE}" <<'JSON'
+{"version": "1.0", "protocols": {}}
+JSON
+  _tg_is_authorized "12345"
+  assert_nonzero "missing .telegram block rejects" "$?"
+
+  # Case 4: chat_id present (numeric) → accept.
+  cat >"${TEST_STATE_FILE}" <<'JSON'
+{
+  "version": "1.0",
+  "telegram": {"enabled": true, "admin_chat_ids": [12345, 67890]}
+}
+JSON
+  _tg_is_authorized "12345"
+  assert_zero "whitelisted chat_id 12345 accepted" "$?"
+  _tg_is_authorized "67890"
+  assert_zero "whitelisted chat_id 67890 accepted" "$?"
+
+  # Case 5: chat_id not present → reject.
+  _tg_is_authorized "11111"
+  assert_nonzero "non-whitelisted chat_id 11111 rejected" "$?"
+
+  # Case 6: empty arg → reject (defensive).
+  _tg_is_authorized ""
+  assert_nonzero "empty chat_id arg rejected" "$?"
+
+  # Case 7: negative chat_id (Telegram group id convention).
+  cat >"${TEST_STATE_FILE}" <<'JSON'
+{"telegram": {"admin_chat_ids": [-100123456789]}}
+JSON
+  _tg_is_authorized "-100123456789"
+  assert_zero "negative group chat_id accepted" "$?"
+else
+  echo "  (skipping is_authorized tests: jq not installed)"
+fi
+
+#==============================================================================
+# _tg_parse_command: split leading /cmd from args; strip @botname suffix.
+#==============================================================================
+echo ""
+echo "Testing _tg_parse_command..."
+
+assert_eq "/status -> 'status'" "status" "$(_tg_parse_command '/status')"
+assert_eq "/help -> 'help'" "help" "$(_tg_parse_command '/help')"
+assert_eq "/adduser alice -> 'adduser alice'" "adduser alice" "$(_tg_parse_command '/adduser alice')"
+assert_eq "leading whitespace in args trimmed" \
+  "adduser alice" "$(_tg_parse_command '/adduser   alice')"
+assert_eq "/cmd@botname stripped" \
+  "status" "$(_tg_parse_command '/status@my_sbx_bot')"
+assert_eq "/cmd@botname with args" \
+  "adduser alice" "$(_tg_parse_command '/adduser@my_sbx_bot alice')"
+assert_eq "multi-word args preserved" \
+  "removeuser alice bob" "$(_tg_parse_command '/removeuser alice bob')"
+
+# Negative paths.
+out=$(_tg_parse_command 'hello world' 2>/dev/null)
+rc=$?
+if [[ ${rc} -ne 0 && -z "${out}" ]]; then
+  test_result "non-command text rejected" "pass"
+else
+  test_result "non-command text rejected" "fail"
+fi
+
+out=$(_tg_parse_command '' 2>/dev/null)
+rc=$?
+if [[ ${rc} -ne 0 && -z "${out}" ]]; then
+  test_result "empty input rejected" "pass"
+else
+  test_result "empty input rejected" "fail"
+fi
+
+out=$(_tg_parse_command '/' 2>/dev/null)
+rc=$?
+if [[ ${rc} -ne 0 ]]; then
+  test_result "lone slash rejected" "pass"
+else
+  test_result "lone slash rejected" "fail"
+fi
+
+#==============================================================================
+# _tg_load_offset / _tg_save_offset: round-trip + missing-file default.
+#==============================================================================
+echo ""
+echo "Testing _tg_load_offset / _tg_save_offset..."
+
+# Missing file → "0".
+rm -rf "${SBX_TG_OFFSET_DIR}"
+assert_eq "missing offset file defaults to 0" "0" "$(_tg_load_offset)"
+
+# Round-trip a positive integer.
+_tg_save_offset 4242
+assert_zero "save_offset returns 0" "$?"
+assert_eq "round-trip 4242" "4242" "$(_tg_load_offset)"
+
+# Overwrite with a different value.
+_tg_save_offset 9999999
+assert_eq "overwrite 9999999" "9999999" "$(_tg_load_offset)"
+
+# Save 0 explicitly.
+_tg_save_offset 0
+assert_eq "round-trip 0" "0" "$(_tg_load_offset)"
+
+# Negative offset (Telegram allows offset=-1 for 'latest only').
+_tg_save_offset -1
+assert_eq "round-trip -1" "-1" "$(_tg_load_offset)"
+
+# Garbage content → load returns "0" (defensive).
+echo "not-a-number" >"${SBX_TG_OFFSET_FILE}"
+assert_eq "garbage offset content defaults to 0" "0" "$(_tg_load_offset)"
+
+# Non-numeric save rejected.
+_tg_save_offset "abc"
+assert_nonzero "save_offset rejects non-numeric" "$?"
+
+# Confirm offset file was created with 0600 (mktemp default may vary; we set
+# it explicitly in _tg_save_offset).
+_tg_save_offset 100
+perm=$(stat -c '%a' "${SBX_TG_OFFSET_FILE}" 2>/dev/null ||
+  stat -f '%Lp' "${SBX_TG_OFFSET_FILE}" 2>/dev/null)
+assert_eq "offset file is mode 600" "600" "${perm}"
+
+#==============================================================================
+# Module is registered in install.sh modules array + contracts map
+# (mirrors tests/unit/test_cloudflare_tunnel.sh:298-309).
+#==============================================================================
+echo ""
+echo "Testing install.sh registration..."
+
+if grep -qE 'local modules=\(.*\btelegram_bot\b.*\)' "${PROJECT_ROOT}/install.sh"; then
+  test_result "telegram_bot registered in install.sh modules array" "pass"
+else
+  test_result "telegram_bot registered in install.sh modules array" "fail"
+fi
+
+if grep -q '\["telegram_bot"\]=' "${PROJECT_ROOT}/install.sh"; then
+  test_result "telegram_bot API contract registered" "pass"
+else
+  test_result "telegram_bot API contract registered" "fail"
+fi
+
+#==============================================================================
+# Public API surface: every exported function exists.
+#==============================================================================
+echo ""
+echo "Testing exported API surface..."
+
+for fn in telegram_bot_setup telegram_bot_enable telegram_bot_disable \
+  telegram_bot_status telegram_bot_logs telegram_bot_admin_add \
+  telegram_bot_admin_remove telegram_bot_admin_list telegram_bot_run; do
+  if declare -F "${fn}" >/dev/null 2>&1; then
+    test_result "${fn} is defined" "pass"
+  else
+    test_result "${fn} is defined" "fail"
+  fi
+done
+
+#==============================================================================
+# Summary
+#==============================================================================
+echo ""
+echo "=== Test Summary ==="
+echo "Tests run:    ${TESTS_RUN}"
+echo "Tests passed: ${TESTS_PASSED}"
+echo "Tests failed: ${TESTS_FAILED}"
+
+if [[ ${TESTS_FAILED} -eq 0 ]]; then
+  exit 0
+else
+  exit 1
+fi

--- a/tests/unit/test_telegram_bot.sh
+++ b/tests/unit/test_telegram_bot.sh
@@ -732,6 +732,120 @@ reply=$(cat "${SEND_LOG}")
 assert_contains_str "/start aliases to help" "/status" "${reply}"
 
 #==============================================================================
+# _tg_update_state: atomic merge into .telegram block. Verifies value
+# typing (bool/int/string/array), allowlist enforcement, format validation,
+# preservation of unrelated state, and chmod 600 after rename.
+#==============================================================================
+echo ""
+echo "Testing _tg_update_state..."
+
+if command -v jq >/dev/null 2>&1; then
+  # Seed a state file with unrelated fields we expect to survive.
+  cat >"${TEST_STATE_FILE}" <<'JSON'
+{
+  "version": "1.0",
+  "server": {"ip": "203.0.113.1"},
+  "protocols": {"reality": {"enabled": true}}
+}
+JSON
+  chmod 600 "${TEST_STATE_FILE}"
+
+  # Case 1: enabled=true (boolean literal).
+  _tg_update_state enabled=true >/dev/null 2>&1
+  assert_zero "set enabled=true returns 0" "$?"
+  assert_eq ".telegram.enabled is JSON true" \
+    "true" "$(jq -r '.telegram.enabled' "${TEST_STATE_FILE}")"
+
+  # Case 2: unrelated state survives.
+  assert_eq "unrelated .protocols.reality.enabled preserved" \
+    "true" "$(jq -r '.protocols.reality.enabled' "${TEST_STATE_FILE}")"
+  assert_eq "unrelated .server.ip preserved" \
+    "203.0.113.1" "$(jq -r '.server.ip' "${TEST_STATE_FILE}")"
+
+  # Case 3: username=mybot (string).
+  _tg_update_state username=mybot >/dev/null 2>&1
+  assert_eq ".telegram.username is JSON string" \
+    "mybot" "$(jq -r '.telegram.username' "${TEST_STATE_FILE}")"
+  # And the previous .telegram.enabled is still there (merge, not replace).
+  assert_eq "previous .telegram.enabled retained after username update" \
+    "true" "$(jq -r '.telegram.enabled' "${TEST_STATE_FILE}")"
+
+  # Case 4: multi-pair single call (atomic).
+  _tg_update_state enabled=false username=otherbot >/dev/null 2>&1
+  assert_eq "multi-pair: enabled=false applied" \
+    "false" "$(jq -r '.telegram.enabled' "${TEST_STATE_FILE}")"
+  assert_eq "multi-pair: username=otherbot applied" \
+    "otherbot" "$(jq -r '.telegram.username' "${TEST_STATE_FILE}")"
+
+  # Case 5: admin_chat_ids as JSON array (--argjson path).
+  _tg_update_state admin_chat_ids='[12345,67890,-100123]' >/dev/null 2>&1
+  assert_eq "admin_chat_ids written as JSON array" \
+    "3" "$(jq -r '.telegram.admin_chat_ids | length' "${TEST_STATE_FILE}")"
+  assert_eq "admin_chat_ids[0] is integer 12345" \
+    "12345" "$(jq -r '.telegram.admin_chat_ids[0]' "${TEST_STATE_FILE}")"
+  assert_eq "admin_chat_ids[2] is negative group id" \
+    "-100123" "$(jq -r '.telegram.admin_chat_ids[2]' "${TEST_STATE_FILE}")"
+
+  # Case 6: file mode is 600 after update.
+  perm=$(stat -c '%a' "${TEST_STATE_FILE}" 2>/dev/null ||
+    stat -f '%Lp' "${TEST_STATE_FILE}" 2>/dev/null)
+  assert_eq "state.json mode preserved at 600" "600" "${perm}"
+
+  # Case 7: state.json remains valid JSON.
+  jq empty "${TEST_STATE_FILE}" >/dev/null 2>&1
+  assert_zero "state.json remains parseable JSON" "$?"
+
+  # Case 8: missing state file → return 0 (warn-and-skip, matches cloudflared).
+  rm -f "${TEST_STATE_FILE}"
+  _tg_update_state enabled=true 2>/dev/null
+  assert_zero "missing state file → return 0 (skip)" "$?"
+
+  # Restore for negative-path tests below.
+  echo '{"version":"1.0"}' >"${TEST_STATE_FILE}"
+
+  # Case 9: no args rejected.
+  _tg_update_state 2>/dev/null
+  assert_nonzero "no args rejected" "$?"
+
+  # Case 10: malformed kv (no '=') rejected.
+  _tg_update_state "notakv" 2>/dev/null
+  assert_nonzero "kv without '=' rejected" "$?"
+
+  # Case 11: invalid key (digits-only / shell metas) rejected.
+  _tg_update_state "123=foo" 2>/dev/null
+  assert_nonzero "key starting with digit rejected" "$?"
+  _tg_update_state "evil;rm=foo" 2>/dev/null
+  assert_nonzero "key with shell meta rejected" "$?"
+
+  # Case 12: key not in allowlist rejected (defense-in-depth).
+  _tg_update_state "bot_token=secret123" 2>/dev/null
+  assert_nonzero "key outside allowlist rejected" "$?"
+  # And the rejected write must NOT have leaked into state.
+  bot_field=$(jq -r '.telegram.bot_token // "MISSING"' "${TEST_STATE_FILE}")
+  assert_eq "rejected key never written" "MISSING" "${bot_field}"
+
+  # Case 13: weird-but-valid string value (spaces) round-trips.
+  _tg_update_state "username=My Bot Name" >/dev/null 2>&1
+  assert_eq "string value with spaces round-trips" \
+    "My Bot Name" "$(jq -r '.telegram.username' "${TEST_STATE_FILE}")"
+
+  # Case 14: integer value typed as JSON int (not string).
+  _tg_update_state "admin_chat_ids=[42]" >/dev/null 2>&1
+  type_check=$(jq -r '.telegram.admin_chat_ids[0] | type' "${TEST_STATE_FILE}")
+  assert_eq "integer in array stays JSON number" "number" "${type_check}"
+
+  # Case 15: trip enable→disable cycle round-trip integrity.
+  _tg_update_state enabled=true username=cycle1 >/dev/null 2>&1
+  _tg_update_state enabled=false >/dev/null 2>&1
+  enabled=$(jq -r '.telegram.enabled' "${TEST_STATE_FILE}")
+  username=$(jq -r '.telegram.username' "${TEST_STATE_FILE}")
+  assert_eq "cycle: enabled is false" "false" "${enabled}"
+  assert_eq "cycle: username preserved across toggle" "cycle1" "${username}"
+else
+  echo "  (skipping _tg_update_state tests: jq not installed)"
+fi
+
+#==============================================================================
 # Module is registered in install.sh modules array + contracts map
 # (mirrors tests/unit/test_cloudflare_tunnel.sh:298-309).
 #==============================================================================

--- a/tests/unit/test_telegram_bot.sh
+++ b/tests/unit/test_telegram_bot.sh
@@ -281,6 +281,231 @@ perm=$(stat -c '%a' "${SBX_TG_OFFSET_FILE}" 2>/dev/null ||
 assert_eq "offset file is mode 600" "600" "${perm}"
 
 #==============================================================================
+# _tg_get_updates: backoff loop, success path, attempt cap, missing token.
+# Curl + sleep are stubbed via SBX_TG_CURL_CMD / SBX_TG_SLEEP_CMD so the
+# test never touches the network or wall clock.
+#==============================================================================
+echo ""
+echo "Testing _tg_get_updates..."
+
+# Counters live in files so subshells don't lose them.
+GU_CALLS_FILE="${TEST_TMP_DIR}/gu_calls"
+GU_SLEEPS_FILE="${TEST_TMP_DIR}/gu_sleeps"
+
+# Stub curl: writes a fixture body and succeeds. Detects the -o argument
+# anywhere in argv (the lib uses curl -o <file>).
+mock_curl_get_success() {
+  local out_file=""
+  while [[ $# -gt 0 ]]; do
+    if [[ "$1" == "-o" ]]; then
+      out_file="$2"
+      shift 2
+      continue
+    fi
+    shift
+  done
+  echo '{"ok":true,"result":[]}' >"${out_file}"
+  echo "ok" >>"${GU_CALLS_FILE}"
+  return 0
+}
+
+# Stub curl: always fails (simulates network error / 5xx).
+mock_curl_get_fail() {
+  echo "fail" >>"${GU_CALLS_FILE}"
+  return 22
+}
+
+# Stub sleep: records arg, returns immediately.
+mock_sleep() {
+  echo "$1" >>"${GU_SLEEPS_FILE}"
+  return 0
+}
+
+export SBX_TG_SLEEP_CMD=mock_sleep
+
+# Case 1: missing BOT_TOKEN → reject without calling curl.
+unset BOT_TOKEN
+: >"${GU_CALLS_FILE}"
+SBX_TG_CURL_CMD=mock_curl_get_success _tg_get_updates 0 "${TEST_TMP_DIR}/gu.out"
+rc=$?
+calls=$(wc -l <"${GU_CALLS_FILE}" | tr -d ' ')
+if [[ ${rc} -ne 0 && "${calls}" == "0" ]]; then
+  test_result "missing BOT_TOKEN rejects without curl call" "pass"
+else
+  test_result "missing BOT_TOKEN rejects without curl call" "fail"
+  echo "      rc=${rc} calls=${calls}"
+fi
+
+# Case 2: missing output_file arg → reject.
+BOT_TOKEN="123456789:AAEhBP0av28FrI51bX4nF12345678901234"
+export BOT_TOKEN
+SBX_TG_CURL_CMD=mock_curl_get_success _tg_get_updates 0 ""
+assert_nonzero "missing output_file rejects" "$?"
+
+# Case 3: success on first try → rc=0, output file written, no sleeps.
+: >"${GU_CALLS_FILE}"
+: >"${GU_SLEEPS_FILE}"
+rm -f "${TEST_TMP_DIR}/gu.out"
+SBX_TG_CURL_CMD=mock_curl_get_success _tg_get_updates 42 "${TEST_TMP_DIR}/gu.out"
+assert_zero "first-try success returns 0" "$?"
+calls=$(wc -l <"${GU_CALLS_FILE}" | tr -d ' ')
+sleeps=$(wc -l <"${GU_SLEEPS_FILE}" | tr -d ' ')
+assert_eq "exactly one curl call on success" "1" "${calls}"
+assert_eq "no sleep on success" "0" "${sleeps}"
+[[ -s "${TEST_TMP_DIR}/gu.out" ]] && test_result "output file populated" "pass" ||
+  test_result "output file populated" "fail"
+
+# Case 4: persistent failure with attempt cap → rc=1, exact attempt count,
+# backoff sequence is 1, 2, 4 (no sleep after the final failed attempt).
+: >"${GU_CALLS_FILE}"
+: >"${GU_SLEEPS_FILE}"
+SBX_TG_BACKOFF_MAX_ATTEMPTS=4 SBX_TG_CURL_CMD=mock_curl_get_fail \
+  _tg_get_updates 0 "${TEST_TMP_DIR}/gu.out"
+rc=$?
+calls=$(wc -l <"${GU_CALLS_FILE}" | tr -d ' ')
+sleeps_seq=$(tr '\n' ',' <"${GU_SLEEPS_FILE}")
+assert_nonzero "persistent failure with cap returns nonzero" "${rc}"
+assert_eq "exactly N curl attempts" "4" "${calls}"
+assert_eq "backoff sequence 1,2,4 between attempts" "1,2,4," "${sleeps_seq}"
+
+# Case 5: backoff caps at 30s. With 7 attempts the 6th sleep would be
+# 32; the cap clamps it back to 30.
+: >"${GU_CALLS_FILE}"
+: >"${GU_SLEEPS_FILE}"
+SBX_TG_BACKOFF_MAX_ATTEMPTS=7 SBX_TG_CURL_CMD=mock_curl_get_fail \
+  _tg_get_updates 0 "${TEST_TMP_DIR}/gu.out" >/dev/null 2>&1
+sleeps_seq=$(tr '\n' ',' <"${GU_SLEEPS_FILE}")
+assert_eq "backoff caps at 30 (1,2,4,8,16,30)" "1,2,4,8,16,30," "${sleeps_seq}"
+
+#==============================================================================
+# _tg_send_message: success, 429 retry, hard failure, missing token.
+#==============================================================================
+echo ""
+echo "Testing _tg_send_message..."
+
+SM_CALLS_FILE="${TEST_TMP_DIR}/sm_calls"
+SM_SLEEPS_FILE="${TEST_TMP_DIR}/sm_sleeps"
+
+# Stub curl for send: writes body to -o file, prints HTTP code via -w.
+mock_curl_send_200() {
+  local out_file=""
+  while [[ $# -gt 0 ]]; do
+    if [[ "$1" == "-o" ]]; then
+      out_file="$2"
+      shift 2
+      continue
+    fi
+    shift
+  done
+  echo '{"ok":true,"result":{"message_id":1}}' >"${out_file}"
+  echo "200" >>"${SM_CALLS_FILE}"
+  printf '200'
+}
+
+mock_curl_send_500() {
+  local out_file=""
+  while [[ $# -gt 0 ]]; do
+    if [[ "$1" == "-o" ]]; then
+      out_file="$2"
+      shift 2
+      continue
+    fi
+    shift
+  done
+  echo '{"ok":false,"error_code":500}' >"${out_file}"
+  echo "500" >>"${SM_CALLS_FILE}"
+  printf '500'
+}
+
+# 429 once, then 200 — exercises the rate-limit retry path.
+mock_curl_send_429_then_200() {
+  local out_file=""
+  while [[ $# -gt 0 ]]; do
+    if [[ "$1" == "-o" ]]; then
+      out_file="$2"
+      shift 2
+      continue
+    fi
+    shift
+  done
+  local n
+  n=$(wc -l <"${SM_CALLS_FILE}" 2>/dev/null | tr -d ' ')
+  n=${n:-0}
+  n=$((n + 1))
+  if [[ ${n} -eq 1 ]]; then
+    echo '{"ok":false,"error_code":429,"parameters":{"retry_after":7}}' >"${out_file}"
+    echo "429" >>"${SM_CALLS_FILE}"
+    printf '429'
+  else
+    echo '{"ok":true}' >"${out_file}"
+    echo "200" >>"${SM_CALLS_FILE}"
+    printf '200'
+  fi
+}
+
+mock_sleep_send() {
+  echo "$1" >>"${SM_SLEEPS_FILE}"
+  return 0
+}
+
+export SBX_TG_SLEEP_CMD=mock_sleep_send
+
+# Case 1: missing token → reject.
+unset BOT_TOKEN
+: >"${SM_CALLS_FILE}"
+SBX_TG_CURL_CMD=mock_curl_send_200 _tg_send_message 12345 "hello"
+rc=$?
+calls=$(wc -l <"${SM_CALLS_FILE}" | tr -d ' ')
+if [[ ${rc} -ne 0 && "${calls}" == "0" ]]; then
+  test_result "send: missing BOT_TOKEN rejects without curl call" "pass"
+else
+  test_result "send: missing BOT_TOKEN rejects without curl call" "fail"
+fi
+
+# Case 2: missing chat_id or text → reject.
+BOT_TOKEN="123456789:AAEhBP0av28FrI51bX4nF12345678901234"
+export BOT_TOKEN
+SBX_TG_CURL_CMD=mock_curl_send_200 _tg_send_message "" "hello"
+assert_nonzero "send: empty chat_id rejected" "$?"
+SBX_TG_CURL_CMD=mock_curl_send_200 _tg_send_message 12345 ""
+assert_nonzero "send: empty text rejected" "$?"
+
+# Case 3: 200 first try.
+: >"${SM_CALLS_FILE}"
+: >"${SM_SLEEPS_FILE}"
+SBX_TG_CURL_CMD=mock_curl_send_200 _tg_send_message 12345 "hello world"
+assert_zero "send: 200 returns 0" "$?"
+calls=$(wc -l <"${SM_CALLS_FILE}" | tr -d ' ')
+sleeps=$(wc -l <"${SM_SLEEPS_FILE}" | tr -d ' ')
+assert_eq "send: exactly one curl call on 200" "1" "${calls}"
+assert_eq "send: no sleep on 200" "0" "${sleeps}"
+
+# Case 4: 500 → fail immediately, no retry.
+: >"${SM_CALLS_FILE}"
+: >"${SM_SLEEPS_FILE}"
+SBX_TG_CURL_CMD=mock_curl_send_500 _tg_send_message 12345 "hello"
+assert_nonzero "send: 500 returns nonzero" "$?"
+calls=$(wc -l <"${SM_CALLS_FILE}" | tr -d ' ')
+assert_eq "send: 500 does not retry" "1" "${calls}"
+
+# Case 5: 429 then 200 → success, exactly one sleep with retry_after=7.
+if command -v jq >/dev/null 2>&1; then
+  : >"${SM_CALLS_FILE}"
+  : >"${SM_SLEEPS_FILE}"
+  SBX_TG_CURL_CMD=mock_curl_send_429_then_200 _tg_send_message 12345 "hello"
+  assert_zero "send: 429-then-200 returns 0" "$?"
+  calls=$(wc -l <"${SM_CALLS_FILE}" | tr -d ' ')
+  sleeps_seq=$(tr '\n' ',' <"${SM_SLEEPS_FILE}")
+  assert_eq "send: 429-then-200 makes 2 calls" "2" "${calls}"
+  assert_eq "send: sleep honors retry_after" "7," "${sleeps_seq}"
+else
+  echo "  (skipping 429 retry test: jq not installed)"
+fi
+
+# Reset SBX_TG_SLEEP_CMD so later tests in this file aren't affected.
+unset SBX_TG_SLEEP_CMD SBX_TG_CURL_CMD SBX_TG_BACKOFF_MAX_ATTEMPTS
+
+#==============================================================================
 # Module is registered in install.sh modules array + contracts map
 # (mirrors tests/unit/test_cloudflare_tunnel.sh:298-309).
 #==============================================================================

--- a/tests/unit/test_telegram_bot.sh
+++ b/tests/unit/test_telegram_bot.sh
@@ -846,6 +846,201 @@ else
 fi
 
 #==============================================================================
+# telegram_bot_* lifecycle helpers: setup / enable / disable / status / logs /
+# admin list mutation.
+#==============================================================================
+echo ""
+echo "Testing telegram_bot lifecycle..."
+
+TG_VERIFY_LOG="${TEST_TMP_DIR}/verify.log"
+JOURNALCTL_LOG="${TEST_TMP_DIR}/journalctl.log"
+
+reset_lifecycle_logs() {
+  : >"${SYSTEMCTL_LOG}"
+  : >"${JOURNALCTL_LOG}"
+  : >"${TG_VERIFY_LOG}"
+}
+
+_tg_verify_token_live() {
+  local token="${1:-}"
+  printf '%s\n' "${token}" >>"${TG_VERIFY_LOG}"
+  if [[ "${token}" == "123456789:AAEhBP0av28FrI51bX4nF12345678901234" ]]; then
+    printf 'my_sbx_bot\n'
+    return 0
+  fi
+  return 1
+}
+
+systemctl() {
+  echo "systemctl $*" >>"${SYSTEMCTL_LOG}"
+  case "${1:-}" in
+    is-active)
+      [[ "${STUB_TG_SYSTEMD_ACTIVE:-0}" == "1" ]]
+      ;;
+    status)
+      echo "sbx-telegram-bot.service - sbx Telegram Bot"
+      if [[ "${STUB_TG_SYSTEMD_ACTIVE:-0}" == "1" ]]; then
+        echo "Active: active (running)"
+        return 0
+      fi
+      echo "Active: inactive (dead)"
+      return 3
+      ;;
+    daemon-reload | enable | disable | start | stop | restart)
+      return 0
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+}
+
+journalctl() {
+  echo "journalctl $*" >>"${JOURNALCTL_LOG}"
+  echo "telegram bot journal output"
+}
+
+need_root() {
+  return 0
+}
+
+if command -v jq >/dev/null 2>&1; then
+  reset_lifecycle_logs
+  cat >"${TEST_STATE_FILE}" <<'JSON'
+{"version":"1.0","protocols":{"reality":{"enabled":true}}}
+JSON
+  rm -f "${SBX_TG_ENV_FILE}" "${SBX_TG_SVC}" "${SBX_TG_BIN}"
+  mkdir -p "$(dirname "${SBX_TG_BIN}")"
+  : >"${SBX_TG_BIN}"
+  chmod 755 "${SBX_TG_BIN}"
+
+  printf '%s\n%s\n' \
+    "123456789:AAEhBP0av28FrI51bX4nF12345678901234" \
+    "99999" | telegram_bot_setup >/dev/null 2>&1
+  assert_zero "telegram_bot_setup succeeds with valid token + admin" "$?"
+  assert_eq "setup writes BOT_TOKEN env file" \
+    "BOT_TOKEN=123456789:AAEhBP0av28FrI51bX4nF12345678901234" \
+    "$(grep '^BOT_TOKEN=' "${SBX_TG_ENV_FILE}")"
+  assert_eq "setup stores username" \
+    "my_sbx_bot" "$(jq -r '.telegram.username' "${TEST_STATE_FILE}")"
+  assert_eq "setup stores enabled=false before service enable" \
+    "false" "$(jq -r '.telegram.enabled' "${TEST_STATE_FILE}")"
+  assert_eq "setup seeds first admin_chat_id" \
+    "99999" "$(jq -r '.telegram.admin_chat_ids[0]' "${TEST_STATE_FILE}")"
+  assert_eq "setup verifies the provided token" \
+    "123456789:AAEhBP0av28FrI51bX4nF12345678901234" "$(tail -n 1 "${TG_VERIFY_LOG}")"
+  perm=$(stat -c '%a' "${SBX_TG_ENV_FILE}" 2>/dev/null ||
+    stat -f '%Lp' "${SBX_TG_ENV_FILE}" 2>/dev/null)
+  assert_eq "telegram.env is mode 600 after setup" "600" "${perm}"
+
+  reset_lifecycle_logs
+  telegram_bot_admin_add 12345 >/dev/null 2>&1
+  assert_zero "admin_add accepts new numeric chat id" "$?"
+  assert_eq "admin_add appends second admin id" \
+    "2" "$(jq -r '.telegram.admin_chat_ids | length' "${TEST_STATE_FILE}")"
+
+  telegram_bot_admin_add 12345 >/dev/null 2>&1
+  assert_eq "admin_add de-duplicates existing chat id" \
+    "2" "$(jq -r '.telegram.admin_chat_ids | length' "${TEST_STATE_FILE}")"
+
+  telegram_bot_admin_remove 99999 >/dev/null 2>&1
+  assert_zero "admin_remove succeeds for existing id" "$?"
+  assert_eq "admin_remove drops the target id" \
+    "12345" "$(jq -r '.telegram.admin_chat_ids[0]' "${TEST_STATE_FILE}")"
+
+  admin_list_output="$(telegram_bot_admin_list 2>/dev/null)"
+  assert_contains_str "admin_list prints the remaining id" "12345" "${admin_list_output}"
+
+  reset_lifecycle_logs
+  telegram_bot_enable >/dev/null 2>&1
+  assert_zero "telegram_bot_enable succeeds once setup is complete" "$?"
+  assert_eq "enable marks telegram.enabled=true" \
+    "true" "$(jq -r '.telegram.enabled' "${TEST_STATE_FILE}")"
+  assert_contains_str "enable writes service file" "[Service]" "$(cat "${SBX_TG_SVC}")"
+  assert_contains_str "enable unit references launcher" \
+    "ExecStart=${SBX_TG_BIN}" "$(cat "${SBX_TG_SVC}")"
+  assert_contains_str "enable unit references env file" \
+    "EnvironmentFile=-${SBX_TG_ENV_FILE}" "$(cat "${SBX_TG_SVC}")"
+  assert_contains_str "enable reloads systemd" \
+    "systemctl daemon-reload" "$(cat "${SYSTEMCTL_LOG}")"
+  assert_contains_str "enable starts service immediately" \
+    "systemctl enable --now ${SBX_TG_SERVICE_NAME}" "$(cat "${SYSTEMCTL_LOG}")"
+
+  reset_lifecycle_logs
+  STUB_TG_SYSTEMD_ACTIVE=1
+  status_output="$(telegram_bot_status 2>&1)"
+  assert_contains_str "status includes username" "my_sbx_bot" "${status_output}"
+  assert_contains_str "status includes admin count" "Admins" "${status_output}"
+  assert_contains_str "status includes active systemd text" "active (running)" "${status_output}"
+  unset STUB_TG_SYSTEMD_ACTIVE
+
+  reset_lifecycle_logs
+  logs_output="$(telegram_bot_logs 2>&1)"
+  assert_contains_str "logs delegates to journalctl output" \
+    "telegram bot journal output" "${logs_output}"
+  assert_contains_str "logs targets the telegram bot unit" \
+    "journalctl -u ${SBX_TG_SERVICE_NAME}" "$(cat "${JOURNALCTL_LOG}")"
+
+  reset_lifecycle_logs
+  telegram_bot_disable >/dev/null 2>&1
+  assert_zero "telegram_bot_disable succeeds" "$?"
+  assert_eq "disable marks telegram.enabled=false" \
+    "false" "$(jq -r '.telegram.enabled' "${TEST_STATE_FILE}")"
+  if [[ ! -f "${SBX_TG_SVC}" ]]; then
+    test_result "disable removes the service unit file" "pass"
+  else
+    test_result "disable removes the service unit file" "fail"
+  fi
+  assert_contains_str "disable stops+disables service" \
+    "systemctl disable --now ${SBX_TG_SERVICE_NAME}" "$(cat "${SYSTEMCTL_LOG}")"
+else
+  echo "  (skipping lifecycle tests: jq not installed)"
+fi
+
+#==============================================================================
+# telegram_bot_run bootstrap offset handling.
+# First startup must discard backlog, persist the new offset, and avoid
+# executing the latest historical command.
+#==============================================================================
+echo ""
+echo "Testing telegram_bot_run bootstrap offset..."
+
+RUN_DISPATCH_LOG="${TEST_TMP_DIR}/run-dispatch.log"
+RUN_GET_UPDATES_LOG="${TEST_TMP_DIR}/run-get-updates.log"
+
+_tg_get_updates() {
+  local offset="${1:-}"
+  local output_file="${2:-}"
+  printf '%s\n' "${offset}" >>"${RUN_GET_UPDATES_LOG}"
+  cat >"${output_file}" <<'JSON'
+{"ok":true,"result":[{"update_id":41,"message":{"chat":{"id":99999},"text":"/restart"}}]}
+JSON
+  return 0
+}
+
+_tg_dispatch_command() {
+  printf '%s\n' "$*" >>"${RUN_DISPATCH_LOG}"
+  return 0
+}
+
+if command -v jq >/dev/null 2>&1; then
+  : >"${RUN_DISPATCH_LOG}"
+  : >"${RUN_GET_UPDATES_LOG}"
+  rm -f "${SBX_TG_OFFSET_FILE}"
+  BOT_TOKEN="123456789:AAEhBP0av28FrI51bX4nF12345678901234" \
+    SBX_TG_RUN_ONCE=1 telegram_bot_run >/dev/null 2>&1
+  assert_zero "telegram_bot_run succeeds in bootstrap discard mode" "$?"
+  assert_eq "first poll uses offset=-1 when offset file is absent" \
+    "-1" "$(head -n 1 "${RUN_GET_UPDATES_LOG}")"
+  sends=$(wc -l <"${RUN_DISPATCH_LOG}" | tr -d ' ')
+  assert_eq "bootstrap discard does not dispatch historical commands" "0" "${sends}"
+  assert_eq "bootstrap discard persists update_id+1 to offset file" \
+    "42" "$(_tg_load_offset)"
+else
+  echo "  (skipping run bootstrap tests: jq not installed)"
+fi
+
+#==============================================================================
 # Module is registered in install.sh modules array + contracts map
 # (mirrors tests/unit/test_cloudflare_tunnel.sh:298-309).
 #==============================================================================

--- a/tests/unit/test_telegram_bot.sh
+++ b/tests/unit/test_telegram_bot.sh
@@ -506,6 +506,232 @@ fi
 unset SBX_TG_SLEEP_CMD SBX_TG_CURL_CMD SBX_TG_BACKOFF_MAX_ATTEMPTS
 
 #==============================================================================
+# _tg_dispatch_command + _tg_handle_*: route commands to the right handler,
+# enforce authorization (silent reject), capture replies via _tg_send_message
+# shadow. Each external dependency (user_add, user_remove, sync, systemctl,
+# check_service_status, restart_service) is stubbed so we exercise the
+# routing logic without touching real state or services.
+#==============================================================================
+echo ""
+echo "Testing _tg_dispatch_command + handlers..."
+
+SEND_LOG="${TEST_TMP_DIR}/send.log"
+USER_ADD_LOG="${TEST_TMP_DIR}/user_add.log"
+USER_REMOVE_LOG="${TEST_TMP_DIR}/user_remove.log"
+SYSTEMCTL_LOG="${TEST_TMP_DIR}/systemctl.log"
+
+# Shadow _tg_send_message: capture every reply for assertion.
+_tg_send_message() {
+  printf '[chat=%s] %s\n' "$1" "$2" >>"${SEND_LOG}"
+  return 0
+}
+
+# Stub external dependencies. Each logs the args so we can assert downstream
+# side effects (e.g. that adduser triggered sync + restart).
+check_service_status() {
+  [[ "${STUB_SERVICE_ACTIVE:-1}" == "1" ]]
+}
+user_list() {
+  echo "alice  uuid-aaa  2025-01-01"
+  echo "bob    uuid-bbb  2025-01-02"
+}
+user_add() {
+  echo "user_add $*" >>"${USER_ADD_LOG}"
+  if [[ "${STUB_USER_ADD_FAIL:-0}" == "1" ]]; then
+    echo "User with name 'dup' already exists" >&2
+    return 1
+  fi
+  # Mimic the real user_add stdout
+  echo "Added user: ${2:-?} (uuid-stub)"
+  return 0
+}
+user_remove() {
+  echo "user_remove $*" >>"${USER_REMOVE_LOG}"
+  if [[ "${STUB_USER_REMOVE_FAIL:-0}" == "1" ]]; then
+    echo "User not found: $1" >&2
+    return 1
+  fi
+  echo "Removed user: $1 (uuid-stub)"
+  return 0
+}
+sync_users_to_config() { return 0; }
+restart_service() {
+  echo "restart_service called" >>"${SYSTEMCTL_LOG}"
+  if [[ "${STUB_RESTART_FAIL:-0}" == "1" ]]; then
+    echo "systemctl restart failed" >&2
+    return 1
+  fi
+  return 0
+}
+# Shadow systemctl so adduser/removeuser don't actually touch services.
+systemctl() {
+  echo "systemctl $*" >>"${SYSTEMCTL_LOG}"
+  return 0
+}
+
+# Whitelist chat_id 99999 in state.json.
+cat >"${TEST_STATE_FILE}" <<'JSON'
+{"version":"1.0","telegram":{"enabled":true,"admin_chat_ids":[99999]}}
+JSON
+
+reset_logs() {
+  : >"${SEND_LOG}"
+  : >"${USER_ADD_LOG}"
+  : >"${USER_REMOVE_LOG}"
+  : >"${SYSTEMCTL_LOG}"
+}
+
+# --- Authorization boundary --------------------------------------------------
+
+# Non-whitelisted chat → silent: NO sendMessage call at all.
+reset_logs
+_tg_dispatch_command 11111 status
+sends=$(wc -l <"${SEND_LOG}" | tr -d ' ')
+assert_eq "non-whitelisted chat → silent (0 replies)" "0" "${sends}"
+
+# Whitelisted chat → at least one reply.
+reset_logs
+_tg_dispatch_command 99999 status
+sends=$(wc -l <"${SEND_LOG}" | tr -d ' ')
+if [[ "${sends}" -ge 1 ]]; then
+  test_result "whitelisted chat → handler invoked" "pass"
+else
+  test_result "whitelisted chat → handler invoked" "fail"
+fi
+
+# Empty chat_id or empty cmd → reject.
+_tg_dispatch_command "" status
+assert_nonzero "dispatch empty chat_id rejected" "$?"
+_tg_dispatch_command 99999 ""
+assert_nonzero "dispatch empty cmd rejected" "$?"
+
+# --- /status routing ---------------------------------------------------------
+
+reset_logs
+STUB_SERVICE_ACTIVE=1 _tg_dispatch_command 99999 status
+reply=$(cat "${SEND_LOG}")
+assert_contains_str() {
+  local name="$1" needle="$2" haystack="$3"
+  if [[ "${haystack}" == *"${needle}"* ]]; then
+    test_result "${name}" "pass"
+  else
+    test_result "${name}" "fail"
+    echo "      missing: ${needle}"
+    echo "      in:      ${haystack}"
+  fi
+}
+assert_contains_str "/status active reply" "active" "${reply}"
+
+reset_logs
+STUB_SERVICE_ACTIVE=0 _tg_dispatch_command 99999 status
+reply=$(cat "${SEND_LOG}")
+assert_contains_str "/status inactive reply" "inactive" "${reply}"
+
+# --- /users routing ----------------------------------------------------------
+
+reset_logs
+_tg_dispatch_command 99999 users
+reply=$(cat "${SEND_LOG}")
+assert_contains_str "/users includes alice" "alice" "${reply}"
+assert_contains_str "/users includes bob" "bob" "${reply}"
+
+# --- /adduser routing -------------------------------------------------------
+
+# Happy path: triggers user_add + sync + restart.
+reset_logs
+_tg_dispatch_command 99999 adduser charlie
+reply=$(cat "${SEND_LOG}")
+ua=$(cat "${USER_ADD_LOG}")
+sysctl=$(cat "${SYSTEMCTL_LOG}")
+assert_contains_str "/adduser invokes user_add with --name <arg>" \
+  "user_add --name charlie" "${ua}"
+assert_contains_str "/adduser triggers systemctl restart" \
+  "systemctl restart sing-box" "${sysctl}"
+assert_contains_str "/adduser success reply contains ✅" "✅" "${reply}"
+
+# Missing arg.
+reset_logs
+_tg_dispatch_command 99999 adduser
+reply=$(cat "${SEND_LOG}")
+assert_contains_str "/adduser without arg shows usage" "Usage" "${reply}"
+ua=$(wc -l <"${USER_ADD_LOG}" | tr -d ' ')
+assert_eq "/adduser without arg does not call user_add" "0" "${ua}"
+
+# Invalid name (contains semicolon — shell metachar).
+reset_logs
+_tg_dispatch_command 99999 adduser "bad;name"
+reply=$(cat "${SEND_LOG}")
+assert_contains_str "/adduser invalid name rejected" "Invalid" "${reply}"
+ua=$(wc -l <"${USER_ADD_LOG}" | tr -d ' ')
+assert_eq "/adduser invalid name skips user_add" "0" "${ua}"
+
+# user_add fails → error reply, no restart.
+reset_logs
+STUB_USER_ADD_FAIL=1 _tg_dispatch_command 99999 adduser dup
+reply=$(cat "${SEND_LOG}")
+sysctl=$(cat "${SYSTEMCTL_LOG}")
+assert_contains_str "/adduser failure reply contains ❌" "❌" "${reply}"
+assert_eq "/adduser failure skips restart" "" "${sysctl}"
+unset STUB_USER_ADD_FAIL
+
+# --- /removeuser routing -----------------------------------------------------
+
+reset_logs
+_tg_dispatch_command 99999 removeuser alice
+reply=$(cat "${SEND_LOG}")
+ur=$(cat "${USER_REMOVE_LOG}")
+sysctl=$(cat "${SYSTEMCTL_LOG}")
+assert_contains_str "/removeuser invokes user_remove" \
+  "user_remove alice" "${ur}"
+assert_contains_str "/removeuser triggers systemctl restart" \
+  "systemctl restart sing-box" "${sysctl}"
+assert_contains_str "/removeuser success reply contains ✅" "✅" "${reply}"
+
+reset_logs
+_tg_dispatch_command 99999 removeuser
+reply=$(cat "${SEND_LOG}")
+assert_contains_str "/removeuser without arg shows usage" "Usage" "${reply}"
+
+reset_logs
+STUB_USER_REMOVE_FAIL=1 _tg_dispatch_command 99999 removeuser ghost
+reply=$(cat "${SEND_LOG}")
+assert_contains_str "/removeuser failure reply contains ❌" "❌" "${reply}"
+unset STUB_USER_REMOVE_FAIL
+
+# --- /restart routing --------------------------------------------------------
+
+reset_logs
+_tg_dispatch_command 99999 restart
+reply=$(cat "${SEND_LOG}")
+assert_contains_str "/restart success reply" "restarted" "${reply}"
+
+reset_logs
+STUB_RESTART_FAIL=1 _tg_dispatch_command 99999 restart
+reply=$(cat "${SEND_LOG}")
+assert_contains_str "/restart failure reply" "Restart failed" "${reply}"
+unset STUB_RESTART_FAIL
+
+# --- /help and unknown command ----------------------------------------------
+
+reset_logs
+_tg_dispatch_command 99999 help
+reply=$(cat "${SEND_LOG}")
+assert_contains_str "/help lists /status" "/status" "${reply}"
+assert_contains_str "/help lists /adduser" "/adduser" "${reply}"
+
+# Unknown command falls back to help (per plan).
+reset_logs
+_tg_dispatch_command 99999 wat
+reply=$(cat "${SEND_LOG}")
+assert_contains_str "unknown command falls back to help" "/help" "${reply}"
+
+# /start (Telegram convention) also shows help.
+reset_logs
+_tg_dispatch_command 99999 start
+reply=$(cat "${SEND_LOG}")
+assert_contains_str "/start aliases to help" "/status" "${reply}"
+
+#==============================================================================
 # Module is registered in install.sh modules array + contracts map
 # (mirrors tests/unit/test_cloudflare_tunnel.sh:298-309).
 #==============================================================================


### PR DESCRIPTION
## Summary
- add Telegram Bot remote management support, including setup, enable/disable, status, logs, admin management, and runtime polling/command dispatch
- wire the feature into `sbx-manager`, install/uninstall flows, and add the `sbx-telegram-bot` launcher
- document the feature and add focused unit coverage for CLI routing, launcher behavior, lifecycle helpers, and bootstrap/install regressions

## Why
This branch completes the Telegram Bot management workflow so operators can manage core actions remotely through Telegram instead of logging into the host for routine tasks.

## Review Fixes
- discard the initial Telegram backlog on first startup by advancing and persisting the offset without dispatching historical updates
- make one-liner installs fail fast if `sbx-telegram-bot` cannot be downloaded, so `sbx telegram enable` cannot succeed with a missing launcher

## Impact
- introduces a documented Telegram Bot management surface for install, runtime, and admin operations
- avoids executing stale pre-enable Telegram commands during first service startup
- prevents partially successful installs that would later fail at runtime because the launcher binary is absent

## Verification
- `bash tests/test-runner.sh unit`
- `bash tests/unit/test_bootstrap_constants.sh`
- `bash -u install.sh --help`
