### PR TITLE
[codex] Batch jq invocations in load_client_info

### DIFF
--- a/lib/export.sh
+++ b/lib/export.sh
@@ -40,6 +40,7 @@ _export_die() {
 load_client_info() {
   local client_info_file='' state_file='' resolved='' owner='' perm='' invalid_line=''
   local ws_enabled_raw='' hy2_enabled_raw='' tuic_enabled_raw='' trojan_enabled_raw=''
+  local -a state_fields=()
   local allowed_keys_regex="^(DOMAIN|UUID|PUBLIC_KEY|SHORT_ID|SNI|REALITY_PORT|WS_PORT|HY2_PORT|HY2_PASS|TUIC_PORT|TUIC_PASS|TROJAN_PORT|TROJAN_PASS|CERT_FULLCHAIN|CERT_KEY|TUNNEL_ENABLED|TUNNEL_HOSTNAME|TUNNEL_MODE)$"
 
   # Prefer structured state file when available, with compatibility fallback.
@@ -72,34 +73,74 @@ load_client_info() {
     jq empty <"${resolved}" 2>/dev/null || _export_die "SBX-EXPORT-009" "State file is not valid JSON: ${resolved}" \
       "Repair or regenerate state.json."
 
-    DOMAIN=$(jq -r '.server.domain // .server.ip // empty' "${resolved}")
-    UUID=$(jq -r '.protocols.reality.uuid // empty' "${resolved}")
-    PUBLIC_KEY=$(jq -r '.protocols.reality.public_key // empty' "${resolved}")
-    SHORT_ID=$(jq -r '.protocols.reality.short_id // empty' "${resolved}")
-    SNI=$(jq -r '.protocols.reality.sni // empty' "${resolved}")
-    REALITY_PORT=$(jq -r '.protocols.reality.port // empty' "${resolved}")
-    WS_PORT=$(jq -r '.protocols.ws_tls.port // empty' "${resolved}")
-    HY2_PORT=$(jq -r '.protocols.hysteria2.port // empty' "${resolved}")
-    HY2_PASS=$(jq -r '.protocols.hysteria2.password // empty' "${resolved}")
-    HY2_PORT_RANGE=$(jq -r '.protocols.hysteria2.port_range // empty' "${resolved}")
-    TUIC_PORT=$(jq -r '.protocols.tuic.port // empty' "${resolved}")
-    TUIC_PASS=$(jq -r '.protocols.tuic.password // empty' "${resolved}")
-    TROJAN_PORT=$(jq -r '.protocols.trojan.port // empty' "${resolved}")
-    TROJAN_PASS=$(jq -r '.protocols.trojan.password // empty' "${resolved}")
-    CERT_FULLCHAIN=$(jq -r '.protocols.ws_tls.certificate // empty' "${resolved}")
-    CERT_KEY=$(jq -r '.protocols.ws_tls.key // empty' "${resolved}")
-    SUB_ENABLED=$(jq -r '.subscription.enabled // false' "${resolved}")
-    SUB_PORT=$(jq -r '.subscription.port // empty' "${resolved}")
-    SUB_BIND=$(jq -r '.subscription.bind // empty' "${resolved}")
-    SUB_TOKEN=$(jq -r '.subscription.token // empty' "${resolved}")
-    SUB_PATH=$(jq -r '.subscription.path // empty' "${resolved}")
-    TUNNEL_ENABLED=$(jq -r '.tunnel.enabled // false' "${resolved}")
-    TUNNEL_HOSTNAME=$(jq -r '.tunnel.hostname // empty' "${resolved}")
-    TUNNEL_MODE=$(jq -r '.tunnel.mode // empty' "${resolved}")
-    ws_enabled_raw=$(jq -r '.protocols.ws_tls.enabled // empty' "${resolved}")
-    hy2_enabled_raw=$(jq -r '.protocols.hysteria2.enabled // empty' "${resolved}")
-    tuic_enabled_raw=$(jq -r '.protocols.tuic.enabled // empty' "${resolved}")
-    trojan_enabled_raw=$(jq -r '.protocols.trojan.enabled // empty' "${resolved}")
+    mapfile -d '' -t state_fields < <(
+      jq -j '
+        [
+          (.server.domain // .server.ip // ""),
+          (.protocols.reality.uuid // ""),
+          (.protocols.reality.public_key // ""),
+          (.protocols.reality.short_id // ""),
+          (.protocols.reality.sni // ""),
+          (.protocols.reality.port // "" | tostring),
+          (.protocols.ws_tls.port // "" | tostring),
+          (.protocols.hysteria2.port // "" | tostring),
+          (.protocols.hysteria2.password // ""),
+          (.protocols.hysteria2.port_range // ""),
+          (.protocols.tuic.port // "" | tostring),
+          (.protocols.tuic.password // ""),
+          (.protocols.trojan.port // "" | tostring),
+          (.protocols.trojan.password // ""),
+          (.protocols.ws_tls.certificate // ""),
+          (.protocols.ws_tls.key // ""),
+          (.subscription.enabled // false | tostring),
+          (.subscription.port // "" | tostring),
+          (.subscription.bind // ""),
+          (.subscription.token // ""),
+          (.subscription.path // ""),
+          (.tunnel.enabled // false | tostring),
+          (.tunnel.hostname // ""),
+          (.tunnel.mode // ""),
+          (.protocols.ws_tls.enabled | if . == null then "" else tostring end),
+          (.protocols.hysteria2.enabled | if . == null then "" else tostring end),
+          (.protocols.tuic.enabled | if . == null then "" else tostring end),
+          (.protocols.trojan.enabled | if . == null then "" else tostring end)
+        ][]
+        | tostring, "\u0000"
+      ' "${resolved}"
+    ) || _export_die "SBX-EXPORT-010" "Failed to extract client info from state file" \
+      "Repair or regenerate state.json."
+
+    [[ "${#state_fields[@]}" -eq 28 ]] || _export_die "SBX-EXPORT-011" "Unexpected state data shape while loading client info" \
+      "Repair or regenerate state.json."
+
+    DOMAIN="${state_fields[0]}"
+    UUID="${state_fields[1]}"
+    PUBLIC_KEY="${state_fields[2]}"
+    SHORT_ID="${state_fields[3]}"
+    SNI="${state_fields[4]}"
+    REALITY_PORT="${state_fields[5]}"
+    WS_PORT="${state_fields[6]}"
+    HY2_PORT="${state_fields[7]}"
+    HY2_PASS="${state_fields[8]}"
+    HY2_PORT_RANGE="${state_fields[9]}"
+    TUIC_PORT="${state_fields[10]}"
+    TUIC_PASS="${state_fields[11]}"
+    TROJAN_PORT="${state_fields[12]}"
+    TROJAN_PASS="${state_fields[13]}"
+    CERT_FULLCHAIN="${state_fields[14]}"
+    CERT_KEY="${state_fields[15]}"
+    SUB_ENABLED="${state_fields[16]}"
+    SUB_PORT="${state_fields[17]}"
+    SUB_BIND="${state_fields[18]}"
+    SUB_TOKEN="${state_fields[19]}"
+    SUB_PATH="${state_fields[20]}"
+    TUNNEL_ENABLED="${state_fields[21]}"
+    TUNNEL_HOSTNAME="${state_fields[22]}"
+    TUNNEL_MODE="${state_fields[23]}"
+    ws_enabled_raw="${state_fields[24]}"
+    hy2_enabled_raw="${state_fields[25]}"
+    tuic_enabled_raw="${state_fields[26]}"
+    trojan_enabled_raw="${state_fields[27]}"
 
     case "${ws_enabled_raw}" in
       true | 1 | yes | on) WS_ENABLED="true" ;;

--- a/tests/unit/test_subscription_state_schema.sh
+++ b/tests/unit/test_subscription_state_schema.sh
@@ -88,6 +88,51 @@ teardown_fixture() {
   [[ -n "${TEST_TMP:-}" && -d "${TEST_TMP}" ]] && rm -rf "${TEST_TMP}"
 }
 
+test_load_client_info_batches_state_reads() {
+  _write_state_with_subscription
+
+  local jq_bin_dir="${TEST_TMP}/bin"
+  local jq_count_file="${TEST_TMP}/jq-count.log"
+  local real_jq=''
+  real_jq=$(command -v jq)
+
+  mkdir -p "${jq_bin_dir}"
+  cat >"${jq_bin_dir}/jq" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf '1\n' >> '${jq_count_file}'
+exec '${real_jq}' "\$@"
+EOF
+  chmod +x "${jq_bin_dir}/jq"
+
+  local out=''
+  out=$(
+    PATH="${jq_bin_dir}:${PATH}" \
+      TEST_STATE_FILE="${STATE_FILE_PATH}" \
+      TEST_CLIENT_INFO="${TEST_TMP}/nope" \
+      bash -c "
+        source '${PROJECT_ROOT}/lib/export.sh'
+        load_client_info >/dev/null
+        printf 'DOMAIN=%s\nSUB_ENABLED=%s\nWS_ENABLED=%s\nHY2_ENABLED=%s\nTUIC_ENABLED=%s\nTROJAN_ENABLED=%s\n' \
+          \"\${DOMAIN:-}\" \"\${SUB_ENABLED:-}\" \"\${WS_ENABLED:-}\" \"\${HY2_ENABLED:-}\" \"\${TUIC_ENABLED:-}\" \"\${TROJAN_ENABLED:-}\"
+      "
+  )
+
+  local jq_count='0'
+  if [[ -f "${jq_count_file}" ]]; then
+    jq_count=$(wc -l <"${jq_count_file}")
+    jq_count="${jq_count//[[:space:]]/}"
+  fi
+
+  assert_equals "2" "${jq_count}" "load_client_info batches state.json reads into one jq extraction"
+  assert_contains "${out}" "DOMAIN=example.com" "batched load preserves DOMAIN"
+  assert_contains "${out}" "SUB_ENABLED=true" "batched load preserves SUB_ENABLED"
+  assert_contains "${out}" "WS_ENABLED=false" "batched load preserves WS_ENABLED"
+  assert_contains "${out}" "HY2_ENABLED=false" "batched load preserves HY2_ENABLED"
+  assert_contains "${out}" "TUIC_ENABLED=false" "batched load preserves TUIC_ENABLED"
+  assert_contains "${out}" "TROJAN_ENABLED=false" "batched load preserves TROJAN_ENABLED"
+}
+
 test_ensure_block_adds_defaults_when_missing() {
   _write_legacy_state
 
@@ -157,6 +202,7 @@ main() {
   test_ensure_block_adds_defaults_when_missing
   test_ensure_block_is_idempotent
   test_load_client_info_exposes_sub_vars
+  test_load_client_info_batches_state_reads
   teardown_fixture
   print_test_summary
 }


### PR DESCRIPTION
## Summary
- batch `state.json` extraction in `load_client_info()` into a single `jq` invocation after JSON validation
- preserve the existing field semantics for empty values, explicit `false`, and protocol enablement fallbacks
- add a unit test that counts `jq` invocations and verifies the exported values still match the fixture state

## Why
`load_client_info()` was forking `jq` once per field on a hot CLI path, which added avoidable startup latency and repeated JSON parsing work on low-end hosts.

## Impact
CLI commands that depend on `load_client_info()` now read `state.json` with one extraction pass instead of dozens of per-field parses, without changing the public export variables consumed by the rest of the module.

## Root Cause
The state loader was implemented as a sequence of single-field `jq -r` calls, so every command re-opened and re-parsed the same JSON document many times.

## Validation
- `bash tests/test-runner.sh unit`

Closes #120
