### PR TITLE
[codex] fix state.json locking races

### DIFF
--- a/bin/sbx-manager.sh
+++ b/bin/sbx-manager.sh
@@ -1292,14 +1292,12 @@ case "${1:-}" in
         }
         apply_port_hopping_rules "${_ph_hy2_port}" "${3%%-*}" "${3##*-}"
         persist_port_hopping_rules "${_ph_hy2_port}" "${3%%-*}" "${3##*-}"
-        # Update state.json atomically
-        _ph_tmp=$(mktemp)
-        if ! jq --arg range "${3}" '.protocols.hysteria2.port_range = $range' "${STATE_INFO_PATH}" >"${_ph_tmp}" || ! mv "${_ph_tmp}" "${STATE_INFO_PATH}"; then
-          rm -f "${_ph_tmp}"
+        if ! state_json_apply "${STATE_INFO_PATH}" \
+          '.protocols.hysteria2.port_range = $range' \
+          --arg range "${3}"; then
           echo -e "${R}[ERR]${N} Failed to update state.json. DNAT rules were applied but state is stale."
           exit 1
         fi
-        chmod 600 "${STATE_INFO_PATH}"
         declare -f subscription_refresh_cache >/dev/null 2>&1 && subscription_refresh_cache || true
         echo -e "${G}✓${N} Port hopping enabled: UDP ${3} → ${_ph_hy2_port}"
         ;;
@@ -1314,13 +1312,11 @@ case "${1:-}" in
           exit 0
         fi
         remove_port_hopping_rules "${_ph_port}" "${_ph_range%%-*}" "${_ph_range##*-}"
-        _ph_tmp=$(mktemp)
-        if ! jq '.protocols.hysteria2.port_range = null' "${STATE_INFO_PATH}" >"${_ph_tmp}" || ! mv "${_ph_tmp}" "${STATE_INFO_PATH}"; then
-          rm -f "${_ph_tmp}"
+        if ! state_json_apply "${STATE_INFO_PATH}" \
+          '.protocols.hysteria2.port_range = null'; then
           echo -e "${R}[ERR]${N} Failed to update state.json. DNAT rules were removed but state is stale."
           exit 1
         fi
-        chmod 600 "${STATE_INFO_PATH}"
         declare -f subscription_refresh_cache >/dev/null 2>&1 && subscription_refresh_cache || true
         echo -e "${G}✓${N} Port hopping disabled"
         ;;

--- a/install.sh
+++ b/install.sh
@@ -1489,6 +1489,30 @@ EOF
 }
 
 # Save structured state for future compatibility and typed access.
+_save_state_info_locked() {
+  local state_file="$1"
+  local state_json="$2"
+  local state_dir=''
+  state_dir="$(dirname "${state_file}")"
+  mkdir -p "${state_dir}" || return 1
+
+  if [[ ! -f "${state_file}" ]]; then
+    install -m "${SECURE_FILE_PERMISSIONS}" /dev/null "${state_file}" || return 1
+    printf '{}\n' >"${state_file}" || return 1
+  fi
+
+  local tmp_file=''
+  tmp_file=$(create_temp_file_in_dir "${state_dir}" "state-json") || return 1
+  printf '%s\n' "${state_json}" >"${tmp_file}" || {
+    rm -f "${tmp_file}" 2>/dev/null || true
+    return 1
+  }
+  chmod --reference="${state_file}" "${tmp_file}" 2>/dev/null ||
+    chmod "${SECURE_FILE_PERMISSIONS}" "${tmp_file}" 2>/dev/null || true
+  chown --reference="${state_file}" "${tmp_file}" 2>/dev/null || true
+  mv -f "${tmp_file}" "${state_file}"
+}
+
 save_state_info() {
   msg "Saving structured state..."
 
@@ -1522,6 +1546,7 @@ save_state_info() {
   local tuic_pass=''
   local trojan_port=''
   local trojan_pass=''
+  local state_json=''
 
   if [[ "${REALITY_ONLY_MODE:-0}" != "1" ]]; then
     local enable_ws="${ENABLE_WS:-}"
@@ -1559,7 +1584,7 @@ save_state_info() {
     cert_key="${CERT_KEY:-}"
   fi
 
-  jq -n \
+  state_json=$(jq -n \
     --arg version "1.0" \
     --arg installed_at "${installed_at}" \
     --arg singbox_version "${resolved_version}" \
@@ -1649,8 +1674,10 @@ save_state_info() {
         hostname: (if $tunnel_hostname == "" then null else $tunnel_hostname end),
         upstream_port: (if $tunnel_upstream == 0 then null else $tunnel_upstream end)
       }
-    }' >"${state_file}"
+    }') || return 1
 
+  with_state_lock "${SBX_LOCK_TIMEOUT_SEC:-30}" \
+    _save_state_info_locked "${state_file}" "${state_json}" || return 1
   chmod "${SECURE_FILE_PERMISSIONS}" "${state_file}"
   success "  ✓ State saved to: ${state_file}"
 }

--- a/lib/cloudflare_tunnel.sh
+++ b/lib/cloudflare_tunnel.sh
@@ -333,29 +333,20 @@ cloudflared_update_state() {
   }
 
   [[ "${enabled}" == "true" ]] || enabled="false"
-
-  local tmp=""
-  tmp=$(create_temp_file "tunnel-state") || return 1
-  # shellcheck disable=SC2064
-  trap "rm -f '${tmp}'" RETURN
-
-  if ! jq \
-    --argjson enabled "${enabled}" \
-    --arg mode "${mode}" \
-    --arg hostname "${hostname}" \
-    --argjson upstream "${upstream_port:-0}" \
+  if ! state_json_apply "${state_file}" \
     '.tunnel = {
        enabled: $enabled,
        mode: (if $mode == "" then null else $mode end),
        hostname: (if $hostname == "" then null else $hostname end),
        upstream_port: (if $upstream == 0 then null else $upstream end)
-     }' "${state_file}" >"${tmp}"; then
+     }' \
+    --argjson enabled "${enabled}" \
+    --arg mode "${mode}" \
+    --arg hostname "${hostname}" \
+    --argjson upstream "${upstream_port:-0}"; then
     err "Failed to update tunnel state in ${state_file}"
     return 1
   fi
