### PR TITLE
[codex] refactor systemd unit helpers

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2189,6 +2189,8 @@ uninstall_flow() {
   # Remove subscription endpoint (unit, cache, launcher, system user)
   if declare -f subscription_remove_unit >/dev/null 2>&1; then
     subscription_remove_unit || true
+  elif declare -f remove_systemd_unit >/dev/null 2>&1; then
+    remove_systemd_unit "${SUBSCRIPTION_SERVICE_NAME}" "/etc/systemd/system/${SUBSCRIPTION_SERVICE_NAME}.service" "best_effort" || true
   else
     systemctl stop "${SUBSCRIPTION_SERVICE_NAME}" 2>/dev/null || true
     systemctl disable "${SUBSCRIPTION_SERVICE_NAME}" 2>/dev/null || true

--- a/lib/service.sh
+++ b/lib/service.sh
@@ -42,7 +42,8 @@ create_service_file() {
 
   msg "Creating systemd service ..."
 
-  unit_content=$(cat <<'EOF'
+  unit_content=$(
+    cat <<'EOF'
 [Unit]
 Description=sing-box
 After=network.target nss-lookup.target
@@ -56,7 +57,7 @@ LimitNOFILE=1048576
 [Install]
 WantedBy=multi-user.target
 EOF
-)
+  )
 
   install_systemd_unit "${SB_SVC}" "${unit_content}"
 

--- a/lib/service.sh
+++ b/lib/service.sh
@@ -24,11 +24,25 @@ source "${_LIB_DIR}/network.sh"
 # Service File Creation
 #==============================================================================
 
+# Install a systemd unit from a rendered content string.
+install_systemd_unit() {
+  local unit_path="$1"
+  local unit_content="${2:-}"
+
+  printf '%s\n' "${unit_content}" >"${unit_path}"
+  chmod 644 "${unit_path}"
+  systemctl daemon-reload >/dev/null 2>&1 || true
+
+  return 0
+}
+
 # Create systemd service unit file
 create_service_file() {
+  local unit_content=""
+
   msg "Creating systemd service ..."
 
-  cat >"${SB_SVC}" <<'EOF'
+  unit_content=$(cat <<'EOF'
 [Unit]
 Description=sing-box
 After=network.target nss-lookup.target
@@ -42,6 +56,9 @@ LimitNOFILE=1048576
 [Install]
 WantedBy=multi-user.target
 EOF
+)
+
+  install_systemd_unit "${SB_SVC}" "${unit_content}"
 
   success "  ✓ Service file created"
   return 0
@@ -295,28 +312,40 @@ reload_service() {
 # Service Uninstallation
 #==============================================================================
 
+# Remove a systemd unit by name.
+remove_systemd_unit() {
+  local unit_name="$1"
+  local unit_path="${2:-/etc/systemd/system/${unit_name}.service}"
+  local reload_mode="${3:-best_effort}"
+
+  if systemctl is-active "${unit_name}" >/dev/null 2>&1; then
+    systemctl stop "${unit_name}" || warn "Failed to stop service"
+  fi
+
+  if systemctl is-enabled "${unit_name}" >/dev/null 2>&1; then
+    systemctl disable "${unit_name}" || warn "Failed to disable service"
+  fi
+
+  rm -f "${unit_path}"
+  if [[ "${reload_mode}" == "strict" ]]; then
+    systemctl daemon-reload || return 1
+  else
+    systemctl daemon-reload >/dev/null 2>&1 || true
+  fi
+
+  return 0
+}
+
 # Remove sing-box service
 remove_service() {
   msg "Removing sing-box service..."
 
-  # Stop service if running
-  if systemctl is-active sing-box >/dev/null 2>&1; then
-    systemctl stop sing-box || warn "Failed to stop service"
-  fi
-
-  # Disable service
-  if systemctl is-enabled sing-box >/dev/null 2>&1; then
-    systemctl disable sing-box || warn "Failed to disable service"
-  fi
-
-  # Remove service file
   if [[ -f "${SB_SVC}" ]]; then
-    rm -f "${SB_SVC}"
+    remove_systemd_unit "sing-box" "${SB_SVC}" "strict" || return 1
     success "  ✓ Service file removed"
+  else
+    remove_systemd_unit "sing-box" "${SB_SVC}" "strict" || return 1
   fi
-
-  # Reload systemd daemon
-  systemctl daemon-reload
 
   success "Service removed successfully"
   return 0
@@ -354,3 +383,4 @@ show_service_logs() {
 export -f create_service_file start_service_with_retry setup_service validate_port_listening
 export -f check_service_status stop_service restart_service reload_service
 export -f remove_service show_service_logs
+export -f install_systemd_unit remove_systemd_unit

--- a/lib/subscription.sh
+++ b/lib/subscription.sh
@@ -24,6 +24,10 @@ readonly _SBX_SUBSCRIPTION_LOADED=1
 _LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=/dev/null
 source "${_LIB_DIR}/common.sh"
+if [[ -z "${_SBX_SERVICE_LOADED:-}" ]]; then
+  # shellcheck source=/dev/null
+  source "${_LIB_DIR}/service.sh"
+fi
 if [[ -z "${_SBX_EXPORT_LOADED:-}" ]]; then
   # shellcheck source=/dev/null
   source "${_LIB_DIR}/export.sh"
@@ -309,6 +313,7 @@ subscription_install_unit() {
   local unit_path=''
   local bind=''
   local port=''
+  local unit_content=''
   local user="${SUB_SYSTEM_USER_OVERRIDE:-${SUBSCRIPTION_SYSTEM_USER}}"
   unit_path=$(_subscription_unit_path)
 
@@ -321,7 +326,7 @@ subscription_install_unit() {
     return 0
   fi
 
-  cat >"${unit_path}" <<EOF
+  unit_content=$(cat <<EOF
 [Unit]
 Description=sbx adaptive subscription endpoint
 After=network.target
@@ -345,8 +350,9 @@ ReadOnlyPaths=$(_subscription_cache_dir)
 [Install]
 WantedBy=multi-user.target
 EOF
-  chmod 644 "${unit_path}"
-  systemctl daemon-reload >/dev/null 2>&1 || true
+)
+
+  install_systemd_unit "${unit_path}" "${unit_content}"
 }
 
 subscription_remove_unit() {
@@ -357,10 +363,7 @@ subscription_remove_unit() {
     return 0
   fi
 
-  systemctl stop "${SUBSCRIPTION_SERVICE_NAME}" 2>/dev/null || true
-  systemctl disable "${SUBSCRIPTION_SERVICE_NAME}" 2>/dev/null || true
-  rm -f "${unit_path}"
-  systemctl daemon-reload >/dev/null 2>&1 || true
+  remove_systemd_unit "${SUBSCRIPTION_SERVICE_NAME}" "${unit_path}" "best_effort"
 }
 
 #==============================================================================

--- a/lib/subscription.sh
+++ b/lib/subscription.sh
@@ -326,7 +326,8 @@ subscription_install_unit() {
     return 0
   fi
 
-  unit_content=$(cat <<EOF
+  unit_content=$(
+    cat <<EOF
 [Unit]
 Description=sbx adaptive subscription endpoint
 After=network.target
@@ -350,7 +351,7 @@ ReadOnlyPaths=$(_subscription_cache_dir)
 [Install]
 WantedBy=multi-user.target
 EOF
-)
+  )
 
   install_systemd_unit "${unit_path}" "${unit_content}"
 }

--- a/tests/unit/test_systemd_unit_helpers.sh
+++ b/tests/unit/test_systemd_unit_helpers.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# tests/unit/test_systemd_unit_helpers.sh - Guard generic systemd unit helpers
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+test_result() {
+  local name="$1"
+  local result="$2"
+
+  TESTS_RUN=$((TESTS_RUN + 1))
+  if [[ "${result}" == "pass" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo "  ✓ ${name}"
+  else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo "  ✗ ${name}"
+  fi
+}
+
+assert_contains() {
+  local name="$1"
+  local haystack="$2"
+  local needle="$3"
+
+  if [[ "${haystack}" == *"${needle}"* ]]; then
+    test_result "${name}" "pass"
+  else
+    test_result "${name}" "fail"
+    echo "      missing: ${needle}"
+  fi
+}
+
+assert_file_contains() {
+  local name="$1"
+  local file="$2"
+  local pattern="$3"
+
+  if grep -q "${pattern}" "${file}"; then
+    test_result "${name}" "pass"
+  else
+    test_result "${name}" "fail"
+    echo "      missing pattern: ${pattern}"
+  fi
+}
+
+echo "=== Generic Systemd Unit Helper Tests ==="
+
+echo ""
+echo "Testing helper definitions..."
+assert_file_contains "install_systemd_unit helper exists" \
+  "${PROJECT_ROOT}/lib/service.sh" \
+  '^install_systemd_unit()'
+assert_file_contains "remove_systemd_unit helper exists" \
+  "${PROJECT_ROOT}/lib/service.sh" \
+  '^remove_systemd_unit()'
+
+echo ""
+echo "Testing service module delegation..."
+create_func=$(sed -n '/^create_service_file()/,/^}/p' "${PROJECT_ROOT}/lib/service.sh")
+assert_contains "create_service_file delegates to install_systemd_unit" \
+  "${create_func}" \
+  'install_systemd_unit'
+
+remove_func=$(sed -n '/^remove_service()/,/^}/p' "${PROJECT_ROOT}/lib/service.sh")
+assert_contains "remove_service delegates to remove_systemd_unit" \
+  "${remove_func}" \
+  'remove_systemd_unit'
+
+echo ""
+echo "Testing subscription module delegation..."
+sub_install_func=$(sed -n '/^subscription_install_unit()/,/^}/p' "${PROJECT_ROOT}/lib/subscription.sh")
+assert_contains "subscription_install_unit delegates to install_systemd_unit" \
+  "${sub_install_func}" \
+  'install_systemd_unit'
+
+sub_remove_func=$(sed -n '/^subscription_remove_unit()/,/^}/p' "${PROJECT_ROOT}/lib/subscription.sh")
+assert_contains "subscription_remove_unit delegates to remove_systemd_unit" \
+  "${sub_remove_func}" \
+  'remove_systemd_unit'
+
+echo ""
+echo "Testing uninstall fallback reuse..."
+install_snippet=$(awk '
+  /if declare -f subscription_remove_unit/ { capture=1 }
+  capture { print }
+  /rm -f \/usr\/local\/bin\/sbx-sub-server/ { capture=0 }
+' "${PROJECT_ROOT}/install.sh")
+assert_contains "install.sh uninstall fallback reuses remove_systemd_unit" \
+  "${install_snippet}" \
+  'remove_systemd_unit'
+
+echo ""
+echo "=========================================="
+echo "Test Summary"
+echo "=========================================="
+echo "Total:  ${TESTS_RUN}"
+echo "Passed: ${TESTS_PASSED}"
+echo "Failed: ${TESTS_FAILED}"
+
+if [[ ${TESTS_FAILED} -eq 0 ]]; then
+  echo ""
+  echo "✓ All tests passed!"
+  exit 0
+fi
+
+echo ""
+echo "✗ Some tests failed"
+exit 1

--- a/tests/unit/test_systemd_unit_remove_behavior.sh
+++ b/tests/unit/test_systemd_unit_remove_behavior.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# tests/unit/test_systemd_unit_remove_behavior.sh
+# Verifies strict vs best-effort daemon-reload behavior after unit removal.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../test_framework.sh"
+
+TEST_TMP=""
+UNIT_PATH=""
+
+setup_fixture() {
+  TEST_TMP=$(mktemp -d /tmp/sbx-systemd-remove.XXXXXX)
+  UNIT_PATH="${TEST_TMP}/test.service"
+  printf '[Unit]\nDescription=test\n' >"${UNIT_PATH}"
+}
+
+teardown_fixture() {
+  [[ -n "${TEST_TMP:-}" && -d "${TEST_TMP}" ]] && rm -rf "${TEST_TMP}"
+}
+
+run_remove_service_with_reload_failure() {
+  TEST_UNIT_PATH="${UNIT_PATH}" \
+    bash -c "
+      export SB_SVC='${UNIT_PATH}'
+      export SB_BIN='/bin/true'
+      export SB_CONF='${TEST_TMP}/config.json'
+      export LOG_VIEW_DEFAULT_HISTORY='1h'
+      source '${PROJECT_ROOT}/lib/service.sh'
+      trap - EXIT INT TERM HUP QUIT ERR RETURN
+      set +e
+      systemctl() {
+        case \"\$1\" in
+          is-active|is-enabled) return 1 ;;
+          daemon-reload) return 1 ;;
+          *) return 0 ;;
+        esac
+      }
+      remove_service
+    "
+}
+
+run_subscription_remove_with_reload_failure() {
+  TEST_UNIT_PATH="${UNIT_PATH}" \
+    bash -c "
+      export SB_SVC='${TEST_TMP}/sing-box.service'
+      export SB_BIN='/bin/true'
+      export SB_CONF='${TEST_TMP}/config.json'
+      export LOG_VIEW_DEFAULT_HISTORY='1h'
+      source '${PROJECT_ROOT}/lib/subscription.sh'
+      trap - EXIT INT TERM HUP QUIT ERR RETURN
+      set +e
+      _subscription_unit_path() { echo '${UNIT_PATH}'; }
+      systemctl() {
+        case \"\$1\" in
+          is-active|is-enabled) return 1 ;;
+          daemon-reload) return 1 ;;
+          *) return 0 ;;
+        esac
+      }
+      subscription_remove_unit
+    "
+}
+
+test_remove_service_fails_when_daemon_reload_fails() {
+  local status=0
+  run_remove_service_with_reload_failure >/dev/null 2>&1
+  status=$?
+  assert_equals "1" "${status}" "remove_service surfaces daemon-reload failure"
+}
+
+test_subscription_remove_unit_is_best_effort() {
+  local status=0
+  run_subscription_remove_with_reload_failure >/dev/null 2>&1
+  status=$?
+  assert_equals "0" "${status}" "subscription_remove_unit tolerates daemon-reload failure"
+}
+
+main() {
+  set +e
+  setup_fixture
+  echo "Running: systemd unit remove behavior"
+  test_remove_service_fails_when_daemon_reload_fails
+  test_subscription_remove_unit_is_best_effort
+  teardown_fixture
+  print_test_summary
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- extract shared systemd unit install/remove helpers into `lib/service.sh`
- switch sing-box and subscription unit management to reuse the shared helpers
- preserve strict daemon-reload failure handling for sing-box uninstall while keeping subscription removal best-effort

## Why
Issue #118 called out duplicated systemd unit lifecycle code between the main service and subscription module. This refactor removes that duplication and keeps the stricter uninstall behavior that code review flagged as a regression risk.

## Validation
- `bash tests/unit/test_systemd_unit_remove_behavior.sh`
- `bash tests/test-runner.sh unit`
