### PR TITLE
fix: stabilize config write unit test and document jq prerequisite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,10 @@ Single source of truth for coding-agent instructions in this repository.
 ## Setup Commands
 
 ```bash
+# Local test prerequisite
+sudo apt-get update
+sudo apt-get install -y jq
+
 # Install local git hooks (required)
 bash hooks/install-hooks.sh
 
@@ -26,6 +30,11 @@ bash tests/unit/test_bootstrap_constants.sh
 # Docker lifecycle smoke e2e
 bash scripts/e2e/install-lifecycle-smoke.sh
 ```
+
+Local note:
+
+- `jq` is required for `bash tests/test-runner.sh unit` on a clean Ubuntu/WSL machine.
+- The Docker lifecycle smoke script installs its own container dependencies, but host-side unit tests still expect `jq` to be available locally.
 
 ## Code and Shell Standards
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,9 +21,9 @@ Thank you for contributing to sbx-lite! This document provides guidelines and se
 # Required
 - bash 4.0+
 - git
+- jq (required for local unit tests)
 
 # Recommended
-- jq (JSON processing)
 - shellcheck (bash linting)
 - openssl (cryptographic operations)
 ```
@@ -34,6 +34,10 @@ Thank you for contributing to sbx-lite! This document provides guidelines and se
 # Clone the repository
 git clone https://github.com/xrf9268-hue/sbx.git
 cd sbx
+
+# Install local test dependency
+sudo apt-get update
+sudo apt-get install -y jq
 
 # Install git hooks (REQUIRED - see next section)
 bash hooks/install-hooks.sh
@@ -200,6 +204,9 @@ When adding constants used during bootstrap (before module loading):
 ### Before Committing
 
 ```bash
+# Ensure local test dependency is available
+sudo apt-get install -y jq
+
 # Run all unit tests
 bash tests/test-runner.sh unit
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -14,6 +14,15 @@ tests/
 
 ## Run tests locally
 
+Local prerequisite:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y jq
+```
+
+`jq` is required for the host-side unit suite. The Docker lifecycle smoke script installs its own container dependencies separately.
+
 ```bash
 # Unit tests
 bash tests/test-runner.sh unit

--- a/tests/unit/test_config_write.sh
+++ b/tests/unit/test_config_write.sh
@@ -69,19 +69,19 @@ test_write_config_defined_in_module() {
 
 test_write_config_uses_jq() {
     # write_config should use jq for JSON handling
-    grep -E "jq" lib/config.sh | grep -q ""
+    grep -Eq "jq" lib/config.sh
 }
 
 test_write_config_validates_before_write() {
     # Should validate JSON before writing
-    grep -E "(validate|check|test)" lib/config.sh | grep -q ""
+    grep -Eq "(validate|check|test)" lib/config.sh
 }
 
 test_write_config_uses_with_flock() {
     # write_config should be protected by with_flock to avoid concurrent writes
     local write_impl
     write_impl=$(sed -n '/^write_config()/,/^}/p' lib/config.sh)
-    echo "${write_impl}" | grep -q "with_flock"
+    grep -q "with_flock" <<< "${write_impl}"
 }
 
 #==============================================================================
@@ -98,7 +98,7 @@ test_create_all_inbounds_defined_in_module() {
 
 test_create_all_inbounds_creates_reality_inbound() {
     # Should call create_reality_inbound
-    grep "_create_all_inbounds" lib/config.sh | head -20 || grep "create_reality_inbound" lib/config.sh | grep -q ""
+    grep -q "create_reality_inbound" lib/config.sh
 }
 
 #==============================================================================


### PR DESCRIPTION
## Summary
- fix `tests/unit/test_config_write.sh` to use `pipefail`-safe assertions instead of `grep ... | grep -q` pipelines that can fail with `SIGPIPE`
- simplify the `_create_all_inbounds` assertion to a direct `grep -q` check
- document `jq` as a required local prerequisite for host-side unit tests in `AGENTS.md`, `CONTRIBUTING.md`, and `tests/README.md`

## Test Plan
- `docker run --rm -v C:\Windows\Temp\sbx-pr-20260418-lf:/workspace/sbx ubuntu:24.04 bash -lc 'cd /workspace/sbx && bash tests/unit/test_config_write.sh'`
- `docker run --rm -v C:\Windows\Temp\sbx-pr-20260418-lf:/workspace/sbx ubuntu:24.04 bash -lc 'cd /workspace/sbx && grep -n "jq" AGENTS.md CONTRIBUTING.md tests/README.md'`

Closes #130
Closes #131