-
-  mv "${tmp}" "${state_file}"
-  chmod "${SECURE_FILE_PERMISSIONS:-600}" "${state_file}"
 }
 
 cloudflared_current_hostname() {

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -637,6 +637,94 @@ with_flock() {
   ) 200>"${lock_file}"
 }
 
+# Run a command under the dedicated state.json process lock.
+# Usage:
+#   with_state_lock 30 my_command arg1 arg2
+#   with_state_lock my_command arg1 arg2
+with_state_lock() {
+  local timeout=30
+  local previous_lock_file="${SBX_LOCK_FILE-__SBX_LOCK_UNSET__}"
+
+  if [[ "${1:-}" =~ ^[0-9]+$ ]]; then
+    timeout="$1"
+    shift
+  fi
+
+  SBX_LOCK_FILE="${SBX_STATE_LOCK_FILE:-/var/lock/sbx-state.lock}"
+  with_flock "${timeout}" "$@"
+  local status=$?
+
+  if [[ "${previous_lock_file}" == "__SBX_LOCK_UNSET__" ]]; then
+    unset SBX_LOCK_FILE
+  else
+    SBX_LOCK_FILE="${previous_lock_file}"
+  fi
+
+  return "${status}"
+}
+
+_state_json_apply_impl() {
+  local state_file="$1"
+  local filter="$2"
+  shift 2
+
+  [[ -n "${state_file}" ]] || {
+    err "state_json_apply requires a state file path"
+    return 1
+  }
+  [[ -n "${filter}" ]] || {
+    err "state_json_apply requires a jq filter"
+    return 1
+  }
+  [[ -f "${state_file}" ]] || {
+    err "State file not found: ${state_file}"
+    return 1
+  }
+  have jq || {
+    err "jq is required to update state"
+    return 1
+  }
+
+  local state_dir=''
+  state_dir="$(dirname "${state_file}")"
+  local tmp_file=''
+  tmp_file=$(create_temp_file_in_dir "${state_dir}" "state-json") || return 1
+
+  if ! jq "$@" "${filter}" "${state_file}" >"${tmp_file}" 2>/dev/null; then
+    rm -f "${tmp_file}" 2>/dev/null || true
+    err "Failed to update state file: ${state_file}"
+    return 1
+  fi
+
+  chmod --reference="${state_file}" "${tmp_file}" 2>/dev/null ||
+    chmod "${SECURE_FILE_PERMISSIONS:-600}" "${tmp_file}" 2>/dev/null || true
+  chown --reference="${state_file}" "${tmp_file}" 2>/dev/null || true
+  mv -f "${tmp_file}" "${state_file}"
+}
+
+# Apply a jq filter to state.json while the caller already holds the state lock.
+# Usage:
+#   with_state_lock 30 state_json_apply_locked /path/to/state.json '.foo = "bar"'
+state_json_apply_locked() {
+  local state_file="${1:-}"
+  local filter="${2:-}"
+  shift 2 || true
+
+  _state_json_apply_impl "${state_file}" "${filter}" "$@"
+}
+
+# Apply a jq filter to state.json under the dedicated process lock.
+# Usage:
+#   state_json_apply /path/to/state.json '.subscription.enabled = true'
+#   state_json_apply /path/to/state.json '.foo = $bar' --arg bar baz
+state_json_apply() {
+  local state_file="${1:-}"
+  local filter="${2:-}"
+  shift 2 || true
+
+  with_state_lock "${SBX_LOCK_TIMEOUT_SEC:-30}" _state_json_apply_impl "${state_file}" "${filter}" "$@"
+}
+
 #==============================================================================
 # Module Initialization
 #==============================================================================
@@ -656,6 +744,6 @@ trap cleanup EXIT INT TERM
 # Export core utility functions
 export -f need_root have safe_rm_temp get_file_size cleanup \
   create_temp_dir create_temp_dir_in_dir create_temp_file create_temp_file_in_dir \
-  with_flock
+  with_flock with_state_lock state_json_apply_locked state_json_apply
 
 # Note: Logging and generator functions are exported by their respective modules

--- a/lib/subscription.sh
+++ b/lib/subscription.sh
@@ -251,7 +251,6 @@ _subscription_state_set() {
   local value="$2"
   local mode="${3:-string}"
   local state_file=''
-  local tmp=''
   state_file=$(_subscription_state_file)
   [[ -f "${state_file}" ]] || {
     err "state.json not found: ${state_file}"
@@ -261,19 +260,16 @@ _subscription_state_set() {
     err "jq required to update state.json"
     return 1
   }
-  local jq_flag="--arg"
-  [[ "${mode}" == "json" ]] && jq_flag="--argjson"
-  tmp=$(mktemp) || return 1
-  if ! jq ${jq_flag} v "${value}" ".subscription.${field} = \$v" "${state_file}" >"${tmp}"; then
-    rm -f "${tmp}"
+  local -a jq_args=()
+  if [[ "${mode}" == "json" ]]; then
+    jq_args=(--argjson v "${value}")
+  else
+    jq_args=(--arg v "${value}")
+  fi
+  if ! state_json_apply "${state_file}" ".subscription.${field} = \$v" "${jq_args[@]}"; then
     err "Failed to update state.json field subscription.${field}"
     return 1
   fi
-  # Preserve existing ownership/permissions (may include group-read for sbx-sub)
-  chmod --reference="${state_file}" "${tmp}" 2>/dev/null ||
-    chmod 600 "${tmp}" 2>/dev/null || true
-  chown --reference="${state_file}" "${tmp}" 2>/dev/null || true
-  mv -f "${tmp}" "${state_file}"
 }
 
 # Merge a default subscription block into state.json if it's missing.
@@ -281,7 +277,6 @@ _subscription_state_set() {
 # enabled=false. Re-invocable and idempotent.
 subscription_ensure_state_block() {
   local state_file=''
-  local tmp=''
   state_file=$(_subscription_state_file)
   [[ -f "${state_file}" ]] || return 0
   have jq || return 0
@@ -290,11 +285,7 @@ subscription_ensure_state_block() {
     return 0
   fi
 
-  tmp=$(mktemp) || return 1
-  if ! jq \
-    --argjson port "${SUBSCRIPTION_PORT_DEFAULT}" \
-    --arg bind "${SUBSCRIPTION_BIND_DEFAULT}" \
-    --arg path "${SUBSCRIPTION_PATH_DEFAULT}" \
+  if ! state_json_apply "${state_file}" \
     '.subscription = {
         enabled: false,
         port: $port,
@@ -302,14 +293,12 @@ subscription_ensure_state_block() {
         token: "",
         path: $path,
         created_at: null
-      }' "${state_file}" >"${tmp}"; then
-    rm -f "${tmp}"
+      }' \
+    --argjson port "${SUBSCRIPTION_PORT_DEFAULT}" \
+    --arg bind "${SUBSCRIPTION_BIND_DEFAULT}" \
+    --arg path "${SUBSCRIPTION_PATH_DEFAULT}"; then
     return 1
   fi
-  chmod --reference="${state_file}" "${tmp}" 2>/dev/null ||
-    chmod 600 "${tmp}" 2>/dev/null || true
-  chown --reference="${state_file}" "${tmp}" 2>/dev/null || true
-  mv -f "${tmp}" "${state_file}"
 }
 
 #==============================================================================
@@ -393,25 +382,47 @@ subscription_enable() {
 
   subscription_ensure_state_block || return 1
 
-  local token=''
-  token=$(_subscription_state_get token)
-  if [[ -z "${token}" || "${rotate}" -eq 1 ]]; then
-    token=$(_subscription_generate_token) || return 1
-    _subscription_state_set token "${token}" || return 1
-  fi
-
-  # Apply bind/port overrides from environment if provided
-  if [[ -n "${SUB_BIND:-}" ]]; then
-    _subscription_state_set bind "${SUB_BIND}" || return 1
-  fi
-  if [[ -n "${SUB_PORT:-}" ]]; then
-    _subscription_state_set port "${SUB_PORT}" json || return 1
-  fi
-
+  local state_file=''
+  state_file=$(_subscription_state_file)
+  local generated_token=''
+  generated_token=$(_subscription_generate_token) || return 1
+  local bind=''
+  bind="${SUB_BIND:-${SUBSCRIPTION_BIND_DEFAULT}}"
+  local port=''
+  port="${SUB_PORT:-${SUBSCRIPTION_PORT_DEFAULT}}"
   local now=''
   now=$(date -Iseconds 2>/dev/null || date)
-  _subscription_state_set created_at "${now}" || true
-  _subscription_state_set enabled true json || return 1
+  if ! state_json_apply "${state_file}" \
+    '.subscription as $sub
+     | .subscription = (
+         ($sub // {
+           enabled: false,
+           port: $default_port,
+           bind: $default_bind,
+           token: "",
+           path: $default_path,
+           created_at: null
+         }) as $current
+         | $current + {
+             enabled: true,
+             port: $port,
+             bind: $bind,
+             path: ($current.path // $default_path),
+             created_at: $now,
+             token: (if $rotate or (($current.token // "") == "") then $generated_token else $current.token end)
+           }
+       )' \
+    --argjson rotate "$([[ "${rotate}" -eq 1 ]] && echo true || echo false)" \
+    --arg generated_token "${generated_token}" \
+    --arg bind "${bind}" \
+    --argjson port "${port}" \
+    --arg now "${now}" \
+    --argjson default_port "${SUBSCRIPTION_PORT_DEFAULT}" \
+    --arg default_bind "${SUBSCRIPTION_BIND_DEFAULT}" \
+    --arg default_path "${SUBSCRIPTION_PATH_DEFAULT}"; then
+    err "Failed to enable subscription state"
+    return 1
+  fi
 
   _subscription_grant_state_read
   subscription_refresh_cache || true

--- a/lib/telegram_bot.sh
+++ b/lib/telegram_bot.sh
@@ -595,19 +595,44 @@ _tg_update_state() {
   done
 
   local filter=". + {telegram: (${merge})}"
-
-  local tmp=""
-  tmp=$(mktemp "${state_file}.XXXXXX") || return 1
-  # shellcheck disable=SC2064
-  trap "rm -f '${tmp}'" RETURN
-
-  if ! jq "${jq_args[@]}" "${filter}" "${state_file}" >"${tmp}" 2>/dev/null; then
+  if ! state_json_apply "${state_file}" "${filter}" "${jq_args[@]}"; then
     err "_tg_update_state: jq filter failed"
     return 1
   fi
+}
 
-  mv -f "${tmp}" "${state_file}"
-  chmod "${SECURE_FILE_PERMISSIONS:-600}" "${state_file}" 2>/dev/null || true
+_tg_update_admin_chat_ids_locked() {
+  local state_file="${1:-}"
+  local action="${2:-}"
+  local chat_id="${3:-}"
+  local filter=''
+
+  case "${action}" in
+    add)
+      filter='.telegram = ((.telegram // {}) + {
+        admin_chat_ids: (
+          ((.telegram.admin_chat_ids // []) | map(tonumber? // .)) as $ids
+          | if ($ids | index($chat_id)) == null then $ids + [$chat_id] else $ids end
+        )
+      })'
+      ;;
+    remove)
+      filter='.telegram = ((.telegram // {}) + {
+        admin_chat_ids: (
+          ((.telegram.admin_chat_ids // []) | map(tonumber? // .) | map(select(. != $chat_id)))
+        )
+      })'
+      ;;
+    *)
+      err "_tg_update_admin_chat_ids_locked: unsupported action '${action}'"
+      return 1
+      ;;
+  esac
+
+  state_json_apply_locked "${state_file}" "${filter}" --argjson chat_id "${chat_id}" || {
+    err "Failed to update Telegram admin_chat_ids"
+    return 1
+  }
 }
 
 # _tg_process_updates_file <file> <offset_var_name>
@@ -811,13 +836,8 @@ telegram_bot_admin_add() {
     return 1
   }
 
-  local admins_json=""
-  admins_json=$(jq -c --argjson id "${chat_id}" \
-    '(.telegram.admin_chat_ids // []) | map(tonumber? // .) |
-     if index($id) == null then . + [$id] else . end' \
-    "${state_file}" 2>/dev/null) || return 1
-
-  _tg_update_state "admin_chat_ids=${admins_json}" || return 1
+  with_state_lock "${SBX_LOCK_TIMEOUT_SEC:-30}" \
+    _tg_update_admin_chat_ids_locked "${state_file}" add "${chat_id}" || return 1
   success "  ✓ Added Telegram admin chat ID: ${chat_id}"
 }
 
@@ -842,13 +862,8 @@ telegram_bot_admin_remove() {
     return 1
   }
 
-  local admins_json=""
-  admins_json=$(jq -c --argjson id "${chat_id}" \
-    '(.telegram.admin_chat_ids // []) | map(tonumber? // .) |
-     map(select(. != $id))' \
-    "${state_file}" 2>/dev/null) || return 1
-
-  _tg_update_state "admin_chat_ids=${admins_json}" || return 1
+  with_state_lock "${SBX_LOCK_TIMEOUT_SEC:-30}" \
+    _tg_update_admin_chat_ids_locked "${state_file}" remove "${chat_id}" || return 1
   success "  ✓ Removed Telegram admin chat ID: ${chat_id}"
 }
 

--- a/lib/users.sh
+++ b/lib/users.sh
@@ -77,7 +77,7 @@ _load_users() {
 # compatibility with load_client_info() in lib/export.sh.
 #
 # Args: users_json (JSON array string)
-_save_users() {
+_save_users_locked() {
   local users_json="$1"
   local state_file=''
   state_file=$(_resolve_state_file)
@@ -90,26 +90,114 @@ _save_users() {
   local first_uuid=''
   first_uuid=$(echo "${users_json}" | jq -r '.[0].uuid // empty' 2>/dev/null || true)
 
-  local tmp_file=''
-  tmp_file=$(mktemp "${state_file}.XXXXXX")
-
-  if jq \
-    --argjson users "${users_json}" \
-    --arg first_uuid "${first_uuid}" \
+  if ! state_json_apply_locked "${state_file}" \
     '.protocols.reality.users = $users |
      if $first_uuid != "" then .protocols.reality.uuid = $first_uuid else . end' \
-    "${state_file}" >"${tmp_file}" 2>/dev/null; then
-    chmod 600 "${tmp_file}"
-    # Skip ownership enforcement in test mode (TEST_STATE_FILE set)
-    if [[ -z "${TEST_STATE_FILE:-}" ]]; then
-      chown root:root "${tmp_file}" 2>/dev/null || true
-    fi
-    mv "${tmp_file}" "${state_file}"
-  else
-    rm -f "${tmp_file}"
+    --argjson users "${users_json}" \
+    --arg first_uuid "${first_uuid}"; then
     err "Failed to update state file"
     return 1
   fi
+}
+
+_save_users() {
+  with_state_lock "${SBX_LOCK_TIMEOUT_SEC:-30}" _save_users_locked "$@"
+}
+
+_user_add_locked() {
+  local requested_name="${1:-}"
+  local uuid="${2:-}"
+  local created_at="${3:-}"
+  local users=''
+  users=$(_load_users)
+
+  local name="${requested_name}"
+  if [[ -z "${name}" ]]; then
+    local count=0
+    count=$(echo "${users}" | jq 'length')
+    name="user$((count + 1))"
+  fi
+
+  local existing=''
+  existing=$(echo "${users}" | jq -r --arg name "${name}" '.[] | select(.name == $name) | .name' 2>/dev/null || true)
+  if [[ -n "${existing}" ]]; then
+    err "User with name '${name}' already exists"
+    return 1
+  fi
+
+  local new_user=''
+  new_user=$(jq -n \
+    --arg name "${name}" \
+    --arg uuid "${uuid}" \
+    --arg created_at "${created_at}" \
+    '{name: $name, uuid: $uuid, created_at: $created_at}')
+
+  local updated_users=''
+  updated_users=$(echo "${users}" | jq --argjson user "${new_user}" '. + [$user]')
+
+  _save_users_locked "${updated_users}" || return 1
+  echo "Added user: ${name} (${uuid})"
+}
+
+_user_remove_locked() {
+  local id="${1:-}"
+  local users=''
+  users=$(_load_users)
+
+  local count=0
+  count=$(echo "${users}" | jq 'length')
+
+  if [[ "${count}" -le 1 ]]; then
+    err "Cannot remove the last user"
+    return 1
+  fi
+
+  local found_info=''
+  found_info=$(echo "${users}" | jq -r --arg id "${id}" \
+    '(.[] | select(.uuid == $id or .name == $id) | [(.name // "?"), .uuid]) | @tsv' 2>/dev/null | head -1 || true)
+
+  if [[ -z "${found_info}" ]]; then
+    err "User not found: ${id}"
+    return 1
+  fi
+
+  local found_name='' found_uuid=''
+  IFS=$'\t' read -r found_name found_uuid <<<"${found_info}"
+
+  local updated_users=''
+  updated_users=$(echo "${users}" | jq --arg id "${id}" \
+    '[.[] | select(.uuid != $id and .name != $id)]')
+
+  _save_users_locked "${updated_users}" || return 1
+  echo "Removed user: ${found_name} (${found_uuid})"
+}
+
+_user_reset_locked() {
+  local id="${1:-}"
+  local new_uuid="${2:-}"
+  local users=''
+  users=$(_load_users)
+
+  local found_info=''
+  found_info=$(echo "${users}" | jq -r --arg id "${id}" \
+    '(.[] | select(.uuid == $id or .name == $id) | [(.name // "?"), .uuid]) | @tsv' 2>/dev/null | head -1 || true)
+
+  if [[ -z "${found_info}" ]]; then
+    err "User not found: ${id}"
+    return 1
+  fi
+
+  local found_name='' old_uuid=''
+  IFS=$'\t' read -r found_name old_uuid <<<"${found_info}"
+
+  local updated_users=''
+  updated_users=$(echo "${users}" | jq \
+    --arg id "${id}" \
+    --arg new_uuid "${new_uuid}" \
+    '[.[] | if (.uuid == $id or .name == $id) then .uuid = $new_uuid else . end]')
+
+  _save_users_locked "${updated_users}" || return 1
+  echo "Reset user ${found_name}: new UUID = ${new_uuid}"
 }
 
 #==============================================================================
@@ -140,27 +228,9 @@ user_add() {
     esac
   done
 
-  local users=''
-  users=$(_load_users)
-
-  # Auto-generate name if not provided
-  if [[ -z "${name}" ]]; then
-    local count=0
-    count=$(echo "${users}" | jq 'length')
-    name="user$((count + 1))"
-  fi
-
   # Validate name characters
-  if ! [[ "${name}" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+  if [[ -n "${name}" ]] && ! [[ "${name}" =~ ^[a-zA-Z0-9_-]+$ ]]; then
     err "Invalid user name '${name}': use alphanumeric characters, underscores, or dashes only"
-    return 1
-  fi
-
-  # Check name uniqueness
-  local existing=''
-  existing=$(echo "${users}" | jq -r --arg name "${name}" '.[] | select(.name == $name) | .name' 2>/dev/null || true)
-  if [[ -n "${existing}" ]]; then
-    err "User with name '${name}' already exists"
     return 1
   fi
 
@@ -172,20 +242,8 @@ user_add() {
 
   local created_at=''
   created_at=$(date -Iseconds 2>/dev/null || date)
-
-  local new_user=''
-  new_user=$(jq -n \
-    --arg name "${name}" \
-    --arg uuid "${uuid}" \
-    --arg created_at "${created_at}" \
-    '{name: $name, uuid: $uuid, created_at: $created_at}')
-
-  local updated_users=''
-  updated_users=$(echo "${users}" | jq --argjson user "${new_user}" '. + [$user]')
-
-  _save_users "${updated_users}" || return 1
-
-  echo "Added user: ${name} (${uuid})"
+  with_state_lock "${SBX_LOCK_TIMEOUT_SEC:-30}" \
+    _user_add_locked "${name}" "${uuid}" "${created_at}"
 }
 
 # List all users in a formatted table.
@@ -222,37 +280,7 @@ user_remove() {
     return 1
   }
 
-  local users=''
-  users=$(_load_users)
-
-  local count=0
-  count=$(echo "${users}" | jq 'length')
-
-  if [[ "${count}" -le 1 ]]; then
-    err "Cannot remove the last user"
-    return 1
-  fi
-
-  # Find user and remove in one pass
-  local found_info=''
-  found_info=$(echo "${users}" | jq -r --arg id "${id}" \
-    '(.[] | select(.uuid == $id or .name == $id) | [(.name // "?"), .uuid]) | @tsv' 2>/dev/null | head -1 || true)
-
-  if [[ -z "${found_info}" ]]; then
-    err "User not found: ${id}"
-    return 1
-  fi
-
-  local found_name='' found_uuid=''
-  IFS=$'\t' read -r found_name found_uuid <<<"${found_info}"
-
-  local updated_users=''
-  updated_users=$(echo "${users}" | jq --arg id "${id}" \
-    '[.[] | select(.uuid != $id and .name != $id)]')
-
-  _save_users "${updated_users}" || return 1
-
-  echo "Removed user: ${found_name} (${found_uuid})"
+  with_state_lock "${SBX_LOCK_TIMEOUT_SEC:-30}" _user_remove_locked "${id}"
 }
 
 # Regenerate the UUID for an existing user.
@@ -266,37 +294,13 @@ user_reset() {
     return 1
   }
 
-  local users=''
-  users=$(_load_users)
-
-  # Find user by UUID or name
-  local found_info=''
-  found_info=$(echo "${users}" | jq -r --arg id "${id}" \
-    '(.[] | select(.uuid == $id or .name == $id) | [(.name // "?"), .uuid]) | @tsv' 2>/dev/null | head -1 || true)
-
-  if [[ -z "${found_info}" ]]; then
-    err "User not found: ${id}"
-    return 1
-  fi
-
-  local found_name='' old_uuid=''
-  IFS=$'\t' read -r found_name old_uuid <<<"${found_info}"
-
   local new_uuid=''
   new_uuid=$(generate_uuid) || {
     err "Failed to generate UUID"
     return 1
   }
-
-  local updated_users=''
-  updated_users=$(echo "${users}" | jq \
-    --arg id "${id}" \
-    --arg new_uuid "${new_uuid}" \
-    '[.[] | if (.uuid == $id or .name == $id) then .uuid = $new_uuid else . end]')
-
-  _save_users "${updated_users}" || return 1
-
-  echo "Reset user ${found_name}: new UUID = ${new_uuid}"
+  with_state_lock "${SBX_LOCK_TIMEOUT_SEC:-30}" \
+    _user_reset_locked "${id}" "${new_uuid}"
 }
 
 #==============================================================================

--- a/tests/unit/test_state_json_locking.sh
+++ b/tests/unit/test_state_json_locking.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# tests/unit/test_state_json_locking.sh
+# Verifies the shared state.json write helper and that current writers use it.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../test_framework.sh"
+
+TEST_TMP=""
+STATE_FILE_PATH=""
+
+setup_fixture() {
+  TEST_TMP=$(mktemp -d /tmp/sbx-state-locking.XXXXXX)
+  STATE_FILE_PATH="${TEST_TMP}/state.json"
+  cat >"${STATE_FILE_PATH}" <<'EOF'
+{
+  "subscription": {
+    "enabled": false,
+    "port": 8838,
+    "bind": "127.0.0.1",
+    "token": "",
+    "path": "/sub",
+    "created_at": null
+  },
+  "protocols": {
+    "hysteria2": {
+      "enabled": true,
+      "port": 8443,
+      "port_range": null
+    },
+    "reality": {
+      "users": [],
+      "uuid": "legacy-uuid"
+    }
+  },
+  "telegram": {
+    "enabled": false,
+    "username": "",
+    "admin_chat_ids": []
+  },
+  "tunnel": {
+    "enabled": false,
+    "mode": null,
+    "hostname": null,
+    "upstream_port": null
+  }
+}
+EOF
+  chmod 600 "${STATE_FILE_PATH}"
+}
+
+teardown_fixture() {
+  [[ -n "${TEST_TMP:-}" && -d "${TEST_TMP}" ]] && rm -rf "${TEST_TMP}"
+}
+
+test_state_json_apply_updates_fixture() {
+  TEST_STATE_FILE="${STATE_FILE_PATH}" \
+    bash -c "
+      source '${PROJECT_ROOT}/lib/common.sh'
+      state_json_apply '${STATE_FILE_PATH}' '.subscription.enabled = true'
+    "
+
+  assert_success "jq -e '.subscription.enabled == true' '${STATE_FILE_PATH}' >/dev/null" \
+    "state_json_apply updates the target file"
+  local perm=''
+  perm=$(stat -c '%a' "${STATE_FILE_PATH}" 2>/dev/null || stat -f '%Lp' "${STATE_FILE_PATH}" 2>/dev/null)
+  assert_equals "600" "${perm}" "state_json_apply preserves secure permissions"
+}
+
+test_common_exports_state_locking_helpers() {
+  local common_funcs=''
+  common_funcs=$(bash -c "
+    source '${PROJECT_ROOT}/lib/common.sh'
+    declare -f with_state_lock
+    printf '\\n--FUNC--\\n'
+    declare -f state_json_apply
+  ")
+
+  assert_contains "${common_funcs}" "with_state_lock (" "with_state_lock helper exists"
+  assert_contains "${common_funcs}" "sbx-state.lock" "state lock file is dedicated"
+  assert_contains "${common_funcs}" "state_json_apply (" "state_json_apply helper exists"
+}
+
+test_state_writers_use_shared_helper() {
+  local subscription_funcs=''
+  subscription_funcs=$(bash -c "
+    source '${PROJECT_ROOT}/lib/common.sh'
+    source '${PROJECT_ROOT}/lib/subscription.sh'
+    declare -f _subscription_state_set
+    printf '\\n--FUNC--\\n'
+    declare -f subscription_ensure_state_block
+  ")
+  assert_contains "${subscription_funcs}" "state_json_apply" \
+    "subscription writers use shared state helper"
+
+  local telegram_func=''
+  telegram_func=$(bash -c "
+    source '${PROJECT_ROOT}/lib/common.sh'
+    source '${PROJECT_ROOT}/lib/telegram_bot.sh'
+    declare -f _tg_update_state
+  ")
+  assert_contains "${telegram_func}" "state_json_apply" \
+    "telegram writer uses shared state helper"
+
+  local tunnel_func=''
+  tunnel_func=$(bash -c "
+    source '${PROJECT_ROOT}/lib/common.sh'
+    source '${PROJECT_ROOT}/lib/cloudflare_tunnel.sh'
+    declare -f cloudflared_update_state
+  ")
+  assert_contains "${tunnel_func}" "state_json_apply" \
+    "tunnel writer uses shared state helper"
+
+  local users_func=''
+  users_func=$(bash -c "
+    source '${PROJECT_ROOT}/lib/common.sh'
+    source '${PROJECT_ROOT}/lib/users.sh'
+    declare -f _save_users_locked
+  ")
+  assert_contains "${users_func}" "state_json_apply_locked" \
+    "users writer uses shared state helper"
+
+  assert_success "grep -q 'state_json_apply' '${PROJECT_ROOT}/bin/sbx-manager.sh'" \
+    "sbx-manager uses shared state helper"
+  assert_success "grep -Eq 'with_state_lock|state_json_apply' '${PROJECT_ROOT}/install.sh'" \
+    "install state write uses state lock"
+}
+
+test_state_mutations_avoid_stale_pre_reads() {
+  local user_mutators=''
+  user_mutators=$(bash -c "
+    source '${PROJECT_ROOT}/lib/common.sh'
+    source '${PROJECT_ROOT}/lib/users.sh'
+    declare -f user_add
+    printf '\\n--FUNC--\\n'
+    declare -f user_remove
+    printf '\\n--FUNC--\\n'
+    declare -f user_reset
+  ")
+  assert_not_contains "${user_mutators}" "_load_users" \
+    "user mutators do not snapshot users outside the lock"
+
+  local telegram_admin_mutators=''
+  telegram_admin_mutators=$(bash -c "
+    source '${PROJECT_ROOT}/lib/common.sh'
+    source '${PROJECT_ROOT}/lib/telegram_bot.sh'
+    declare -f telegram_bot_admin_add
+    printf '\\n--FUNC--\\n'
+    declare -f telegram_bot_admin_remove
+  ")
+  assert_not_contains "${telegram_admin_mutators}" 'admins_json=$(jq -c' \
+    "telegram admin mutators do not precompute admin arrays outside the lock"
+}
+
+main() {
+  set +e
+  setup_fixture
+  echo "Running: state.json locking"
+  test_state_json_apply_updates_fixture
+  test_common_exports_state_locking_helpers
+  test_state_writers_use_shared_helper
+  test_state_mutations_avoid_stale_pre_reads
+  teardown_fixture
+  print_test_summary
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add shared `state.json` locking helpers and migrate current writers onto the shared transaction path
- collapse `subscription_enable` into a single locked state mutation and lock install-time state writes
- fix remaining stale read-modify-write races in user CRUD and Telegram admin mutations, with locking-focused regression coverage

## Root Cause
Several commands were still doing shell-side read-modify-write cycles against `state.json`. Even when the final write was atomic, concurrent invocations could compute updates from stale snapshots and silently overwrite each other.

## Validation
- [x] `bash tests/unit/test_state_json_locking.sh`
- [x] `bash tests/unit/test_user_management.sh`
- [x] `bash tests/unit/test_telegram_bot.sh`
- [x] `bash tests/unit/test_subscription_token.sh`
- [x] `bash tests/unit/test_subscription_state_schema.sh`
- [x] `bash tests/unit/test_cloudflare_tunnel.sh`
- [x] `bash tests/unit/test_install_state_persistence.sh`
- [x] `bash tests/test-runner.sh unit`
- [x] `bash -u install.sh --help`
