### PR TITLE
feat: add Reality short ID rotation

### DIFF
--- a/.claude/CODING_STANDARDS.md
+++ b/.claude/CODING_STANDARDS.md
@@ -261,3 +261,21 @@ part of the feature, not as follow-up cleanup.
   paths.
 - Tests must not depend on host `/var/lock` ownership or on side effects from
   prior root-run installs.
+
+## Failure Propagation for Shared Helpers
+
+When a shared helper performs side effects, its return value must reflect the
+first failing step. Do not rely on `set -e` to stop execution inside helpers
+that may be called from `if`, `&&`, or `||` contexts.
+
+- Do **not** end a side-effecting helper with unconditional `return 0` after
+  commands that may fail. That converts partial failure into false success for
+  every caller.
+- In helpers such as unit installers, config writers, or state mutators, guard
+  each critical step explicitly: `write_file ... || return 1`,
+  `chmod ... || return 1`, `systemctl daemon-reload ... || return 1`.
+- Callers may still use `helper || { rollback; return 1; }`, but the helper
+  itself must already have correct failure semantics.
+- Add a regression test for the negative path that triggered the bug. Prefer
+  reproductions like missing target directories, unwritable destinations, or
+  failing `systemctl` stubs over purely synthetic assertions.

--- a/.claude/CODING_STANDARDS.md
+++ b/.claude/CODING_STANDARDS.md
@@ -224,3 +224,40 @@ tmpfile=$(create_temp_file "backup") || return 1
 # Secure temp directory (700 permissions automatic)
 tmpdir=$(create_temp_dir "restore") || return 1
 ```
+
+## Runtime Mutation Discipline
+
+When a command mutates installed runtime artifacts, treat locking and rollback as
+part of the feature, not as follow-up cleanup.
+
+**Locking order is mandatory:**
+- If a flow mutates `config.json`, systemd units, or restarts services, take the
+  shared mutation lock with `with_flock` at the top-level boundary.
+- If the same flow also mutates `state.json`, nest `with_state_lock` inside the
+  global lock, in that order.
+- Do **not** add a state-only mutator that can race with existing global
+  mutators such as `write_config`, `restart_service`, or `backup_restore`.
+
+**Nested restart paths must avoid lock inheritance:**
+- If code already runs under the shared mutation lock, prefer calling the
+  unlocked implementation (`_restart_service_impl`) from a helper/subshell
+  instead of re-entering `restart_service`.
+- Re-entering `restart_service` while `SBX_LOCK_FILE` still points at
+  `sbx-state.lock` can deadlock on the same lock file.
+
+**Multi-file rollback must be staged:**
+- For restores involving multiple live files (`config.json`,
+  `client-info.txt`, `state.json`, unit files), stage backup copies into temp
+  files in the destination directory first, then switch them into place with
+  `mv`.
+- Do **not** sequentially `cp` over live files. If a later copy fails, you
+  leave a mixed on-disk state and rollback becomes unsafe.
+- If the apply step itself fails, restore the captured pre-restore files before
+  returning failure.
+
+**State-mutating tests must isolate lock files:**
+- Unit tests that call `state_json_apply`, `with_state_lock`, or any higher-level
+  state mutator must override `SBX_LOCK_FILE` and `SBX_STATE_LOCK_FILE` to temp
+  paths.
+- Tests must not depend on host `/var/lock` ownership or on side effects from
+  prior root-run installs.

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Refactor progress notes (local-only)
 .claude/refactor-progress.md
+
+# Local git worktrees
+.worktrees/

--- a/bin/sbx-manager.sh
+++ b/bin/sbx-manager.sh
@@ -38,6 +38,8 @@ if [[ -d "$LIB_DIR" ]]; then
   [[ -f "$LIB_DIR/cloudflare_tunnel.sh" ]] && source "$LIB_DIR/cloudflare_tunnel.sh"
   # shellcheck source=/dev/null
   [[ -f "$LIB_DIR/telegram_bot.sh" ]] && source "$LIB_DIR/telegram_bot.sh"
+  # shellcheck source=/dev/null
+  [[ -f "$LIB_DIR/reality_rotation.sh" ]] && source "$LIB_DIR/reality_rotation.sh"
 fi
 
 # Simple logo for management tool
@@ -126,6 +128,11 @@ ${B}Telegram Bot:${N}
   telegram admin add <chat_id>    Add an allowed Telegram chat ID
   telegram admin remove <chat_id> Remove an allowed Telegram chat ID
   telegram admin list             List allowed Telegram chat IDs
+
+${B}Reality Rotation:${N}
+  rotate-shortid [--dry-run]                 Rotate the Reality short ID
+  rotate-shortid --schedule <daily|weekly|monthly|off>
+                                            Configure scheduled rotation
 
 ${B}System:${N}
   uninstall|remove    Complete uninstall (requires root)
@@ -807,6 +814,44 @@ output_backup_list_json() {
           count: ($backups | length),
           backups: $backups
         }'
+}
+
+handle_rotate_shortid_command() {
+  local schedule_seen=0
+  local arg=''
+
+  need_root || exit 1
+
+  if ! declare -f reality_rotate_shortid >/dev/null 2>&1 || \
+    ! declare -f reality_rotation_schedule >/dev/null 2>&1; then
+    echo -e "${R}[ERR]${N} Reality rotation module not loaded. Please reinstall sbx-lite."
+    exit 1
+  fi
+
+  for arg in "$@"; do
+    [[ "${arg}" == "--schedule" ]] && schedule_seen=1
+  done
+
+  if [[ "${schedule_seen}" -eq 1 ]]; then
+    if [[ $# -ne 2 ]]; then
+      if [[ "${1:-}" == "--schedule" && $# -eq 1 ]]; then
+        echo -e "${R}[ERR]${N} Usage: sbx rotate-shortid --schedule <daily|weekly|monthly|off>"
+      else
+        echo -e "${R}[ERR]${N} --schedule cannot be combined with other flags."
+      fi
+      exit 1
+    fi
+
+    if [[ "${1:-}" != "--schedule" || -z "${2:-}" ]]; then
+      echo -e "${R}[ERR]${N} Usage: sbx rotate-shortid --schedule <daily|weekly|monthly|off>"
+      exit 1
+    fi
+
+    reality_rotation_schedule "${2}"
+    return 0
+  fi
+
+  reality_rotate_shortid "$@"
 }
 
 require_jq_for_json
@@ -1516,6 +1561,11 @@ case "${1:-}" in
         exit 1
         ;;
     esac
+    ;;
+
+  rotate-shortid)
+    shift
+    handle_rotate_shortid_command "$@"
     ;;
 
   help | --help | -h | "")

--- a/bin/sbx-manager.sh
+++ b/bin/sbx-manager.sh
@@ -818,23 +818,18 @@ output_backup_list_json() {
 
 handle_rotate_shortid_command() {
   local schedule_seen=0
+  local schedule_value=''
   local arg=''
 
-  need_root || exit 1
-
-  if ! declare -f reality_rotate_shortid >/dev/null 2>&1 || \
-    ! declare -f reality_rotation_schedule >/dev/null 2>&1; then
-    echo -e "${R}[ERR]${N} Reality rotation module not loaded. Please reinstall sbx-lite."
-    exit 1
-  fi
-
   for arg in "$@"; do
-    [[ "${arg}" == "--schedule" ]] && schedule_seen=1
+    if [[ "${arg}" == "--schedule" ]]; then
+      schedule_seen=1
+    fi
   done
 
   if [[ "${schedule_seen}" -eq 1 ]]; then
-    if [[ $# -ne 2 ]]; then
-      if [[ "${1:-}" == "--schedule" && $# -eq 1 ]]; then
+    if [[ $# -ne 2 || "${1:-}" != "--schedule" || -z "${2:-}" ]]; then
+      if [[ $# -eq 1 && "${1:-}" == "--schedule" ]]; then
         echo -e "${R}[ERR]${N} Usage: sbx rotate-shortid --schedule <daily|weekly|monthly|off>"
       else
         echo -e "${R}[ERR]${N} --schedule cannot be combined with other flags."
@@ -842,12 +837,19 @@ handle_rotate_shortid_command() {
       exit 1
     fi
 
-    if [[ "${1:-}" != "--schedule" || -z "${2:-}" ]]; then
-      echo -e "${R}[ERR]${N} Usage: sbx rotate-shortid --schedule <daily|weekly|monthly|off>"
-      exit 1
-    fi
+    schedule_value="${2}"
+  fi
 
-    reality_rotation_schedule "${2}"
+  if ! declare -f reality_rotate_shortid >/dev/null 2>&1 || \
+    ! declare -f reality_rotation_schedule >/dev/null 2>&1; then
+    echo -e "${R}[ERR]${N} Reality rotation module not loaded. Please reinstall sbx-lite."
+    exit 1
+  fi
+
+  need_root || exit 1
+
+  if [[ -n "${schedule_value}" ]]; then
+    reality_rotation_schedule "${schedule_value}"
     return 0
   fi
 

--- a/bin/sbx-manager.sh
+++ b/bin/sbx-manager.sh
@@ -840,7 +840,7 @@ handle_rotate_shortid_command() {
     schedule_value="${2}"
   fi
 
-  if ! declare -f reality_rotate_shortid >/dev/null 2>&1 || \
+  if ! declare -f reality_rotate_shortid >/dev/null 2>&1 ||
     ! declare -f reality_rotation_schedule >/dev/null 2>&1; then
     echo -e "${R}[ERR]${N} Reality rotation module not loaded. Please reinstall sbx-lite."
     exit 1

--- a/docs/superpowers/plans/2026-04-18-rotate-shortid.md
+++ b/docs/superpowers/plans/2026-04-18-rotate-shortid.md
@@ -1,0 +1,595 @@
+# Reality Short ID Rotation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `sbx rotate-shortid` so the installed app can rotate Reality short IDs manually or on a `systemd` schedule, update all live server-side artifacts, refresh subscription output, and keep structured audit history without adding compatibility debt.
+
+**Architecture:** Add `lib/reality_rotation.sh` as the single owner of rotation and timer logic. `bin/sbx-manager.sh` only parses CLI flags and delegates. `install.sh` only registers the module and removes the timer units during uninstall. The rotation path writes a candidate config, validates it with `sing-box check`, atomically swaps `config.json`, `client-info.txt`, and `state.json`, restarts `sing-box`, then refreshes subscription cache if enabled.
+
+**Tech Stack:** Bash, jq, systemd, existing `lib/common.sh` locking helpers, `lib/service.sh`, `lib/subscription.sh`, unit tests in `tests/unit`, runtime verification on the existing Debian 12 AWS VM.
+
+---
+
+## File Structure
+
+- Create: `lib/reality_rotation.sh`
+  - Public API for `reality_rotate_shortid`, `reality_rotation_schedule`, and uninstall cleanup.
+  - Owns state mutation, candidate config validation, timer unit install/remove, and audit history trimming.
+
+- Create: `tests/unit/test_reality_rotation.sh`
+  - Fixture-driven tests for manual rotation, dry-run, rollback, schedule state, timer units, and history trimming.
+
+- Create: `tests/unit/test_sbx_manager_rotate_shortid.sh`
+  - CLI help, routing, and invalid flag combination tests using stub libraries.
+
+- Create: `tests/unit/test_reality_rotation_installation.sh`
+  - Static assertions for install-time module registration, API contract registration, and uninstall cleanup hooks.
+
+- Modify: `bin/sbx-manager.sh`
+  - Source the new module, expose help text, validate flags, and route the `rotate-shortid` command.
+
+- Modify: `install.sh`
+  - Register `reality_rotation` in the module download/load list and API contract map.
+  - Remove `sbx-shortid-rotate.service` and `sbx-shortid-rotate.timer` during uninstall.
+
+## Spec Input
+
+- Design spec: `docs/superpowers/specs/2026-04-18-rotate-shortid-design.md`
+
+## Task 1: Build the Core Rotation Module With Red-Green Tests
+
+**Files:**
+- Create: `tests/unit/test_reality_rotation.sh`
+- Create: `lib/reality_rotation.sh`
+- Test: `bash tests/unit/test_reality_rotation.sh`
+
+- [ ] **Step 1: Write failing fixture tests for the manual rotation path**
+
+Create `tests/unit/test_reality_rotation.sh` with a temp fixture containing:
+
+- `state.json` with `.protocols.reality.short_id = "abcd1234"`
+- `client-info.txt` with `SHORT_ID="abcd1234"`
+- `config.json` with one Reality inbound containing `"short_id": ["abcd1234"]`
+- optional subscription state enabled for cache refresh assertions
+
+Include failing tests shaped like:
+
+```bash
+test_manual_rotation_updates_live_files() {
+  _run_rotation "reality_rotate_shortid" >/dev/null
+  new_sid=$(jq -r '.protocols.reality.short_id' "${STATE_FILE}")
+  assert_matches "${new_sid}" '^[0-9a-f]{8}$' "state.json stores an 8-char hex short ID"
+  assert_failure "[[ '${new_sid}' == 'abcd1234' ]]" "short ID must change"
+  assert_equals "${new_sid}" \
+    "$(jq -r '.inbounds[0].tls.reality.short_id[0]' "${CONFIG_FILE}")" \
+    "config.json uses the new short ID"
+  assert_contains "$(cat "${CLIENT_INFO_FILE}")" "SHORT_ID=\"${new_sid}\"" \
+    "client-info.txt uses the new short ID"
+}
+
+test_dry_run_leaves_live_files_untouched() {
+  before_state=$(sha256sum "${STATE_FILE}" | awk '{print $1}')
+  before_client=$(sha256sum "${CLIENT_INFO_FILE}" | awk '{print $1}')
+  before_config=$(sha256sum "${CONFIG_FILE}" | awk '{print $1}')
+  _run_rotation "reality_rotate_shortid --dry-run" >/dev/null
+  assert_equals "${before_state}" "$(sha256sum "${STATE_FILE}" | awk '{print $1}')" \
+    "dry-run does not rewrite state.json"
+  assert_equals "${before_client}" "$(sha256sum "${CLIENT_INFO_FILE}" | awk '{print $1}')" \
+    "dry-run does not rewrite client-info.txt"
+  assert_equals "${before_config}" "$(sha256sum "${CONFIG_FILE}" | awk '{print $1}')" \
+    "dry-run does not rewrite config.json"
+}
+
+test_restart_failure_rolls_back_files() {
+  ROTATION_FORCE_RESTART_FAILURE=1 _run_rotation "reality_rotate_shortid" >/dev/null 2>&1
+  assert_equals "abcd1234" "$(jq -r '.protocols.reality.short_id' "${STATE_FILE}")" \
+    "rollback restores state.json"
+}
+```
+
+- [ ] **Step 2: Run the new unit test to verify it fails**
+
+Run:
+
+```bash
+bash tests/unit/test_reality_rotation.sh
+```
+
+Expected:
+
+- FAIL because `lib/reality_rotation.sh` does not exist yet, or
+- FAIL because `reality_rotate_shortid` is undefined
+
+- [ ] **Step 3: Implement the minimal core module**
+
+Create `lib/reality_rotation.sh` with:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+[[ -n "${_SBX_REALITY_ROTATION_LOADED:-}" ]] && return 0
+readonly _SBX_REALITY_ROTATION_LOADED=1
+
+_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${_LIB_DIR}/common.sh"
+source "${_LIB_DIR}/validation.sh"
+source "${_LIB_DIR}/service.sh"
+
+: "${ROTATION_SERVICE_NAME:=sbx-shortid-rotate.service}"
+: "${ROTATION_TIMER_NAME:=sbx-shortid-rotate.timer}"
+: "${ROTATION_HISTORY_LIMIT:=20}"
+
+reality_rotate_shortid() {
+  local trigger="manual"
+  local dry_run=0
+  local arg=''
+  for arg in "$@"; do
+    case "${arg}" in
+      --dry-run) dry_run=1 ;;
+      --scheduled-run) trigger="timer" ;;
+      *) err "Unknown option: ${arg}"; return 1 ;;
+    esac
+  done
+  with_state_lock "${SBX_LOCK_TIMEOUT_SEC:-30}" \
+    _reality_rotate_shortid_locked "${trigger}" "${dry_run}"
+}
+```
+
+Inside `_reality_rotate_shortid_locked` implement the minimum green path:
+
+- resolve current `state.json`, `client-info.txt`, `config.json`
+- read current short ID from `state.json`
+- generate a new value with `openssl rand -hex 4`
+- reject equal-to-old values in a small retry loop
+- write a candidate config using `jq '(.inbounds[] | select(.tls.reality) | .tls.reality.short_id) = [$sid]'`
+- validate with `"${SB_BIN}" check -c "${tmp_config}"`
+- if `dry_run=1`, print the preview and exit success
+- backup the three live files
+- atomically replace `config.json`, `client-info.txt`, and `state.json`
+- call `restart_service`
+- call `subscription_refresh_cache` only when available and enabled
+
+- [ ] **Step 4: Run the core module test until it passes**
+
+Run:
+
+```bash
+bash tests/unit/test_reality_rotation.sh
+```
+
+Expected:
+
+- PASS for manual rotate
+- PASS for dry-run
+- PASS for rollback-on-restart-failure
+
+- [ ] **Step 5: Commit the core module**
+
+Run:
+
+```bash
+git add lib/reality_rotation.sh tests/unit/test_reality_rotation.sh
+git commit -m "feat: add core reality short id rotation"
+```
+
+## Task 2: Add Audit History and `systemd` Schedule Management
+
+**Files:**
+- Modify: `lib/reality_rotation.sh`
+- Modify: `tests/unit/test_reality_rotation.sh`
+- Test: `bash tests/unit/test_reality_rotation.sh`
+
+- [ ] **Step 1: Extend the module test with schedule and history cases**
+
+Add failing tests:
+
+```bash
+test_schedule_weekly_installs_units_and_updates_state() {
+  _run_rotation "reality_rotation_schedule weekly" >/dev/null
+  assert_equals "weekly" \
+    "$(jq -r '.protocols.reality.short_id_rotation.schedule' "${STATE_FILE}")" \
+    "state.json records the schedule"
+  assert_file_exists "${UNIT_DIR}/sbx-shortid-rotate.service" \
+    "service unit is rendered"
+  assert_file_exists "${UNIT_DIR}/sbx-shortid-rotate.timer" \
+    "timer unit is rendered"
+  assert_contains "$(cat "${UNIT_DIR}/sbx-shortid-rotate.timer")" "OnCalendar=weekly" \
+    "timer uses weekly cadence"
+}
+
+test_schedule_off_removes_units() {
+  _run_rotation "reality_rotation_schedule off" >/dev/null
+  assert_success "jq -e '.protocols.reality.short_id_rotation.enabled == false' '${STATE_FILE}' >/dev/null" \
+    "state disables scheduling"
+}
+
+test_history_trim_keeps_20_entries() {
+  seed_history_entries 25
+  _run_rotation "reality_rotate_shortid" >/dev/null
+  assert_equals "20" \
+    "$(jq -r '.protocols.reality.short_id_rotation.history | length' "${STATE_FILE}")" \
+    "history is trimmed to 20 entries"
+}
+```
+
+Stub `install_systemd_unit`, `remove_systemd_unit`, and `systemctl` inside the test harness so the test never touches `/etc/systemd/system`.
+
+- [ ] **Step 2: Run the module test again to capture the red state**
+
+Run:
+
+```bash
+bash tests/unit/test_reality_rotation.sh
+```
+
+Expected:
+
+- FAIL because schedule helpers and history trimming do not exist yet
+
+- [ ] **Step 3: Implement schedule and audit helpers in the module**
+
+Add these public and private helpers to `lib/reality_rotation.sh`:
+
+```bash
+_rotation_schedule_to_oncalendar() {
+  case "${1:-}" in
+    daily|weekly|monthly) printf '%s\n' "$1" ;;
+    off) printf '\n' ;;
+    *) return 1 ;;
+  esac
+}
+
+reality_rotation_schedule() {
+  local schedule="${1:-}"
+  local on_calendar=''
+  on_calendar=$(_rotation_schedule_to_oncalendar "${schedule}") || {
+    err "Invalid schedule: ${schedule}"
+    return 1
+  }
+  if [[ "${schedule}" == "off" ]]; then
+    reality_rotation_remove_units || return 1
+  else
+    _rotation_install_units "${on_calendar}" || return 1
+  fi
+  _rotation_write_schedule_state "${schedule}" "${on_calendar}"
+}
+
+reality_rotation_remove_units() {
+  remove_systemd_unit "${ROTATION_SERVICE_NAME}" "/etc/systemd/system/${ROTATION_SERVICE_NAME}" "best_effort" || true
+  remove_systemd_unit "${ROTATION_TIMER_NAME}" "/etc/systemd/system/${ROTATION_TIMER_NAME}" "best_effort" || true
+}
+```
+
+Also add:
+
+- `_rotation_append_history` with newest-first history
+- `_rotation_trim_history` with `.[0:20]`
+- `_rotation_write_schedule_state`
+- rendered unit contents for `sbx-shortid-rotate.service` and `sbx-shortid-rotate.timer`
+- `Persistent=true` in the timer file
+
+- [ ] **Step 4: Re-run the module test until all schedule and history cases pass**
+
+Run:
+
+```bash
+bash tests/unit/test_reality_rotation.sh
+```
+
+Expected:
+
+- PASS for weekly schedule setup
+- PASS for schedule off
+- PASS for history trimming
+
+- [ ] **Step 5: Commit the schedule layer**
+
+Run:
+
+```bash
+git add lib/reality_rotation.sh tests/unit/test_reality_rotation.sh
+git commit -m "feat: add scheduled short id rotation"
+```
+
+## Task 3: Wire `sbx-manager` Help, Routing, and Flag Validation
+
+**Files:**
+- Create: `tests/unit/test_sbx_manager_rotate_shortid.sh`
+- Modify: `bin/sbx-manager.sh`
+- Test: `bash tests/unit/test_sbx_manager_rotate_shortid.sh`
+
+- [ ] **Step 1: Write failing CLI routing tests**
+
+Create `tests/unit/test_sbx_manager_rotate_shortid.sh` using the pattern from `tests/unit/test_sbx_manager_telegram.sh`.
+
+Stub library example:
+
+```bash
+cat >"${STUB_LIB}/common.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+need_root() { echo "need_root" >>"${INVOCATION_LOG}"; return 0; }
+EOF
+
+cat >"${STUB_LIB}/reality_rotation.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+reality_rotate_shortid() { echo "reality_rotate_shortid $*" >>"${INVOCATION_LOG}"; }
+reality_rotation_schedule() { echo "reality_rotation_schedule $*" >>"${INVOCATION_LOG}"; }
+EOF
+```
+
+Add tests for:
+
+- help text lists `rotate-shortid`
+- `sbx rotate-shortid --dry-run` calls `need_root` then `reality_rotate_shortid --dry-run`
+- `sbx rotate-shortid --schedule weekly` calls `need_root` then `reality_rotation_schedule weekly`
+- `sbx rotate-shortid --dry-run --schedule weekly` exits non-zero with a clear error
+
+- [ ] **Step 2: Run the CLI test to verify it fails**
+
+Run:
+
+```bash
+bash tests/unit/test_sbx_manager_rotate_shortid.sh
+```
+
+Expected:
+
+- FAIL because `bin/sbx-manager.sh` does not yet source `reality_rotation.sh`
+- FAIL because `rotate-shortid` is not in help or command routing
+
+- [ ] **Step 3: Implement the `sbx-manager` integration**
+
+Modify `bin/sbx-manager.sh` in two places:
+
+1. Source the module if present:
+
+```bash
+[[ -f "$LIB_DIR/reality_rotation.sh" ]] && source "$LIB_DIR/reality_rotation.sh"
+```
+
+2. Add help text and command dispatch:
+
+```bash
+${B}Reality Rotation:${N}
+  rotate-shortid [--dry-run]                     Rotate the active Reality short ID
+  rotate-shortid --schedule <daily|weekly|monthly|off>
+                                                Configure automatic short ID rotation
+```
+
+```bash
+  rotate-shortid)
+    need_root || exit 1
+    case "${2:-}" in
+      --schedule)
+        [[ -n "${3:-}" ]] || error_exit "Usage: sbx rotate-shortid --schedule <daily|weekly|monthly|off>"
+        [[ $# -eq 3 ]] || error_exit "Do not combine --schedule with other flags."
+        reality_rotation_schedule "${3}"
+        ;;
+      *)
+        reality_rotate_shortid "$@"
+        ;;
+    esac
+    ;;
+```
+
+Normalize the argument handling so `"$@"` passed to `reality_rotate_shortid` excludes the top-level command name.
+
+- [ ] **Step 4: Re-run the CLI routing test**
+
+Run:
+
+```bash
+bash tests/unit/test_sbx_manager_rotate_shortid.sh
+```
+
+Expected:
+
+- PASS for help text
+- PASS for `--dry-run` routing
+- PASS for `--schedule weekly` routing
+- PASS for invalid flag combinations
+
+- [ ] **Step 5: Commit the CLI integration**
+
+Run:
+
+```bash
+git add bin/sbx-manager.sh tests/unit/test_sbx_manager_rotate_shortid.sh
+git commit -m "feat: add rotate-shortid CLI command"
+```
+
+## Task 4: Register the Module in `install.sh` and Remove Rotation Units on Uninstall
+
+**Files:**
+- Create: `tests/unit/test_reality_rotation_installation.sh`
+- Modify: `install.sh`
+- Test: `bash tests/unit/test_reality_rotation_installation.sh`
+
+- [ ] **Step 1: Write failing install-time assertions**
+
+Create `tests/unit/test_reality_rotation_installation.sh` with static checks:
+
+```bash
+assert_success "grep -qE '\\breality_rotation\\b' '${PROJECT_ROOT}/install.sh'" \
+  "install.sh module list includes reality_rotation"
+assert_success "grep -q '\\[\"reality_rotation\"\\]=' '${PROJECT_ROOT}/install.sh'" \
+  "install.sh API contract includes reality_rotation"
+assert_success "grep -q 'sbx-shortid-rotate.timer' '${PROJECT_ROOT}/install.sh'" \
+  "uninstall flow removes the timer unit"
+assert_success "grep -q 'sbx-shortid-rotate.service' '${PROJECT_ROOT}/install.sh'" \
+  "uninstall flow removes the service unit"
+```
+
+- [ ] **Step 2: Run the install-time assertion test to verify it fails**
+
+Run:
+
+```bash
+bash tests/unit/test_reality_rotation_installation.sh
+```
+
+Expected:
+
+- FAIL because `install.sh` is not yet aware of the new module or timer cleanup
+
+- [ ] **Step 3: Update `install.sh`**
+
+Make these changes:
+
+1. Add `reality_rotation` to the `_load_modules` array after `subscription` and before `stats`.
+
+2. Add an API contract entry:
+
+```bash
+["reality_rotation"]="reality_rotate_shortid reality_rotation_schedule reality_rotation_remove_units"
+```
+
+3. In `uninstall_flow`, remove the units best-effort:
+
+```bash
+  if declare -f reality_rotation_remove_units >/dev/null 2>&1; then
+    reality_rotation_remove_units || true
+  else
+    systemctl stop sbx-shortid-rotate.timer 2>/dev/null || true
+    systemctl disable sbx-shortid-rotate.timer 2>/dev/null || true
+    systemctl stop sbx-shortid-rotate.service 2>/dev/null || true
+    rm -f /etc/systemd/system/sbx-shortid-rotate.service
+    rm -f /etc/systemd/system/sbx-shortid-rotate.timer
+    systemctl daemon-reload 2>/dev/null || true
+  fi
+```
+
+- [ ] **Step 4: Run the install integration test and module dependency tests**
+
+Run:
+
+```bash
+bash tests/unit/test_reality_rotation_installation.sh
+bash tests/unit/test_module_dependencies.sh
+bash tests/unit/test_module_loading_sequence.sh
+```
+
+Expected:
+
+- PASS for module registration
+- PASS for uninstall cleanup assertions
+- PASS for updated module counts and dependency ordering
+
+- [ ] **Step 5: Commit the install/uninstall integration**
+
+Run:
+
+```bash
+git add install.sh tests/unit/test_reality_rotation_installation.sh
+git commit -m "feat: register short id rotation module"
+```
+
+## Task 5: Run Full Verification Locally and on the AWS VM
+
+**Files:**
+- Modify: none expected
+- Test: local unit suite, VM unit suite, VM runtime checks, VM docker smoke
+
+- [ ] **Step 1: Run the targeted local tests**
+
+Run:
+
+```bash
+bash tests/unit/test_reality_rotation.sh
+bash tests/unit/test_sbx_manager_rotate_shortid.sh
+bash tests/unit/test_reality_rotation_installation.sh
+```
+
+Expected:
+
+- all three targeted tests pass
+
+- [ ] **Step 2: Run the local regression suite**
+
+Run:
+
+```bash
+bash tests/test-runner.sh unit
+bash -u install.sh --help
+```
+
+Expected:
+
+- unit suite exits 0
+- `install.sh --help` exits 0 under `bash -u`
+
+- [ ] **Step 3: Sync the branch to the existing AWS VM and run remote unit checks**
+
+On the VM, in `~/sbx`, update to the branch under test, then run:
+
+```bash
+ssh -i ~/.ssh/ai-polling-proxy.pem -o StrictHostKeyChecking=accept-new \
+  admin@18.217.254.125 \
+  'cd ~/sbx && bash tests/test-runner.sh unit'
+```
+
+Expected:
+
+- remote unit suite exits 0 on Debian 12 x86_64
+
+- [ ] **Step 4: Run VM runtime validation for the new command and timer**
+
+On the VM host, with the current branch installed in the existing test environment, run:
+
+```bash
+ssh -i ~/.ssh/ai-polling-proxy.pem -o StrictHostKeyChecking=accept-new \
+  admin@18.217.254.125 \
+  'sudo sbx rotate-shortid --dry-run'
+
+ssh -i ~/.ssh/ai-polling-proxy.pem -o StrictHostKeyChecking=accept-new \
+  admin@18.217.254.125 \
+  'sudo sbx rotate-shortid'
+
+ssh -i ~/.ssh/ai-polling-proxy.pem -o StrictHostKeyChecking=accept-new \
+  admin@18.217.254.125 \
+  "sudo sbx rotate-shortid --schedule weekly && systemctl status sbx-shortid-rotate.timer --no-pager"
+
+ssh -i ~/.ssh/ai-polling-proxy.pem -o StrictHostKeyChecking=accept-new \
+  admin@18.217.254.125 \
+  "sudo systemctl start sbx-shortid-rotate.service && journalctl -u sbx-shortid-rotate.service -n 50 --no-pager"
+```
+
+Expected:
+
+- dry-run prints old/new short IDs without mutating files
+- live rotation changes `config.json`, `client-info.txt`, and `state.json`
+- weekly timer is active
+- service journal shows a successful scheduled rotation path
+
+- [ ] **Step 5: Run VM docker smoke and create the final feature commit**
+
+Run:
+
+```bash
+ssh -i ~/.ssh/ai-polling-proxy.pem -o StrictHostKeyChecking=accept-new \
+  admin@18.217.254.125 \
+  'cd ~/sbx && bash scripts/e2e/install-lifecycle-smoke.sh'
+
+git status --short
+git commit -m "feat: add reality short id rotation"
+```
+
+Expected:
+
+- Docker lifecycle smoke passes on the VM
+- working tree is clean except for the intended feature changes
+
+## Review Checklist
+
+- One scheduler model only: `systemd`, not cron.
+- One state model only: `.protocols.reality.short_id_rotation`.
+- One execution path only: manual and timer runs both call `reality_rotate_shortid`.
+- `--schedule` never performs an immediate rotation.
+- `--dry-run` never mutates files or timers.
+- Config validation happens before any live file replacement.
+- Restart failure restores the old live files.
+- Subscription refresh happens only after a successful restart and only when subscription is enabled.
+- Uninstall removes both `sbx-shortid-rotate.service` and `sbx-shortid-rotate.timer`.

--- a/docs/superpowers/specs/2026-04-18-rotate-shortid-design.md
+++ b/docs/superpowers/specs/2026-04-18-rotate-shortid-design.md
@@ -1,0 +1,356 @@
+# Reality Short ID Rotation Design
+
+Date: 2026-04-18
+
+Status: approved for planning
+
+## Goal
+
+Add an end-to-end Reality short ID rotation feature that supports:
+
+- manual rotation via `sbx rotate-shortid`
+- preview via `--dry-run`
+- scheduled rotation via `systemd` timer
+- automatic refresh of server-side export and subscription sources
+- structured audit history in `state.json`
+
+## Design Principles
+
+- Treat this feature as new product surface, not as a compatibility patch.
+- Do not add cron support, legacy aliases, or alternate schedule syntaxes unless they are required by the current repository.
+- Keep only the minimum compatibility needed to avoid breaking the current primary runtime paths.
+- Prefer one coherent state model, one scheduler model, and one execution path for both manual and scheduled rotation.
+- Fail closed. If validation or restart fails, the old short ID must remain active or be restored.
+
+## Scope
+
+### In scope
+
+- `sbx rotate-shortid` command family
+- `--dry-run`
+- `--schedule {daily|weekly|monthly|off}`
+- dedicated `systemd` service and timer for scheduled rotation
+- `config.json`, `client-info.txt`, and `state.json` updates
+- subscription cache refresh after successful rotation
+- audit logging in `state.json` and `systemd` journal
+- unit tests
+- remote VM runtime verification
+
+### Out of scope
+
+- cron support
+- arbitrary custom `OnCalendar` expressions
+- client-side push updates to already imported remote devices
+- installer-time auto-enable of short ID rotation
+- preserving undocumented legacy short ID rotation state shapes
+
+## Existing Code Anchors
+
+- CLI entrypoint: `bin/sbx-manager.sh`
+- install/uninstall flow: `install.sh`
+- subscription cache and unit patterns: `lib/subscription.sh`
+- generic service helpers: `lib/service.sh`
+- config writers and Reality config shape: `lib/config.sh`
+- export pipeline reading `state.json` and `client-info.txt`: `lib/export.sh`
+- state locking helpers: `lib/common.sh`
+
+## Architecture
+
+### 1. CLI boundary
+
+`bin/sbx-manager.sh` will add a new top-level command:
+
+- `sbx rotate-shortid`
+
+Supported forms:
+
+- `sbx rotate-shortid`
+- `sbx rotate-shortid --dry-run`
+- `sbx rotate-shortid --schedule daily`
+- `sbx rotate-shortid --schedule weekly`
+- `sbx rotate-shortid --schedule monthly`
+- `sbx rotate-shortid --schedule off`
+
+Internal-only invocation for `systemd`:
+
+- `sbx rotate-shortid --scheduled-run`
+
+The CLI layer only parses arguments, enforces incompatible flag combinations, checks root requirement where needed, and delegates to the rotation module.
+
+### 2. Rotation module
+
+Add a new module:
+
+- `lib/reality_rotation.sh`
+
+Responsibilities:
+
+- generate a new valid short ID
+- ensure the new short ID differs from the current one
+- update the Reality short ID in `config.json`
+- update `SHORT_ID` in `client-info.txt`
+- update current short ID and rotation metadata in `state.json`
+- validate candidate config before replacing the live config
+- restart `sing-box`
+- refresh subscription cache when enabled
+- install, remove, and inspect the rotation `systemd` timer
+- emit audit output for manual and scheduled runs
+
+This module owns the feature. The logic must not be spread across `sbx-manager.sh` and `install.sh`.
+
+### 3. Scheduler model
+
+Use only `systemd`:
+
+- `sbx-shortid-rotate.service`
+- `sbx-shortid-rotate.timer`
+
+`service` type:
+
+- `Type=oneshot`
+- `ExecStart=/usr/local/bin/sbx rotate-shortid --scheduled-run`
+
+`timer` schedule mapping:
+
+- `daily` -> `OnCalendar=daily`
+- `weekly` -> `OnCalendar=weekly`
+- `monthly` -> `OnCalendar=monthly`
+
+Required timer properties:
+
+- `Persistent=true`
+
+Rationale:
+
+- matches current Debian 12 VM environment
+- keeps audit trail in `journalctl`
+- aligns with existing repository use of `systemd` units
+- avoids carrying a second scheduling mechanism
+
+## State Model
+
+Keep the current live short ID at:
+
+- `.protocols.reality.short_id`
+
+Add a nested rotation state object at:
+
+- `.protocols.reality.short_id_rotation`
+
+Proposed shape:
+
+```json
+{
+  "protocols": {
+    "reality": {
+      "short_id": "cafebabe",
+      "short_id_rotation": {
+        "enabled": true,
+        "schedule": "weekly",
+        "on_calendar": "weekly",
+        "last_rotated_at": "2026-04-18T12:34:56Z",
+        "last_trigger": "manual",
+        "last_result": "success",
+        "history": [
+          {
+            "at": "2026-04-18T12:34:56Z",
+            "trigger": "manual",
+            "old_short_id": "abcd1234",
+            "new_short_id": "cafebabe",
+            "result": "success"
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+Rules:
+
+- `.protocols.reality.short_id` is the single source of truth for the active runtime short ID.
+- `short_id_rotation.history` stores newest-first entries.
+- History length is capped at 20 entries.
+- `schedule` accepts only `daily`, `weekly`, `monthly`, or `off`.
+- When schedule is `off`, `enabled=false` and `on_calendar=null`.
+- Manual rotations update `last_trigger=manual`.
+- Scheduled rotations update `last_trigger=timer`.
+- Failed attempts append a failure history entry and update `last_result=failed`.
+
+## Command Semantics
+
+### `sbx rotate-shortid`
+
+- Requires root.
+- Rotates immediately.
+- Updates runtime files and restarts `sing-box`.
+- Refreshes subscription cache if subscription is enabled.
+- Writes success or failure audit state.
+
+### `sbx rotate-shortid --dry-run`
+
+- Requires root.
+- Generates a candidate short ID.
+- Validates a temporary config with the candidate short ID.
+- Does not modify live files.
+- Does not restart services.
+- Does not update timer state.
+- Prints the old short ID, candidate short ID, and affected resources.
+
+### `sbx rotate-shortid --schedule <value>`
+
+- Requires root.
+- Only updates scheduling state and timer installation.
+- Does not trigger an immediate rotation.
+- Accepted values: `daily`, `weekly`, `monthly`, `off`.
+
+### `sbx rotate-shortid --scheduled-run`
+
+- Internal-only path for the timer service.
+- Reuses the exact same rotation code path as manual execution.
+- Records trigger type as `timer`.
+
+### Invalid combinations
+
+These must fail fast with a clear error:
+
+- `--dry-run` with `--schedule`
+- `--scheduled-run` with `--dry-run`
+- `--scheduled-run` with `--schedule`
+- unknown schedule value
+
+## Rotation Flow
+
+### Successful rotation
+
+1. Acquire the repository state lock.
+2. Read current short ID from `state.json` or `client-info.txt`, preferring `state.json`.
+3. Generate a new short ID using the existing validation rules.
+4. Ensure new short ID is different from the current short ID.
+5. Build a temporary candidate `config.json` with the new short ID applied to all Reality inbounds.
+6. Run `sing-box check -c <temp_config>`.
+7. If `--dry-run`, print the preview and exit success.
+8. Create backups of live `config.json`, `client-info.txt`, and `state.json`.
+9. Atomically replace live `config.json`.
+10. Atomically replace live `client-info.txt`.
+11. Atomically update `state.json` current short ID and rotation metadata.
+12. Restart `sing-box` using the existing service helper path.
+13. If subscription is enabled, call `subscription_refresh_cache`.
+14. Append success audit entry and trim history to 20.
+15. Print the new short ID and any updated subscription/export context.
+
+### Failure handling
+
+Failure cases:
+
+- candidate config generation fails
+- `sing-box check` fails
+- file replacement fails
+- restart fails
+- subscription refresh fails after successful restart
+
+Handling rules:
+
+- If failure occurs before live file replacement, leave all live files unchanged.
+- If failure occurs after partial replacement but before successful restart, restore backed-up files and restart with the old config.
+- If subscription refresh fails after a successful restart, keep the new short ID active but record the failure in audit state and stderr output.
+- Scheduled runs must surface errors through `journalctl -u sbx-shortid-rotate.service`.
+
+## File Mutation Rules
+
+### `config.json`
+
+- Update every Reality inbound `tls.reality.short_id` to a single-element array containing the new short ID.
+- Do not rewrite unrelated protocol blocks.
+
+### `client-info.txt`
+
+- Update `SHORT_ID="<new_sid>"`.
+- Preserve existing supported keys and file permissions.
+- Use the same secure ownership and permission rules as the current installer output.
+
+### `state.json`
+
+- Update `.protocols.reality.short_id`.
+- Create or update `.protocols.reality.short_id_rotation`.
+- Append success or failure history entry.
+- Trim history to 20 entries.
+
+## Subscription and Export Behavior
+
+After a successful rotation:
+
+- `lib/export.sh` must resolve the new short ID through the updated live sources.
+- If the subscription endpoint is enabled, `subscription_refresh_cache` must rebuild its cached payloads.
+- The feature guarantees that newly fetched export output and subscription responses reflect the new short ID.
+
+The feature does not attempt to mutate configuration files already imported onto external client devices.
+
+## Install and Uninstall Integration
+
+### Install side
+
+- Ensure `lib/reality_rotation.sh` is installed alongside other runtime libraries.
+- Ensure `sbx-manager` help text includes the new command.
+- Do not auto-enable the timer on install.
+
+### Uninstall side
+
+`install.sh` uninstall flow must remove:
+
+- `sbx-shortid-rotate.service`
+- `sbx-shortid-rotate.timer`
+
+This cleanup should follow the repository's current best-effort `systemd` removal pattern.
+
+## Testing Strategy
+
+### Unit tests
+
+Add unit coverage for:
+
+- manual rotation updates `config.json`, `client-info.txt`, and `state.json`
+- `--dry-run` validates candidate config but leaves live files untouched
+- generated short ID differs from previous value
+- history is appended and trimmed to 20 entries
+- `--schedule` writes state and installs or removes timer correctly
+- invalid flag combinations fail
+- restart failure triggers rollback
+- subscription refresh is called only when enabled
+
+### AWS VM runtime verification
+
+Run on the VM:
+
+- `bash tests/test-runner.sh unit`
+- `bash scripts/e2e/install-lifecycle-smoke.sh`
+
+Additional targeted VM validation:
+
+- install or update the timer with `sbx rotate-shortid --schedule weekly`
+- inspect `systemctl status sbx-shortid-rotate.timer`
+- manually trigger the timer service
+- verify `config.json`, `client-info.txt`, `state.json`, and subscription cache reflect the new short ID
+- verify failure and recovery path if runtime validation exposes one
+
+## No-Debt Decisions
+
+These are intentional, not follow-up debt:
+
+- no cron path
+- no arbitrary schedule strings
+- no second compatibility state block outside `.protocols.reality.short_id_rotation`
+- no separate code path for scheduled rotation beyond trigger labeling
+- no attempt to preserve undocumented historical rotation formats
+
+## Planning Notes
+
+Implementation should use TDD:
+
+1. write failing tests for rotation behavior and timer behavior
+2. implement the minimal rotation module
+3. wire CLI entrypoints
+4. wire install and uninstall integration
+5. run unit and VM verification
+
+This design is ready to move into an implementation plan once the user reviews the written spec.

--- a/install.sh
+++ b/install.sh
@@ -2225,13 +2225,16 @@ uninstall_flow() {
   # Remove short-id rotation units (best effort)
   if declare -f reality_rotation_remove_units >/dev/null 2>&1; then
     reality_rotation_remove_units || true
+  elif declare -f remove_systemd_unit >/dev/null 2>&1; then
+    remove_systemd_unit "sbx-shortid-rotate.timer" "/etc/systemd/system/sbx-shortid-rotate.timer" "best_effort" || true
+    remove_systemd_unit "sbx-shortid-rotate.service" "/etc/systemd/system/sbx-shortid-rotate.service" "best_effort" || true
   else
-    systemctl stop "${ROTATION_TIMER_NAME}" 2>/dev/null || true
-    systemctl disable "${ROTATION_TIMER_NAME}" 2>/dev/null || true
-    rm -f "/etc/systemd/system/${ROTATION_TIMER_NAME}"
-    systemctl stop "${ROTATION_SERVICE_NAME}" 2>/dev/null || true
-    systemctl disable "${ROTATION_SERVICE_NAME}" 2>/dev/null || true
-    rm -f "/etc/systemd/system/${ROTATION_SERVICE_NAME}"
+    systemctl stop "sbx-shortid-rotate.timer" 2>/dev/null || true
+    systemctl disable "sbx-shortid-rotate.timer" 2>/dev/null || true
+    rm -f "/etc/systemd/system/sbx-shortid-rotate.timer"
+    systemctl stop "sbx-shortid-rotate.service" 2>/dev/null || true
+    systemctl disable "sbx-shortid-rotate.service" 2>/dev/null || true
+    rm -f "/etc/systemd/system/sbx-shortid-rotate.service"
     systemctl daemon-reload 2>/dev/null || true
   fi
   rm -f /usr/local/bin/sbx-sub-server

--- a/install.sh
+++ b/install.sh
@@ -519,7 +519,7 @@ _download_and_validate_manager_script() {
 _load_modules() {
   local github_repo="https://raw.githubusercontent.com/xrf9268-hue/sbx/main"
   # Module loading order: colors first (required by common and logging), then common loads logging and generators, tools after common
-  local modules=(colors common logging generators tools retry download network validation checksum version certificate caddy_cleanup config config_validator schema_validator service ui backup export messages users port_hopping subscription stats cloudflare_tunnel telegram_bot)
+  local modules=(colors common logging generators tools retry download network validation checksum version certificate caddy_cleanup config config_validator schema_validator service ui backup export messages users port_hopping subscription reality_rotation stats cloudflare_tunnel telegram_bot)
   local temp_lib_dir=""
 
   # Check if lib directory exists
@@ -681,6 +681,7 @@ _verify_module_apis() {
     ["users"]="user_add user_list user_remove user_reset sync_users_to_config"
     ["port_hopping"]="validate_port_range apply_port_hopping_rules remove_port_hopping_rules show_port_hopping_status"
     ["subscription"]="subscription_render subscription_enable subscription_disable subscription_status subscription_url subscription_ensure_state_block"
+    ["reality_rotation"]="reality_rotate_shortid reality_rotation_schedule reality_rotation_remove_units"
     ["stats"]="stats_ensure_state_block stats_overview_pretty stats_overview_json stats_enable stats_disable"
     ["cloudflare_tunnel"]="cloudflared_install cloudflared_enable_token cloudflared_disable cloudflared_status cloudflared_update_state"
     ["telegram_bot"]="telegram_bot_setup telegram_bot_enable telegram_bot_disable telegram_bot_status telegram_bot_run"
@@ -2218,6 +2219,19 @@ uninstall_flow() {
     systemctl stop "${SUBSCRIPTION_SERVICE_NAME}" 2>/dev/null || true
     systemctl disable "${SUBSCRIPTION_SERVICE_NAME}" 2>/dev/null || true
     rm -f "/etc/systemd/system/${SUBSCRIPTION_SERVICE_NAME}.service"
+    systemctl daemon-reload 2>/dev/null || true
+  fi
+
+  # Remove short-id rotation units (best effort)
+  if declare -f reality_rotation_remove_units >/dev/null 2>&1; then
+    reality_rotation_remove_units || true
+  else
+    systemctl stop "${ROTATION_TIMER_NAME}" 2>/dev/null || true
+    systemctl disable "${ROTATION_TIMER_NAME}" 2>/dev/null || true
+    rm -f "/etc/systemd/system/${ROTATION_TIMER_NAME}"
+    systemctl stop "${ROTATION_SERVICE_NAME}" 2>/dev/null || true
+    systemctl disable "${ROTATION_SERVICE_NAME}" 2>/dev/null || true
+    rm -f "/etc/systemd/system/${ROTATION_SERVICE_NAME}"
     systemctl daemon-reload 2>/dev/null || true
   fi
   rm -f /usr/local/bin/sbx-sub-server

--- a/lib/reality_rotation.sh
+++ b/lib/reality_rotation.sh
@@ -55,7 +55,7 @@ _rotation_schedule_to_oncalendar() {
   local schedule="$1"
 
   case "${schedule}" in
-    daily|weekly|monthly)
+    daily | weekly | monthly)
       printf '%s\n' "${schedule}"
       return 0
       ;;
@@ -552,7 +552,7 @@ _reality_rotation_schedule_locked() {
   fi
 
   case "${schedule}" in
-    daily|weekly|monthly)
+    daily | weekly | monthly)
       on_calendar=$(_rotation_schedule_to_oncalendar "${schedule}") || {
         err "Invalid schedule value: ${schedule}"
         return 1
@@ -651,7 +651,7 @@ _reality_rotate_shortid_locked() {
       --scheduled-run)
         scheduled_run=1
         ;;
-      --help|-h)
+      --help | -h)
         _reality_rotation_usage
         return 0
         ;;

--- a/lib/reality_rotation.sh
+++ b/lib/reality_rotation.sh
@@ -91,10 +91,12 @@ _rotation_schedule_backup_file() {
   local backup_file="$2"
 
   if [[ -f "${source_file}" ]]; then
-    cp -a "${source_file}" "${backup_file}"
+    cp -a "${source_file}" "${backup_file}" || return 1
   else
     rm -f "${backup_file}" 2>/dev/null || true
   fi
+
+  return 0
 }
 
 _rotation_schedule_restore_file() {
@@ -102,10 +104,12 @@ _rotation_schedule_restore_file() {
   local target_file="$2"
 
   if [[ -f "${backup_file}" ]]; then
-    cp -a "${backup_file}" "${target_file}"
+    cp -a "${backup_file}" "${target_file}" || return 1
   else
     rm -f "${target_file}" 2>/dev/null || true
   fi
+
+  return 0
 }
 
 _rotation_schedule_restore_consistency() {
@@ -116,17 +120,19 @@ _rotation_schedule_restore_consistency() {
   local timer_backup="$5"
   local timer_unit_path="$6"
 
-  _rotation_schedule_restore_file "${state_backup}" "${state_file}"
-  _rotation_schedule_restore_file "${service_backup}" "${service_unit_path}"
-  _rotation_schedule_restore_file "${timer_backup}" "${timer_unit_path}"
+  _rotation_schedule_restore_file "${state_backup}" "${state_file}" || return 1
+  _rotation_schedule_restore_file "${service_backup}" "${service_unit_path}" || return 1
+  _rotation_schedule_restore_file "${timer_backup}" "${timer_unit_path}" || return 1
+
+  systemctl daemon-reload >/dev/null 2>&1 || return 1
 
   if [[ -f "${timer_backup}" ]]; then
-    systemctl enable --now "${ROTATION_TIMER_NAME}" >/dev/null 2>&1 || true
+    systemctl enable --now "${ROTATION_TIMER_NAME}" >/dev/null 2>&1 || return 1
   else
-    remove_systemd_unit "${ROTATION_TIMER_NAME}" "${timer_unit_path}" "strict" >/dev/null 2>&1 || true
+    remove_systemd_unit "${ROTATION_TIMER_NAME}" "${timer_unit_path}" "strict" || return 1
   fi
 
-  systemctl daemon-reload >/dev/null 2>&1 || true
+  return 0
 }
 
 _rotation_service_unit_content() {

--- a/lib/reality_rotation.sh
+++ b/lib/reality_rotation.sh
@@ -86,6 +86,49 @@ _rotation_append_history() {
     ' <<<"${history_json}"
 }
 
+_rotation_schedule_backup_file() {
+  local source_file="$1"
+  local backup_file="$2"
+
+  if [[ -f "${source_file}" ]]; then
+    cp -a "${source_file}" "${backup_file}"
+  else
+    rm -f "${backup_file}" 2>/dev/null || true
+  fi
+}
+
+_rotation_schedule_restore_file() {
+  local backup_file="$1"
+  local target_file="$2"
+
+  if [[ -f "${backup_file}" ]]; then
+    cp -a "${backup_file}" "${target_file}"
+  else
+    rm -f "${target_file}" 2>/dev/null || true
+  fi
+}
+
+_rotation_schedule_restore_consistency() {
+  local state_backup="$1"
+  local state_file="$2"
+  local service_backup="$3"
+  local service_unit_path="$4"
+  local timer_backup="$5"
+  local timer_unit_path="$6"
+
+  _rotation_schedule_restore_file "${state_backup}" "${state_file}"
+  _rotation_schedule_restore_file "${service_backup}" "${service_unit_path}"
+  _rotation_schedule_restore_file "${timer_backup}" "${timer_unit_path}"
+
+  if [[ -f "${timer_backup}" ]]; then
+    systemctl enable --now "${ROTATION_TIMER_NAME}" >/dev/null 2>&1 || true
+  else
+    remove_systemd_unit "${ROTATION_TIMER_NAME}" "${timer_unit_path}" "strict" >/dev/null 2>&1 || true
+  fi
+
+  systemctl daemon-reload >/dev/null 2>&1 || true
+}
+
 _rotation_service_unit_content() {
   cat <<'EOF'
 [Unit]
@@ -128,7 +171,7 @@ _rotation_install_units() {
 
   install_systemd_unit "${service_unit_path}" "${service_unit_content}"
   install_systemd_unit "${timer_unit_path}" "${timer_unit_content}"
-  systemctl enable "${ROTATION_TIMER_NAME}" >/dev/null 2>&1 || true
+  systemctl enable --now "${ROTATION_TIMER_NAME}" >/dev/null 2>&1
 }
 
 reality_rotation_remove_units() {
@@ -314,10 +357,20 @@ _reality_rotation_update_config() {
 }
 
 reality_rotation_schedule() {
+  with_state_lock "${SBX_LOCK_TIMEOUT_SEC:-30}" _reality_rotation_schedule_locked "$@"
+}
+
+_reality_rotation_schedule_locked() {
   local schedule="${1:-}"
   local state_file=''
   local state_tmp=''
   local on_calendar=''
+  local backup_dir=''
+  local state_backup=''
+  local service_unit_path=''
+  local timer_unit_path=''
+  local service_backup=''
+  local timer_backup=''
 
   if [[ $# -ne 1 ]]; then
     err "Usage: reality_rotation_schedule <daily|weekly|monthly|off>"
@@ -341,34 +394,60 @@ reality_rotation_schedule() {
   esac
 
   state_file=$(_reality_rotation_state_file)
+  service_unit_path=$(_rotation_service_unit_path)
+  timer_unit_path=$(_rotation_timer_unit_path)
   [[ -f "${state_file}" ]] || {
     err "state.json not found: ${state_file}"
     return 1
   }
+
+  backup_dir=$(create_temp_dir "reality-schedule") || return 1
+  state_backup="${backup_dir}/state.json"
+  service_backup="${backup_dir}/$(basename "${service_unit_path}")"
+  timer_backup="${backup_dir}/$(basename "${timer_unit_path}")"
+
+  _rotation_schedule_backup_file "${state_file}" "${state_backup}"
+  _rotation_schedule_backup_file "${service_unit_path}" "${service_backup}"
+  _rotation_schedule_backup_file "${timer_unit_path}" "${timer_backup}"
 
   state_tmp=$(create_temp_file_in_dir "$(dirname "${state_file}")" "state.json") || return 1
 
   if [[ "${schedule}" == "off" ]]; then
     reality_rotation_remove_units || {
       rm -f "${state_tmp}" 2>/dev/null || true
+      _rotation_schedule_restore_consistency "${state_backup}" "${state_file}" "${service_backup}" "${service_unit_path}" "${timer_backup}" "${timer_unit_path}"
+      rm -rf "${backup_dir}" 2>/dev/null || true
       return 1
     }
     _rotation_write_schedule_state "${state_file}" "${state_tmp}" "${schedule}" false "${on_calendar}" || {
       rm -f "${state_tmp}" 2>/dev/null || true
+      _rotation_schedule_restore_consistency "${state_backup}" "${state_file}" "${service_backup}" "${service_unit_path}" "${timer_backup}" "${timer_unit_path}"
+      rm -rf "${backup_dir}" 2>/dev/null || true
       return 1
     }
   else
     _rotation_install_units "${on_calendar}" || {
       rm -f "${state_tmp}" 2>/dev/null || true
+      _rotation_schedule_restore_consistency "${state_backup}" "${state_file}" "${service_backup}" "${service_unit_path}" "${timer_backup}" "${timer_unit_path}"
+      rm -rf "${backup_dir}" 2>/dev/null || true
       return 1
     }
     _rotation_write_schedule_state "${state_file}" "${state_tmp}" "${schedule}" true "${on_calendar}" || {
       rm -f "${state_tmp}" 2>/dev/null || true
+      _rotation_schedule_restore_consistency "${state_backup}" "${state_file}" "${service_backup}" "${service_unit_path}" "${timer_backup}" "${timer_unit_path}"
+      rm -rf "${backup_dir}" 2>/dev/null || true
       return 1
     }
   fi
 
-  mv -f "${state_tmp}" "${state_file}"
+  if ! mv -f "${state_tmp}" "${state_file}"; then
+    rm -f "${state_tmp}" 2>/dev/null || true
+    _rotation_schedule_restore_consistency "${state_backup}" "${state_file}" "${service_backup}" "${service_unit_path}" "${timer_backup}" "${timer_unit_path}"
+    rm -rf "${backup_dir}" 2>/dev/null || true
+    return 1
+  fi
+
+  rm -rf "${backup_dir}" 2>/dev/null || true
 }
 
 _reality_rotate_shortid_locked() {

--- a/lib/reality_rotation.sh
+++ b/lib/reality_rotation.sh
@@ -275,9 +275,11 @@ _rotation_install_units() {
   service_unit_content=$(_rotation_service_unit_content)
   timer_unit_content=$(_rotation_timer_unit_content "${on_calendar}")
 
-  install_systemd_unit "${service_unit_path}" "${service_unit_content}"
-  install_systemd_unit "${timer_unit_path}" "${timer_unit_content}"
-  systemctl enable --now "${ROTATION_TIMER_NAME}" >/dev/null 2>&1
+  install_systemd_unit "${service_unit_path}" "${service_unit_content}" || return 1
+  install_systemd_unit "${timer_unit_path}" "${timer_unit_content}" || return 1
+  systemctl enable --now "${ROTATION_TIMER_NAME}" >/dev/null 2>&1 || return 1
+
+  return 0
 }
 
 reality_rotation_remove_units() {

--- a/lib/reality_rotation.sh
+++ b/lib/reality_rotation.sh
@@ -21,6 +21,7 @@ source "${_LIB_DIR}/service.sh"
 declare -gr ROTATION_SERVICE_NAME="sbx-shortid-rotate.service"
 declare -gr ROTATION_TIMER_NAME="sbx-shortid-rotate.timer"
 declare -gr ROTATION_HISTORY_LIMIT=20
+declare -gr ROTATION_STAGE_REMOVE="__SBX_ROTATION_REMOVE__"
 
 #------------------------------------------------------------------------------
 # Path helpers
@@ -112,6 +113,59 @@ _rotation_schedule_restore_file() {
   return 0
 }
 
+_rotation_stage_restore_target() {
+  local backup_file="$1"
+  local target_file="$2"
+  local out_var="$3"
+  local staged_file=''
+
+  if [[ ! -f "${backup_file}" ]]; then
+    printf -v "${out_var}" '%s' "${ROTATION_STAGE_REMOVE}"
+    return 0
+  fi
+
+  staged_file=$(create_temp_file_in_dir "$(dirname "${target_file}")" "$(basename "${target_file}")") || return 1
+  cp -a "${backup_file}" "${staged_file}" || {
+    rm -f "${staged_file}" 2>/dev/null || true
+    return 1
+  }
+
+  printf -v "${out_var}" '%s' "${staged_file}"
+  return 0
+}
+
+_rotation_cleanup_staged_target() {
+  local staged_file="${1:-}"
+
+  [[ -n "${staged_file}" && "${staged_file}" != "${ROTATION_STAGE_REMOVE}" ]] || return 0
+  rm -f "${staged_file}" 2>/dev/null || true
+}
+
+_rotation_apply_staged_target() {
+  local staged_file="$1"
+  local target_file="$2"
+
+  if [[ "${staged_file}" == "${ROTATION_STAGE_REMOVE}" ]]; then
+    rm -f "${target_file}" 2>/dev/null || true
+    return 0
+  fi
+
+  mv -f "${staged_file}" "${target_file}"
+}
+
+_rotation_restore_target_from_capture() {
+  local capture_file="$1"
+  local target_file="$2"
+
+  if [[ -f "${capture_file}" ]]; then
+    cp -a "${capture_file}" "${target_file}" || return 1
+  else
+    rm -f "${target_file}" 2>/dev/null || true
+  fi
+
+  return 0
+}
+
 _rotation_schedule_restore_consistency() {
   local state_backup="$1"
   local state_file="$2"
@@ -119,10 +173,55 @@ _rotation_schedule_restore_consistency() {
   local service_unit_path="$4"
   local timer_backup="$5"
   local timer_unit_path="$6"
+  local rollback_dir=''
+  local staged_state=''
+  local staged_service=''
+  local staged_timer=''
 
-  _rotation_schedule_restore_file "${state_backup}" "${state_file}" || return 1
-  _rotation_schedule_restore_file "${service_backup}" "${service_unit_path}" || return 1
-  _rotation_schedule_restore_file "${timer_backup}" "${timer_unit_path}" || return 1
+  rollback_dir=$(create_temp_dir "reality-schedule-restore") || return 1
+  _rotation_schedule_backup_file "${state_file}" "${rollback_dir}/state.json" || {
+    rm -rf "${rollback_dir}" 2>/dev/null || true
+    return 1
+  }
+  _rotation_schedule_backup_file "${service_unit_path}" "${rollback_dir}/$(basename "${service_unit_path}")" || {
+    rm -rf "${rollback_dir}" 2>/dev/null || true
+    return 1
+  }
+  _rotation_schedule_backup_file "${timer_unit_path}" "${rollback_dir}/$(basename "${timer_unit_path}")" || {
+    rm -rf "${rollback_dir}" 2>/dev/null || true
+    return 1
+  }
+
+  _rotation_stage_restore_target "${state_backup}" "${state_file}" staged_state || {
+    rm -rf "${rollback_dir}" 2>/dev/null || true
+    return 1
+  }
+  _rotation_stage_restore_target "${service_backup}" "${service_unit_path}" staged_service || {
+    _rotation_cleanup_staged_target "${staged_state}"
+    rm -rf "${rollback_dir}" 2>/dev/null || true
+    return 1
+  }
+  _rotation_stage_restore_target "${timer_backup}" "${timer_unit_path}" staged_timer || {
+    _rotation_cleanup_staged_target "${staged_state}"
+    _rotation_cleanup_staged_target "${staged_service}"
+    rm -rf "${rollback_dir}" 2>/dev/null || true
+    return 1
+  }
+
+  if ! {
+    _rotation_apply_staged_target "${staged_state}" "${state_file}" &&
+      _rotation_apply_staged_target "${staged_service}" "${service_unit_path}" &&
+      _rotation_apply_staged_target "${staged_timer}" "${timer_unit_path}"
+  }; then
+    _rotation_restore_target_from_capture "${rollback_dir}/state.json" "${state_file}" || true
+    _rotation_restore_target_from_capture "${rollback_dir}/$(basename "${service_unit_path}")" "${service_unit_path}" || true
+    _rotation_restore_target_from_capture "${rollback_dir}/$(basename "${timer_unit_path}")" "${timer_unit_path}" || true
+    _rotation_cleanup_staged_target "${staged_state}"
+    _rotation_cleanup_staged_target "${staged_service}"
+    _rotation_cleanup_staged_target "${staged_timer}"
+    rm -rf "${rollback_dir}" 2>/dev/null || true
+    return 1
+  fi
 
   systemctl daemon-reload >/dev/null 2>&1 || return 1
 
@@ -132,6 +231,7 @@ _rotation_schedule_restore_consistency() {
     remove_systemd_unit "${ROTATION_TIMER_NAME}" "${timer_unit_path}" "strict" || return 1
   fi
 
+  rm -rf "${rollback_dir}" 2>/dev/null || true
   return 0
 }
 
@@ -302,17 +402,84 @@ _reality_rotation_restore_backups() {
   local config_file="$2"
   local client_info_file="$3"
   local state_file="$4"
+  local config_backup="${backup_dir}/config.json"
+  local client_backup="${backup_dir}/client-info.txt"
+  local state_backup="${backup_dir}/state.json"
+  local rollback_dir=''
+  local staged_config=''
+  local staged_client=''
+  local staged_state=''
 
-  [[ -f "${backup_dir}/config.json" ]] && cp -a "${backup_dir}/config.json" "${config_file}"
-  [[ -f "${backup_dir}/client-info.txt" ]] && cp -a "${backup_dir}/client-info.txt" "${client_info_file}"
-  [[ -f "${backup_dir}/state.json" ]] && cp -a "${backup_dir}/state.json" "${state_file}"
+  [[ -f "${config_backup}" ]] || return 1
+  [[ -f "${client_backup}" ]] || return 1
+  [[ -f "${state_backup}" ]] || return 1
+
+  rollback_dir=$(create_temp_dir "reality-restore") || return 1
+  _reality_rotation_backup_file "${config_file}" "${rollback_dir}/config.json" || {
+    rm -rf "${rollback_dir}" 2>/dev/null || true
+    return 1
+  }
+  _reality_rotation_backup_file "${client_info_file}" "${rollback_dir}/client-info.txt" || {
+    rm -rf "${rollback_dir}" 2>/dev/null || true
+    return 1
+  }
+  _reality_rotation_backup_file "${state_file}" "${rollback_dir}/state.json" || {
+    rm -rf "${rollback_dir}" 2>/dev/null || true
+    return 1
+  }
+
+  _rotation_stage_restore_target "${config_backup}" "${config_file}" staged_config || {
+    rm -rf "${rollback_dir}" 2>/dev/null || true
+    return 1
+  }
+  _rotation_stage_restore_target "${client_backup}" "${client_info_file}" staged_client || {
+    _rotation_cleanup_staged_target "${staged_config}"
+    rm -rf "${rollback_dir}" 2>/dev/null || true
+    return 1
+  }
+  _rotation_stage_restore_target "${state_backup}" "${state_file}" staged_state || {
+    _rotation_cleanup_staged_target "${staged_config}"
+    _rotation_cleanup_staged_target "${staged_client}"
+    rm -rf "${rollback_dir}" 2>/dev/null || true
+    return 1
+  }
+
+  if ! {
+    _rotation_apply_staged_target "${staged_config}" "${config_file}" &&
+      _rotation_apply_staged_target "${staged_client}" "${client_info_file}" &&
+      _rotation_apply_staged_target "${staged_state}" "${state_file}"
+  }; then
+    _rotation_restore_target_from_capture "${rollback_dir}/config.json" "${config_file}" || true
+    _rotation_restore_target_from_capture "${rollback_dir}/client-info.txt" "${client_info_file}" || true
+    _rotation_restore_target_from_capture "${rollback_dir}/state.json" "${state_file}" || true
+    _rotation_cleanup_staged_target "${staged_config}"
+    _rotation_cleanup_staged_target "${staged_client}"
+    _rotation_cleanup_staged_target "${staged_state}"
+    rm -rf "${rollback_dir}" 2>/dev/null || true
+    return 1
+  fi
+
+  rm -rf "${rollback_dir}" 2>/dev/null || true
+  return 0
 }
 
 _reality_rotation_restart_service_safely() {
   (
-    unset SBX_LOCK_FILE
-    restart_service
+    _restart_service_impl
   )
+}
+
+_reality_rotation_with_mutation_locks() {
+  local locked_command="${1:-}"
+  local timeout="${SBX_LOCK_TIMEOUT_SEC:-30}"
+
+  [[ -n "${locked_command}" ]] || {
+    err "_reality_rotation_with_mutation_locks requires a command"
+    return 1
+  }
+  shift || true
+
+  with_flock "${timeout}" with_state_lock "${timeout}" "${locked_command}" "$@"
 }
 
 _reality_rotation_update_state() {
@@ -364,7 +531,7 @@ _reality_rotation_update_config() {
 }
 
 reality_rotation_schedule() {
-  with_state_lock "${SBX_LOCK_TIMEOUT_SEC:-30}" _reality_rotation_schedule_locked "$@"
+  _reality_rotation_with_mutation_locks _reality_rotation_schedule_locked "$@"
 }
 
 _reality_rotation_schedule_locked() {
@@ -591,7 +758,9 @@ _reality_rotate_shortid_locked() {
       mv -f "${state_tmp}" "${state_file}"
   }; then
     warn "Failed to commit rotation changes, restoring previous files"
-    _reality_rotation_restore_backups "${backup_dir}" "${config_file}" "${client_info_file}" "${state_file}"
+    if ! _reality_rotation_restore_backups "${backup_dir}" "${config_file}" "${client_info_file}" "${state_file}"; then
+      warn "Failed to restore previous files after commit failure"
+    fi
     rm -f "${config_tmp}" "${client_tmp}" "${state_tmp}" 2>/dev/null || true
     rm -rf "${backup_dir}" 2>/dev/null || true
     return 1
@@ -599,7 +768,11 @@ _reality_rotate_shortid_locked() {
 
   if ! _reality_rotation_restart_service_safely; then
     warn "Service restart failed, restoring previous Reality short ID"
-    _reality_rotation_restore_backups "${backup_dir}" "${config_file}" "${client_info_file}" "${state_file}"
+    if ! _reality_rotation_restore_backups "${backup_dir}" "${config_file}" "${client_info_file}" "${state_file}"; then
+      warn "Failed to restore previous Reality short ID files"
+      rm -rf "${backup_dir}" 2>/dev/null || true
+      return 1
+    fi
     if ! _reality_rotation_restart_service_safely; then
       warn "Failed to restart sing-box after restoring previous files"
       rm -rf "${backup_dir}" 2>/dev/null || true
@@ -622,9 +795,7 @@ _reality_rotate_shortid_locked() {
 }
 
 reality_rotate_shortid() {
-  local arg=''
-
-  with_state_lock "${SBX_LOCK_TIMEOUT_SEC:-30}" _reality_rotate_shortid_locked "$@"
+  _reality_rotation_with_mutation_locks _reality_rotate_shortid_locked "$@"
 }
 
 export -f reality_rotate_shortid

--- a/lib/reality_rotation.sh
+++ b/lib/reality_rotation.sh
@@ -1,0 +1,336 @@
+#!/usr/bin/env bash
+# lib/reality_rotation.sh - Reality short ID rotation
+
+set -euo pipefail
+
+[[ -n "${_SBX_REALITY_ROTATION_LOADED:-}" ]] && return 0
+readonly _SBX_REALITY_ROTATION_LOADED=1
+
+_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${_LIB_DIR}/common.sh"
+# shellcheck source=/dev/null
+source "${_LIB_DIR}/validation.sh"
+# shellcheck source=/dev/null
+source "${_LIB_DIR}/service.sh"
+
+#------------------------------------------------------------------------------
+# Rotation constants
+#------------------------------------------------------------------------------
+
+declare -gr ROTATION_SERVICE_NAME="sbx-shortid-rotate.service"
+declare -gr ROTATION_TIMER_NAME="sbx-shortid-rotate.timer"
+declare -gr ROTATION_HISTORY_LIMIT=20
+
+#------------------------------------------------------------------------------
+# Path helpers
+#------------------------------------------------------------------------------
+
+_reality_rotation_state_file() {
+  echo "${TEST_STATE_FILE:-${STATE_FILE:-${SB_CONF_DIR:-/etc/sing-box}/state.json}}"
+}
+
+_reality_rotation_client_info_file() {
+  echo "${TEST_CLIENT_INFO:-${CLIENT_INFO:-${SB_CONF_DIR:-/etc/sing-box}/client-info.txt}}"
+}
+
+_reality_rotation_config_file() {
+  echo "${TEST_CONFIG_FILE:-${SB_CONF:-${SB_CONF_DIR:-/etc/sing-box}/config.json}}"
+}
+
+_reality_rotation_usage() {
+  cat <<'EOF'
+Usage: reality_rotate_shortid [--dry-run] [--scheduled-run]
+EOF
+}
+
+_reality_rotation_read_short_id() {
+  local state_file="$1"
+
+  jq -r '.protocols.reality.short_id // empty' "${state_file}" 2>/dev/null
+}
+
+_reality_rotation_generate_short_id() {
+  local current_short_id="$1"
+  local attempt=0
+  local candidate=''
+
+  while [[ ${attempt} -lt 5 ]]; do
+    candidate=$(openssl rand -hex 4)
+    [[ "${candidate}" =~ ^[0-9a-f]{8}$ ]] || {
+      attempt=$((attempt + 1))
+      continue
+    }
+    if [[ "${candidate}" != "${current_short_id}" ]]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+    attempt=$((attempt + 1))
+  done
+
+  return 1
+}
+
+_reality_rotation_write_client_info() {
+  local source_file="$1"
+  local target_file="$2"
+  local short_id="$3"
+
+  awk -v short_id="${short_id}" '
+    BEGIN { replaced = 0 }
+    /^[[:space:]]*SHORT_ID=/ {
+      print "SHORT_ID=\"" short_id "\""
+      replaced = 1
+      next
+    }
+    { print }
+    END {
+      if (!replaced) {
+        print "SHORT_ID=\"" short_id "\""
+      }
+    }
+  ' "${source_file}" >"${target_file}"
+}
+
+_reality_rotation_validate_candidate_config() {
+  local config_file="$1"
+  local reality_count=''
+  local sb_bin="${TEST_SB_BIN:-${SB_BIN}}"
+
+  have jq || {
+    err "jq is required to validate candidate Reality configs"
+    return 1
+  }
+
+  reality_count=$(jq '[.inbounds[]? | select(.tls.reality? != null)] | length' "${config_file}" 2>/dev/null)
+  if [[ "${reality_count}" -lt 1 ]]; then
+    err "No Reality inbound found in configuration"
+    return 1
+  fi
+
+  "${sb_bin}" check -c "${config_file}" >/dev/null
+}
+
+_reality_rotation_backup_file() {
+  local source_file="$1"
+  local target_file="$2"
+
+  cp -a "${source_file}" "${target_file}"
+}
+
+_reality_rotation_restore_backups() {
+  local backup_dir="$1"
+  local config_file="$2"
+  local client_info_file="$3"
+  local state_file="$4"
+
+  [[ -f "${backup_dir}/config.json" ]] && cp -a "${backup_dir}/config.json" "${config_file}"
+  [[ -f "${backup_dir}/client-info.txt" ]] && cp -a "${backup_dir}/client-info.txt" "${client_info_file}"
+  [[ -f "${backup_dir}/state.json" ]] && cp -a "${backup_dir}/state.json" "${state_file}"
+}
+
+_reality_rotation_update_state() {
+  local state_file="$1"
+  local output_file="$2"
+  local current_short_id="$3"
+  local new_short_id="$4"
+  local trigger="$5"
+  local rotated_at="$6"
+
+  jq \
+    --arg sid "${new_short_id}" \
+    --arg old "${current_short_id}" \
+    --arg trigger "${trigger}" \
+    --arg rotated_at "${rotated_at}" \
+    --argjson history_limit "${ROTATION_HISTORY_LIMIT}" \
+    '
+    .protocols.reality.short_id = $sid
+    | .protocols.reality.short_id_rotation = (
+        (.protocols.reality.short_id_rotation // {})
+        | .current_short_id = $sid
+        | .previous_short_id = $old
+        | .rotated_at = $rotated_at
+        | .trigger = $trigger
+        | .history = ([{short_id: $old, rotated_at: $rotated_at, trigger: $trigger}] + (.history // []))[:$history_limit]
+      )
+    ' "${state_file}" >"${output_file}"
+}
+
+_reality_rotation_update_config() {
+  local config_file="$1"
+  local output_file="$2"
+  local short_id="$3"
+
+  jq \
+    --arg sid "${short_id}" \
+    '
+    (.inbounds[]? | select(.tls.reality? != null) | .tls.reality.short_id) = [$sid]
+    ' "${config_file}" >"${output_file}"
+}
+
+_reality_rotate_shortid_locked() {
+  local dry_run=0
+  local scheduled_run=0
+  local arg=''
+  local state_file=''
+  local config_file=''
+  local client_info_file=''
+  local current_short_id=''
+  local new_short_id=''
+  local trigger='manual'
+  local rotated_at=''
+  local backup_dir=''
+  local config_tmp=''
+  local client_tmp=''
+  local state_tmp=''
+  local subscription_enabled='false'
+
+  while [[ $# -gt 0 ]]; do
+    arg="$1"
+    shift
+    case "${arg}" in
+      --dry-run)
+        dry_run=1
+        ;;
+      --scheduled-run)
+        scheduled_run=1
+        ;;
+      --help|-h)
+        _reality_rotation_usage
+        return 0
+        ;;
+      *)
+        err "Unknown argument: ${arg}"
+        _reality_rotation_usage
+        return 1
+        ;;
+    esac
+  done
+
+  if [[ "${scheduled_run}" -eq 1 ]]; then
+    trigger='scheduled'
+  fi
+
+  state_file=$(_reality_rotation_state_file)
+  config_file=$(_reality_rotation_config_file)
+  client_info_file=$(_reality_rotation_client_info_file)
+
+  [[ -f "${state_file}" ]] || {
+    err "state.json not found: ${state_file}"
+    return 1
+  }
+  [[ -f "${config_file}" ]] || {
+    err "config.json not found: ${config_file}"
+    return 1
+  }
+  [[ -f "${client_info_file}" ]] || {
+    err "client-info.txt not found: ${client_info_file}"
+    return 1
+  }
+
+  current_short_id=$(_reality_rotation_read_short_id "${state_file}")
+  [[ -n "${current_short_id}" ]] || {
+    err "Current Reality short ID is missing from state.json"
+    return 1
+  }
+  [[ "${current_short_id}" =~ ^[0-9a-fA-F]{1,8}$ ]] || {
+    err "Current Reality short ID is invalid: ${current_short_id}"
+    return 1
+  }
+
+  new_short_id=$(_reality_rotation_generate_short_id "${current_short_id}") || {
+    err "Failed to generate a new Reality short ID"
+    return 1
+  }
+
+  rotated_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  backup_dir=$(create_temp_dir "reality-rotate") || return 1
+  config_tmp=$(create_temp_file_in_dir "$(dirname "${config_file}")" "config.json") || {
+    rm -rf "${backup_dir}" 2>/dev/null || true
+    return 1
+  }
+  client_tmp=$(create_temp_file_in_dir "$(dirname "${client_info_file}")" "client-info.txt") || {
+    rm -f "${config_tmp}" 2>/dev/null || true
+    rm -rf "${backup_dir}" 2>/dev/null || true
+    return 1
+  }
+  state_tmp=$(create_temp_file_in_dir "$(dirname "${state_file}")" "state.json") || {
+    rm -f "${config_tmp}" "${client_tmp}" 2>/dev/null || true
+    rm -rf "${backup_dir}" 2>/dev/null || true
+    return 1
+  }
+
+  _reality_rotation_update_config "${config_file}" "${config_tmp}" "${new_short_id}" || {
+    rm -f "${config_tmp}" "${client_tmp}" "${state_tmp}" 2>/dev/null || true
+    rm -rf "${backup_dir}" 2>/dev/null || true
+    return 1
+  }
+  _reality_rotation_write_client_info "${client_info_file}" "${client_tmp}" "${new_short_id}" || {
+    rm -f "${config_tmp}" "${client_tmp}" "${state_tmp}" 2>/dev/null || true
+    rm -rf "${backup_dir}" 2>/dev/null || true
+    return 1
+  }
+  _reality_rotation_update_state "${state_file}" "${state_tmp}" "${current_short_id}" "${new_short_id}" "${trigger}" "${rotated_at}" || {
+    rm -f "${config_tmp}" "${client_tmp}" "${state_tmp}" 2>/dev/null || true
+    rm -rf "${backup_dir}" 2>/dev/null || true
+    return 1
+  }
+
+  _reality_rotation_validate_candidate_config "${config_tmp}" || {
+    rm -f "${config_tmp}" "${client_tmp}" "${state_tmp}" 2>/dev/null || true
+    rm -rf "${backup_dir}" 2>/dev/null || true
+    return 1
+  }
+
+  if [[ "${dry_run}" -eq 1 ]]; then
+    msg "Reality short ID rotation dry run"
+    msg "  current: ${current_short_id}"
+    msg "  new:     ${new_short_id}"
+    msg "  trigger:  ${trigger}"
+    rm -f "${config_tmp}" "${client_tmp}" "${state_tmp}" 2>/dev/null || true
+    rm -rf "${backup_dir}" 2>/dev/null || true
+    return 0
+  fi
+
+  _reality_rotation_backup_file "${config_file}" "${backup_dir}/config.json"
+  _reality_rotation_backup_file "${client_info_file}" "${backup_dir}/client-info.txt"
+  _reality_rotation_backup_file "${state_file}" "${backup_dir}/state.json"
+
+  if ! {
+    mv -f "${config_tmp}" "${config_file}" &&
+      mv -f "${client_tmp}" "${client_info_file}" &&
+      mv -f "${state_tmp}" "${state_file}"
+  }; then
+    warn "Failed to commit rotation changes, restoring previous files"
+    _reality_rotation_restore_backups "${backup_dir}" "${config_file}" "${client_info_file}" "${state_file}"
+    rm -f "${config_tmp}" "${client_tmp}" "${state_tmp}" 2>/dev/null || true
+    rm -rf "${backup_dir}" 2>/dev/null || true
+    return 1
+  fi
+
+  if ! restart_service; then
+    warn "Service restart failed, restoring previous Reality short ID"
+    _reality_rotation_restore_backups "${backup_dir}" "${config_file}" "${client_info_file}" "${state_file}"
+    rm -rf "${backup_dir}" 2>/dev/null || true
+    return 1
+  fi
+
+  if declare -f subscription_refresh_cache >/dev/null 2>&1; then
+    subscription_enabled=$(jq -r '.subscription.enabled // false' "${state_file}" 2>/dev/null || echo false)
+    if [[ "${subscription_enabled}" == "true" ]]; then
+      subscription_refresh_cache >/dev/null 2>&1 || true
+    fi
+  fi
+
+  rm -rf "${backup_dir}" 2>/dev/null || true
+  success "Reality short ID rotated: ${current_short_id} -> ${new_short_id}"
+  return 0
+}
+
+reality_rotate_shortid() {
+  local arg=''
+
+  with_state_lock "${SBX_LOCK_TIMEOUT_SEC:-30}" _reality_rotate_shortid_locked "$@"
+}
+
+export -f reality_rotate_shortid

--- a/lib/reality_rotation.sh
+++ b/lib/reality_rotation.sh
@@ -129,6 +129,12 @@ _reality_rotation_restore_backups() {
   [[ -f "${backup_dir}/state.json" ]] && cp -a "${backup_dir}/state.json" "${state_file}"
 }
 
+_reality_rotation_restart_service_safely() {
+  (
+    restart_service
+  )
+}
+
 _reality_rotation_update_state() {
   local state_file="$1"
   local output_file="$2"
@@ -208,7 +214,7 @@ _reality_rotate_shortid_locked() {
   done
 
   if [[ "${scheduled_run}" -eq 1 ]]; then
-    trigger='scheduled'
+    trigger='timer'
   fi
 
   state_file=$(_reality_rotation_state_file)
@@ -308,9 +314,14 @@ _reality_rotate_shortid_locked() {
     return 1
   fi
 
-  if ! restart_service; then
+  if ! _reality_rotation_restart_service_safely; then
     warn "Service restart failed, restoring previous Reality short ID"
     _reality_rotation_restore_backups "${backup_dir}" "${config_file}" "${client_info_file}" "${state_file}"
+    if ! _reality_rotation_restart_service_safely; then
+      warn "Failed to restart sing-box after restoring previous files"
+      rm -rf "${backup_dir}" 2>/dev/null || true
+      return 1
+    fi
     rm -rf "${backup_dir}" 2>/dev/null || true
     return 1
   fi

--- a/lib/reality_rotation.sh
+++ b/lib/reality_rotation.sh
@@ -38,6 +38,136 @@ _reality_rotation_config_file() {
   echo "${TEST_CONFIG_FILE:-${SB_CONF:-${SB_CONF_DIR:-/etc/sing-box}/config.json}}"
 }
 
+_rotation_unit_dir() {
+  echo "${TEST_SYSTEMD_DIR:-${SBX_SYSTEMD_DIR:-/etc/systemd/system}}"
+}
+
+_rotation_service_unit_path() {
+  printf '%s/%s\n' "$(_rotation_unit_dir)" "${ROTATION_SERVICE_NAME}"
+}
+
+_rotation_timer_unit_path() {
+  printf '%s/%s\n' "$(_rotation_unit_dir)" "${ROTATION_TIMER_NAME}"
+}
+
+_rotation_schedule_to_oncalendar() {
+  local schedule="$1"
+
+  case "${schedule}" in
+    daily|weekly|monthly)
+      printf '%s\n' "${schedule}"
+      return 0
+      ;;
+    off)
+      printf '\n'
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+_rotation_append_history() {
+  local history_json="${1:-[]}"
+  local short_id="$2"
+  local rotated_at="$3"
+  local trigger="$4"
+  local history_limit="${5:-${ROTATION_HISTORY_LIMIT}}"
+
+  jq -c \
+    --arg short_id "${short_id}" \
+    --arg rotated_at "${rotated_at}" \
+    --arg trigger "${trigger}" \
+    --argjson history_limit "${history_limit}" \
+    '
+    ([{short_id: $short_id, rotated_at: $rotated_at, trigger: $trigger}] +
+      (if type == "array" then . else [] end))[:$history_limit]
+    ' <<<"${history_json}"
+}
+
+_rotation_service_unit_content() {
+  cat <<'EOF'
+[Unit]
+Description=sbx short ID rotation service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/sbx rotate-shortid --scheduled-run
+EOF
+}
+
+_rotation_timer_unit_content() {
+  local on_calendar="$1"
+
+  cat <<EOF
+[Unit]
+Description=sbx short ID rotation timer
+
+[Timer]
+OnCalendar=${on_calendar}
+Persistent=true
+Unit=${ROTATION_SERVICE_NAME}
+
+[Install]
+WantedBy=timers.target
+EOF
+}
+
+_rotation_install_units() {
+  local on_calendar="$1"
+  local service_unit_path=''
+  local timer_unit_path=''
+  local service_unit_content=''
+  local timer_unit_content=''
+
+  service_unit_path=$(_rotation_service_unit_path)
+  timer_unit_path=$(_rotation_timer_unit_path)
+  service_unit_content=$(_rotation_service_unit_content)
+  timer_unit_content=$(_rotation_timer_unit_content "${on_calendar}")
+
+  install_systemd_unit "${service_unit_path}" "${service_unit_content}"
+  install_systemd_unit "${timer_unit_path}" "${timer_unit_content}"
+  systemctl enable "${ROTATION_TIMER_NAME}" >/dev/null 2>&1 || true
+}
+
+reality_rotation_remove_units() {
+  local service_unit_path=''
+  local timer_unit_path=''
+
+  service_unit_path=$(_rotation_service_unit_path)
+  timer_unit_path=$(_rotation_timer_unit_path)
+
+  remove_systemd_unit "${ROTATION_TIMER_NAME}" "${timer_unit_path}" "strict" || return 1
+  remove_systemd_unit "${ROTATION_SERVICE_NAME}" "${service_unit_path}" "strict" || return 1
+}
+
+_rotation_write_schedule_state() {
+  local state_file="$1"
+  local output_file="$2"
+  local schedule="$3"
+  local enabled="$4"
+  local on_calendar="${5:-}"
+  local on_calendar_json='null'
+
+  if [[ -n "${on_calendar}" ]]; then
+    on_calendar_json=$(jq -Rn --arg value "${on_calendar}" '$value')
+  fi
+
+  jq \
+    --arg schedule "${schedule}" \
+    --argjson enabled "${enabled}" \
+    --argjson on_calendar "${on_calendar_json}" \
+    '
+    .protocols.reality.short_id_rotation = (
+      (.protocols.reality.short_id_rotation // {})
+      | .schedule = $schedule
+      | .enabled = $enabled
+      | .on_calendar = $on_calendar
+    )
+    ' "${state_file}" >"${output_file}"
+}
+
 _reality_rotation_usage() {
   cat <<'EOF'
 Usage: reality_rotate_shortid [--dry-run] [--scheduled-run]
@@ -142,13 +272,22 @@ _reality_rotation_update_state() {
   local new_short_id="$4"
   local trigger="$5"
   local rotated_at="$6"
+  local history=''
 
+  history=$(
+    _rotation_append_history \
+      "$(jq -c '.protocols.reality.short_id_rotation.history // []' "${state_file}" 2>/dev/null || echo '[]')" \
+      "${current_short_id}" \
+      "${rotated_at}" \
+      "${trigger}" \
+      "${ROTATION_HISTORY_LIMIT}"
+  )
   jq \
     --arg sid "${new_short_id}" \
     --arg old "${current_short_id}" \
     --arg trigger "${trigger}" \
     --arg rotated_at "${rotated_at}" \
-    --argjson history_limit "${ROTATION_HISTORY_LIMIT}" \
+    --argjson history "${history}" \
     '
     .protocols.reality.short_id = $sid
     | .protocols.reality.short_id_rotation = (
@@ -157,7 +296,7 @@ _reality_rotation_update_state() {
         | .previous_short_id = $old
         | .rotated_at = $rotated_at
         | .trigger = $trigger
-        | .history = ([{short_id: $old, rotated_at: $rotated_at, trigger: $trigger}] + (.history // []))[:$history_limit]
+        | .history = $history
       )
     ' "${state_file}" >"${output_file}"
 }
@@ -172,6 +311,64 @@ _reality_rotation_update_config() {
     '
     (.inbounds[]? | select(.tls.reality? != null) | .tls.reality.short_id) = [$sid]
     ' "${config_file}" >"${output_file}"
+}
+
+reality_rotation_schedule() {
+  local schedule="${1:-}"
+  local state_file=''
+  local state_tmp=''
+  local on_calendar=''
+
+  if [[ $# -ne 1 ]]; then
+    err "Usage: reality_rotation_schedule <daily|weekly|monthly|off>"
+    return 1
+  fi
+
+  case "${schedule}" in
+    daily|weekly|monthly)
+      on_calendar=$(_rotation_schedule_to_oncalendar "${schedule}") || {
+        err "Invalid schedule value: ${schedule}"
+        return 1
+      }
+      ;;
+    off)
+      on_calendar=''
+      ;;
+    *)
+      err "Invalid schedule value: ${schedule}"
+      return 1
+      ;;
+  esac
+
+  state_file=$(_reality_rotation_state_file)
+  [[ -f "${state_file}" ]] || {
+    err "state.json not found: ${state_file}"
+    return 1
+  }
+
+  state_tmp=$(create_temp_file_in_dir "$(dirname "${state_file}")" "state.json") || return 1
+
+  if [[ "${schedule}" == "off" ]]; then
+    reality_rotation_remove_units || {
+      rm -f "${state_tmp}" 2>/dev/null || true
+      return 1
+    }
+    _rotation_write_schedule_state "${state_file}" "${state_tmp}" "${schedule}" false "${on_calendar}" || {
+      rm -f "${state_tmp}" 2>/dev/null || true
+      return 1
+    }
+  else
+    _rotation_install_units "${on_calendar}" || {
+      rm -f "${state_tmp}" 2>/dev/null || true
+      return 1
+    }
+    _rotation_write_schedule_state "${state_file}" "${state_tmp}" "${schedule}" true "${on_calendar}" || {
+      rm -f "${state_tmp}" 2>/dev/null || true
+      return 1
+    }
+  fi
+
+  mv -f "${state_tmp}" "${state_file}"
 }
 
 _reality_rotate_shortid_locked() {
@@ -345,3 +542,4 @@ reality_rotate_shortid() {
 }
 
 export -f reality_rotate_shortid
+export -f reality_rotation_schedule reality_rotation_remove_units

--- a/lib/reality_rotation.sh
+++ b/lib/reality_rotation.sh
@@ -310,6 +310,7 @@ _reality_rotation_restore_backups() {
 
 _reality_rotation_restart_service_safely() {
   (
+    unset SBX_LOCK_FILE
     restart_service
   )
 }

--- a/lib/service.sh
+++ b/lib/service.sh
@@ -29,9 +29,9 @@ install_systemd_unit() {
   local unit_path="$1"
   local unit_content="${2:-}"
 
-  printf '%s\n' "${unit_content}" >"${unit_path}"
-  chmod 644 "${unit_path}"
-  systemctl daemon-reload >/dev/null 2>&1 || true
+  printf '%s\n' "${unit_content}" >"${unit_path}" || return 1
+  chmod 644 "${unit_path}" || return 1
+  systemctl daemon-reload >/dev/null 2>&1 || return 1
 
   return 0
 }
@@ -59,7 +59,7 @@ WantedBy=multi-user.target
 EOF
   )
 
-  install_systemd_unit "${SB_SVC}" "${unit_content}"
+  install_systemd_unit "${SB_SVC}" "${unit_content}" || return 1
 
   success "  ✓ Service file created"
   return 0

--- a/tests/unit/test_reality_rotation.sh
+++ b/tests/unit/test_reality_rotation.sh
@@ -245,6 +245,18 @@ run_schedule() {
       source "'"${PROJECT_ROOT}"'/lib/reality_rotation.sh"
       systemctl() {
         printf "systemctl %s\n" "$*" >>"'"${TEST_TMP}"'/systemctl.log"
+        if [[ "${SYSTEMCTL_FAIL_ENABLE_NOW_ONCE:-0}" == "1" && "${1:-}" == "enable" && "${2:-}" == "--now" ]]; then
+          local enable_now_count_file="'"${TEST_TMP}"'/systemctl-enable-now.count"
+          local enable_now_count=0
+          if [[ -f "${enable_now_count_file}" ]]; then
+            enable_now_count=$(cat "${enable_now_count_file}")
+          fi
+          enable_now_count=$((enable_now_count + 1))
+          printf "%s\n" "${enable_now_count}" >"${enable_now_count_file}"
+          if [[ "${enable_now_count}" -eq 1 ]]; then
+            return 1
+          fi
+        fi
         if [[ "${SYSTEMCTL_FAIL_ENABLE_NOW:-0}" == "1" && "${1:-}" == "enable" && "${2:-}" == "--now" ]]; then
           return 1
         fi
@@ -454,6 +466,40 @@ test_schedule_enable_failure_rolls_back_state_and_units() {
     "failed activation exercises rollback removal"
 }
 
+test_schedule_change_failure_restores_prior_active_schedule() {
+  local before_state=''
+  local before_service=''
+  local before_timer=''
+  local daemon_reload_line=''
+  local rollback_enable_line=''
+
+  run_schedule weekly
+  before_state=$(cat "${STATE_FILE_PATH}")
+  before_service=$(cat "$(rotation_service_unit_path)")
+  before_timer=$(cat "$(rotation_timer_unit_path)")
+
+  SYSTEMCTL_FAIL_ENABLE_NOW_ONCE=1 assert_failure "run_schedule monthly" \
+    "failed schedule change should fail"
+
+  assert_equals "${before_state}" "$(cat "${STATE_FILE_PATH}")" \
+    "failed schedule change restores prior state"
+  assert_equals "${before_service}" "$(cat "$(rotation_service_unit_path)")" \
+    "failed schedule change restores prior service unit"
+  assert_equals "${before_timer}" "$(cat "$(rotation_timer_unit_path)")" \
+    "failed schedule change restores prior timer unit"
+  assert_equals "weekly" "$(jq -r '.protocols.reality.short_id_rotation.schedule' "${STATE_FILE_PATH}")" \
+    "failed schedule change keeps prior schedule"
+  assert_equals "true" "$(jq -r '.protocols.reality.short_id_rotation.enabled' "${STATE_FILE_PATH}")" \
+    "failed schedule change keeps prior enabled state"
+  assert_equals "weekly" "$(jq -r '.protocols.reality.short_id_rotation.on_calendar' "${STATE_FILE_PATH}")" \
+    "failed schedule change keeps prior on-calendar"
+
+  daemon_reload_line=$(grep -n 'systemctl daemon-reload' "${TEST_TMP}/systemctl.log" | tail -1 | cut -d: -f1)
+  rollback_enable_line=$(grep -n 'systemctl enable --now sbx-shortid-rotate.timer' "${TEST_TMP}/systemctl.log" | tail -1 | cut -d: -f1)
+  assert_greater_than "${rollback_enable_line}" "${daemon_reload_line}" \
+    "rollback re-enables timer only after daemon-reload"
+}
+
 test_history_trimming_keeps_twenty_entries() {
   local history_count=''
 
@@ -495,6 +541,9 @@ main() {
   teardown_fixture
   setup_fixture
   test_schedule_enable_failure_rolls_back_state_and_units
+  teardown_fixture
+  setup_fixture
+  test_schedule_change_failure_restores_prior_active_schedule
   teardown_fixture
   setup_fixture
   test_history_trimming_keeps_twenty_entries

--- a/tests/unit/test_reality_rotation.sh
+++ b/tests/unit/test_reality_rotation.sh
@@ -15,8 +15,12 @@ FAKE_BIN_DIR=""
 STATE_FILE_PATH=""
 CONFIG_FILE_PATH=""
 CLIENT_INFO_PATH=""
+SYSTEMD_DIR_PATH=""
 LOCK_FILE_PATH=""
 LAST_ROTATION_OUTPUT=""
+LAST_SCHEDULE_OUTPUT=""
+ROTATION_SERVICE_UNIT_NAME="sbx-shortid-rotate.service"
+ROTATION_TIMER_UNIT_NAME="sbx-shortid-rotate.timer"
 
 setup_fixture() {
   LAST_ROTATION_OUTPUT=""
@@ -25,9 +29,11 @@ setup_fixture() {
   STATE_FILE_PATH="${TEST_TMP}/state.json"
   CONFIG_FILE_PATH="${TEST_TMP}/config.json"
   CLIENT_INFO_PATH="${TEST_TMP}/client-info.txt"
+  SYSTEMD_DIR_PATH="${TEST_TMP}/systemd"
   LOCK_FILE_PATH="${TEST_TMP}/sbx-state.lock"
 
   mkdir -p "${FAKE_BIN_DIR}"
+  mkdir -p "${SYSTEMD_DIR_PATH}"
 
   cat >"${FAKE_BIN_DIR}/sing-box" <<'EOF'
 #!/usr/bin/env bash
@@ -127,6 +133,8 @@ EOF
   export TEST_CONFIG_FILE="${CONFIG_FILE_PATH}"
   export TEST_STATE_FILE="${STATE_FILE_PATH}"
   export TEST_CLIENT_INFO="${CLIENT_INFO_PATH}"
+  export TEST_SYSTEMD_DIR="${SYSTEMD_DIR_PATH}"
+  export SBX_SYSTEMD_DIR="${SYSTEMD_DIR_PATH}"
   export SBX_STATE_LOCK_FILE="${LOCK_FILE_PATH}"
   export SBX_LOCK_TIMEOUT_SEC=1
 
@@ -154,6 +162,39 @@ current_client_short_id() {
 
 current_config_short_id() {
   jq -r '.inbounds[] | select(.tls.reality) | .tls.reality.short_id[0]' "${CONFIG_FILE_PATH}"
+}
+
+rotation_service_unit_path() {
+  printf '%s/%s\n' "${SYSTEMD_DIR_PATH}" "${ROTATION_SERVICE_UNIT_NAME}"
+}
+
+rotation_timer_unit_path() {
+  printf '%s/%s\n' "${SYSTEMD_DIR_PATH}" "${ROTATION_TIMER_UNIT_NAME}"
+}
+
+seed_rotation_history() {
+  local count="$1"
+  local history_json='[]'
+  local i=1
+  local second=''
+
+  while [[ "${i}" -le "${count}" ]]; do
+    printf -v second '%02d' "${i}"
+    history_json=$(
+      jq -c \
+        --arg short_id "seed-${i}" \
+        --arg rotated_at "2026-04-18T00:00:${second}Z" \
+        --arg trigger "manual" \
+        '. + [{short_id: $short_id, rotated_at: $rotated_at, trigger: $trigger}]' \
+        <<<"${history_json}"
+    )
+    i=$((i + 1))
+  done
+
+  jq --argjson history "${history_json}" \
+    '.protocols.reality.short_id_rotation.history = $history' \
+    "${STATE_FILE_PATH}" >"${STATE_FILE_PATH}.tmp"
+  mv -f "${STATE_FILE_PATH}.tmp" "${STATE_FILE_PATH}"
 }
 
 run_rotation() {
@@ -190,6 +231,36 @@ run_rotation() {
         printf "subscription_refresh_cache\n" >>"'"${TEST_TMP}"'/subscription-refresh.log"
       }
       reality_rotate_shortid "$@"
+    ' -- "$@"
+  )
+}
+
+run_schedule() {
+  LAST_SCHEDULE_OUTPUT=$(
+    bash -c '
+      set -euo pipefail
+      source "'"${PROJECT_ROOT}"'/lib/common.sh"
+      source "'"${PROJECT_ROOT}"'/lib/validation.sh"
+      source "'"${PROJECT_ROOT}"'/lib/service.sh"
+      source "'"${PROJECT_ROOT}"'/lib/reality_rotation.sh"
+      systemctl() {
+        printf "systemctl %s\n" "$*" >>"'"${TEST_TMP}"'/systemctl.log"
+        return 0
+      }
+      install_systemd_unit() {
+        local unit_path="$1"
+        local unit_content="${2:-}"
+        printf "install_systemd_unit %s\n" "${unit_path}" >>"'"${TEST_TMP}"'/systemd.log"
+        printf "%s\n" "${unit_content}" >"${unit_path}"
+        chmod 644 "${unit_path}"
+      }
+      remove_systemd_unit() {
+        local unit_name="$1"
+        local unit_path="${2:-}"
+        printf "remove_systemd_unit %s %s\n" "${unit_name}" "${unit_path}" >>"'"${TEST_TMP}"'/systemd.log"
+        rm -f "${unit_path}"
+      }
+      reality_rotation_schedule "$@"
     ' -- "$@"
   )
 }
@@ -300,6 +371,51 @@ test_scheduled_run_records_timer_trigger() {
     "rotation history records timer trigger"
 }
 
+test_reality_rotation_schedule_weekly_installs_units_and_updates_state() {
+  run_schedule weekly
+
+  assert_equals "weekly" "$(jq -r '.protocols.reality.short_id_rotation.schedule' "${STATE_FILE_PATH}")" \
+    "state.json records weekly schedule"
+  assert_equals "true" "$(jq -r '.protocols.reality.short_id_rotation.enabled' "${STATE_FILE_PATH}")" \
+    "state.json records enabled schedule"
+  assert_equals "weekly" "$(jq -r '.protocols.reality.short_id_rotation.on_calendar' "${STATE_FILE_PATH}")" \
+    "state.json records weekly on-calendar"
+  assert_file_exists "$(rotation_service_unit_path)" "service unit is rendered"
+  assert_file_exists "$(rotation_timer_unit_path)" "timer unit is rendered"
+  assert_contains "$(cat "$(rotation_timer_unit_path)")" "OnCalendar=weekly" \
+    "timer unit contains weekly OnCalendar"
+  assert_contains "$(cat "$(rotation_timer_unit_path)")" "Persistent=true" \
+    "timer unit contains Persistent=true"
+}
+
+test_reality_rotation_schedule_off_removes_units_and_disables_state() {
+  run_schedule off
+
+  assert_equals "off" "$(jq -r '.protocols.reality.short_id_rotation.schedule' "${STATE_FILE_PATH}")" \
+    "state.json records off schedule"
+  assert_equals "false" "$(jq -r '.protocols.reality.short_id_rotation.enabled' "${STATE_FILE_PATH}")" \
+    "state.json records disabled schedule"
+  assert_equals "null" "$(jq -r '.protocols.reality.short_id_rotation.on_calendar' "${STATE_FILE_PATH}")" \
+    "state.json clears on-calendar when disabled"
+  assert_file_exists "${TEST_TMP}/systemd.log" "off schedule logs unit removal"
+  assert_not_contains "$(cat "${TEST_TMP}/systemd.log")" "install_systemd_unit" \
+    "off schedule does not render units"
+  assert_contains "$(cat "${TEST_TMP}/systemd.log")" "remove_systemd_unit" \
+    "off schedule exercises unit removal"
+}
+
+test_history_trimming_keeps_twenty_entries() {
+  local history_count=''
+
+  seed_rotation_history 25
+  run_rotation
+
+  history_count=$(jq '.protocols.reality.short_id_rotation.history | length' "${STATE_FILE_PATH}")
+  assert_equals "20" "${history_count}" "rotation history is trimmed to 20 entries"
+  assert_equals "abcd1234" "$(jq -r '.protocols.reality.short_id_rotation.history[0].short_id' "${STATE_FILE_PATH}")" \
+    "newest history entry stays first"
+}
+
 main() {
   set +e
   echo "Running: reality rotation"
@@ -317,6 +433,15 @@ main() {
   teardown_fixture
   setup_fixture
   test_scheduled_run_records_timer_trigger
+  teardown_fixture
+  setup_fixture
+  test_reality_rotation_schedule_weekly_installs_units_and_updates_state
+  teardown_fixture
+  setup_fixture
+  test_reality_rotation_schedule_off_removes_units_and_disables_state
+  teardown_fixture
+  setup_fixture
+  test_history_trimming_keeps_twenty_entries
   teardown_fixture
   print_test_summary
 }

--- a/tests/unit/test_reality_rotation.sh
+++ b/tests/unit/test_reality_rotation.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+# tests/unit/test_reality_rotation.sh
+# Fixture-driven tests for Reality short ID rotation.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../test_framework.sh"
+
+TEST_TMP=""
+FAKE_BIN_DIR=""
+STATE_FILE_PATH=""
+CONFIG_FILE_PATH=""
+CLIENT_INFO_PATH=""
+LOCK_FILE_PATH=""
+LAST_ROTATION_OUTPUT=""
+
+setup_fixture() {
+  LAST_ROTATION_OUTPUT=""
+  TEST_TMP=$(mktemp -d /tmp/sbx-reality-rotate.XXXXXX)
+  FAKE_BIN_DIR="${TEST_TMP}/bin"
+  STATE_FILE_PATH="${TEST_TMP}/state.json"
+  CONFIG_FILE_PATH="${TEST_TMP}/config.json"
+  CLIENT_INFO_PATH="${TEST_TMP}/client-info.txt"
+  LOCK_FILE_PATH="${TEST_TMP}/sbx-state.lock"
+
+  mkdir -p "${FAKE_BIN_DIR}"
+
+  cat >"${FAKE_BIN_DIR}/sing-box" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "check" && "${2:-}" == "-c" && -n "${3:-}" ]]; then
+  jq empty "${3}"
+  exit 0
+fi
+
+exit 0
+EOF
+  chmod +x "${FAKE_BIN_DIR}/sing-box"
+
+  cat >"${STATE_FILE_PATH}" <<'EOF'
+{
+  "version": "1.0",
+  "installed_at": "2026-04-18T00:00:00Z",
+  "mode": "single_protocol",
+  "server": {"domain": "example.com", "ip": null},
+  "protocols": {
+    "reality": {
+      "enabled": true,
+      "port": 443,
+      "uuid": "11111111-2222-3333-4444-555555555555",
+      "public_key": "fixture_public_key",
+      "short_id": "abcd1234",
+      "sni": "www.microsoft.com",
+      "short_id_rotation": {
+        "history": []
+      }
+    }
+  },
+  "subscription": {
+    "enabled": true,
+    "port": 8838,
+    "bind": "127.0.0.1",
+    "token": "deadbeefdeadbeefdeadbeefdeadbeef",
+    "path": "/sub",
+    "created_at": "2026-04-18T00:00:00Z"
+  }
+}
+EOF
+
+  cat >"${CLIENT_INFO_PATH}" <<'EOF'
+UUID="11111111-2222-3333-4444-555555555555"
+SHORT_ID="abcd1234"
+SNI="www.microsoft.com"
+EOF
+
+  cat >"${CONFIG_FILE_PATH}" <<'EOF'
+{
+  "log": {"level": "warn", "timestamp": true},
+  "inbounds": [
+    {
+      "type": "vless",
+      "tag": "in-reality",
+      "listen": "::",
+      "listen_port": 443,
+      "users": [
+        {
+          "uuid": "11111111-2222-3333-4444-555555555555",
+          "flow": "xtls-rprx-vision"
+        }
+      ],
+      "tls": {
+        "enabled": true,
+        "server_name": "www.microsoft.com",
+        "reality": {
+          "enabled": true,
+          "private_key": "fixture_private_key",
+          "short_id": ["abcd1234"],
+          "handshake": {
+            "server": "www.microsoft.com",
+            "server_port": 443
+          }
+        }
+      }
+    }
+  ],
+  "outbounds": [
+    {"type": "direct"}
+  ]
+}
+EOF
+
+  chmod 600 "${STATE_FILE_PATH}" "${CLIENT_INFO_PATH}" "${CONFIG_FILE_PATH}"
+
+  export PATH="${FAKE_BIN_DIR}:${PATH}"
+  export SBX_TEST_MODE=1
+  export SB_BIN="${FAKE_BIN_DIR}/sing-box"
+  export TEST_SB_BIN="${FAKE_BIN_DIR}/sing-box"
+  export SB_CONF="${CONFIG_FILE_PATH}"
+  export SB_CONF_DIR="${TEST_TMP}"
+  export CLIENT_INFO="${CLIENT_INFO_PATH}"
+  export STATE_FILE="${STATE_FILE_PATH}"
+  export TEST_CONFIG_FILE="${CONFIG_FILE_PATH}"
+  export TEST_STATE_FILE="${STATE_FILE_PATH}"
+  export TEST_CLIENT_INFO="${CLIENT_INFO_PATH}"
+  export SBX_STATE_LOCK_FILE="${LOCK_FILE_PATH}"
+  export SBX_LOCK_TIMEOUT_SEC=1
+
+  bash -c "
+    set -euo pipefail
+    source '${PROJECT_ROOT}/lib/common.sh'
+    source '${PROJECT_ROOT}/lib/validation.sh'
+    source '${PROJECT_ROOT}/lib/service.sh'
+    source '${PROJECT_ROOT}/lib/reality_rotation.sh'
+    declare -f reality_rotate_shortid >/dev/null
+  "
+}
+
+teardown_fixture() {
+  [[ -n "${TEST_TMP:-}" && -d "${TEST_TMP}" ]] && rm -rf "${TEST_TMP}"
+}
+
+current_state_short_id() {
+  jq -r '.protocols.reality.short_id' "${STATE_FILE_PATH}"
+}
+
+current_client_short_id() {
+  grep '^SHORT_ID=' "${CLIENT_INFO_PATH}" | head -1 | cut -d= -f2- | tr -d '"'
+}
+
+current_config_short_id() {
+  jq -r '.inbounds[] | select(.tls.reality) | .tls.reality.short_id[0]' "${CONFIG_FILE_PATH}"
+}
+
+run_rotation() {
+  LAST_ROTATION_OUTPUT=$(
+    MOCK_RESTART_RESULT="${MOCK_RESTART_RESULT:-0}" bash -c '
+      set -euo pipefail
+      source "'"${PROJECT_ROOT}"'/lib/common.sh"
+      source "'"${PROJECT_ROOT}"'/lib/validation.sh"
+      source "'"${PROJECT_ROOT}"'/lib/service.sh"
+      source "'"${PROJECT_ROOT}"'/lib/reality_rotation.sh"
+      restart_service() {
+        if [[ "${MOCK_RESTART_RESULT:-0}" != "0" ]]; then
+          return 1
+        fi
+        return 0
+      }
+      subscription_refresh_cache() {
+        printf "subscription_refresh_cache\n" >>"'"${TEST_TMP}"'/subscription-refresh.log"
+      }
+      reality_rotate_shortid "$@"
+    ' -- "$@"
+  )
+}
+
+test_manual_rotation_updates_files() {
+  local before_state=''
+  local before_client=''
+  local before_config=''
+  local old_sid=''
+  old_sid=$(current_state_short_id)
+  before_state=$(cat "${STATE_FILE_PATH}")
+  before_client=$(cat "${CLIENT_INFO_PATH}")
+  before_config=$(cat "${CONFIG_FILE_PATH}")
+
+  run_rotation
+
+  local new_sid=''
+  new_sid=$(current_state_short_id)
+
+  assert_matches "${new_sid}" '^[0-9a-f]{8}$' "rotation writes an 8-char hex short ID"
+  assert_not_contains "${new_sid}" "${old_sid}" "rotation picks a different short ID"
+  assert_equals "${new_sid}" "$(current_client_short_id)" "client-info.txt short ID updated"
+  assert_equals "${new_sid}" "$(current_config_short_id)" "config.json Reality inbound short ID updated"
+  assert_equals "${new_sid}" "$(jq -r '.protocols.reality.short_id_rotation.current_short_id' "${STATE_FILE_PATH}")" \
+    "state.json rotation metadata records the new short ID"
+  assert_equals "${old_sid}" "$(jq -r '.protocols.reality.short_id_rotation.previous_short_id' "${STATE_FILE_PATH}")" \
+    "state.json rotation metadata records the previous short ID"
+  assert_file_exists "${TEST_TMP}/subscription-refresh.log" "subscription cache refresh is triggered when enabled"
+  assert_contains "$(cat "${TEST_TMP}/subscription-refresh.log")" "subscription_refresh_cache" \
+    "subscription cache refresh is triggered when enabled"
+  assert_not_contains "$(cat "${STATE_FILE_PATH}")" "${before_state}" "state.json changed"
+  assert_not_contains "$(cat "${CLIENT_INFO_PATH}")" "${before_client}" "client-info.txt changed"
+  assert_not_contains "$(cat "${CONFIG_FILE_PATH}")" "${before_config}" "config.json changed"
+}
+
+test_dry_run_leaves_files_untouched() {
+  local before_state=''
+  local before_client=''
+  local before_config=''
+  before_state=$(cat "${STATE_FILE_PATH}")
+  before_client=$(cat "${CLIENT_INFO_PATH}")
+  before_config=$(cat "${CONFIG_FILE_PATH}")
+
+  run_rotation --dry-run
+
+  assert_equals "${before_state}" "$(cat "${STATE_FILE_PATH}")" "dry-run leaves state.json untouched"
+  assert_equals "${before_client}" "$(cat "${CLIENT_INFO_PATH}")" "dry-run leaves client-info.txt untouched"
+  assert_equals "${before_config}" "$(cat "${CONFIG_FILE_PATH}")" "dry-run leaves config.json untouched"
+  assert_file_not_exists "${TEST_TMP}/subscription-refresh.log" "dry-run does not refresh subscription cache"
+  assert_equals "abcd1234" "$(current_state_short_id)" "dry-run preserves original state short ID"
+  assert_equals "abcd1234" "$(current_client_short_id)" "dry-run preserves original client short ID"
+  assert_equals "abcd1234" "$(current_config_short_id)" "dry-run preserves original config short ID"
+}
+
+test_restart_failure_rolls_back_files() {
+  local before_state=''
+  local before_client=''
+  local before_config=''
+  before_state=$(cat "${STATE_FILE_PATH}")
+  before_client=$(cat "${CLIENT_INFO_PATH}")
+  before_config=$(cat "${CONFIG_FILE_PATH}")
+
+  MOCK_RESTART_RESULT=1 run_rotation
+
+  assert_equals "${before_state}" "$(cat "${STATE_FILE_PATH}")" "restart failure rolls back state.json"
+  assert_equals "${before_client}" "$(cat "${CLIENT_INFO_PATH}")" "restart failure rolls back client-info.txt"
+  assert_equals "${before_config}" "$(cat "${CONFIG_FILE_PATH}")" "restart failure rolls back config.json"
+  assert_file_not_exists "${TEST_TMP}/subscription-refresh.log" "rollback path skips subscription cache refresh"
+  assert_equals "abcd1234" "$(current_state_short_id)" "rollback restores original state short ID"
+  assert_equals "abcd1234" "$(current_client_short_id)" "rollback restores original client short ID"
+  assert_equals "abcd1234" "$(current_config_short_id)" "rollback restores original config short ID"
+}
+
+main() {
+  set +e
+  echo "Running: reality rotation"
+  setup_fixture
+  test_manual_rotation_updates_files
+  teardown_fixture
+  setup_fixture
+  test_dry_run_leaves_files_untouched
+  teardown_fixture
+  setup_fixture
+  test_restart_failure_rolls_back_files
+  teardown_fixture
+  print_test_summary
+}
+
+main "$@"

--- a/tests/unit/test_reality_rotation.sh
+++ b/tests/unit/test_reality_rotation.sh
@@ -17,6 +17,8 @@ CONFIG_FILE_PATH=""
 CLIENT_INFO_PATH=""
 SYSTEMD_DIR_PATH=""
 LOCK_FILE_PATH=""
+GLOBAL_LOCK_FILE_PATH=""
+LOCK_HOLDER_PID=""
 LAST_ROTATION_OUTPUT=""
 LAST_SCHEDULE_OUTPUT=""
 ROTATION_SERVICE_UNIT_NAME="sbx-shortid-rotate.service"
@@ -31,6 +33,7 @@ setup_fixture() {
   CLIENT_INFO_PATH="${TEST_TMP}/client-info.txt"
   SYSTEMD_DIR_PATH="${TEST_TMP}/systemd"
   LOCK_FILE_PATH="${TEST_TMP}/sbx-state.lock"
+  GLOBAL_LOCK_FILE_PATH="${TEST_TMP}/sbx.lock"
 
   mkdir -p "${FAKE_BIN_DIR}"
   mkdir -p "${SYSTEMD_DIR_PATH}"
@@ -135,6 +138,7 @@ EOF
   export TEST_CLIENT_INFO="${CLIENT_INFO_PATH}"
   export TEST_SYSTEMD_DIR="${SYSTEMD_DIR_PATH}"
   export SBX_SYSTEMD_DIR="${SYSTEMD_DIR_PATH}"
+  export SBX_LOCK_FILE="${GLOBAL_LOCK_FILE_PATH}"
   export SBX_STATE_LOCK_FILE="${LOCK_FILE_PATH}"
   export SBX_LOCK_TIMEOUT_SEC=1
 
@@ -149,6 +153,10 @@ EOF
 }
 
 teardown_fixture() {
+  if [[ -n "${LOCK_HOLDER_PID:-}" ]]; then
+    wait "${LOCK_HOLDER_PID}" 2>/dev/null || true
+    LOCK_HOLDER_PID=""
+  fi
   [[ -n "${TEST_TMP:-}" && -d "${TEST_TMP}" ]] && rm -rf "${TEST_TMP}"
 }
 
@@ -227,6 +235,9 @@ run_rotation() {
         fi
         return 0
       }
+      _restart_service_impl() {
+        restart_service "$@"
+      }
       subscription_refresh_cache() {
         printf "subscription_refresh_cache\n" >>"'"${TEST_TMP}"'/subscription-refresh.log"
       }
@@ -287,12 +298,213 @@ run_restart_inside_state_lock() {
     source "'"${PROJECT_ROOT}"'/lib/validation.sh"
     source "'"${PROJECT_ROOT}"'/lib/service.sh"
     source "'"${PROJECT_ROOT}"'/lib/reality_rotation.sh"
-    restart_lock_file="'"${TEST_TMP}"'/restart-lock-file.txt"
     restart_service() {
-      printf "%s\n" "${SBX_LOCK_FILE-__unset__}" >"${restart_lock_file}"
       with_flock "${SBX_LOCK_TIMEOUT_SEC:-30}" true
     }
+    _restart_service_impl() {
+      printf "called\n" >"'"${TEST_TMP}"'/restart-impl-called.txt"
+      return 0
+    }
     with_state_lock "${SBX_LOCK_TIMEOUT_SEC:-30}" _reality_rotation_restart_service_safely
+  '
+}
+
+hold_global_lock_in_background() {
+  local ready_file="${TEST_TMP}/global-lock.ready"
+  local spin=0
+
+  rm -f "${ready_file}" 2>/dev/null || true
+  bash -c '
+    set -euo pipefail
+    source "'"${PROJECT_ROOT}"'/lib/common.sh"
+    with_flock 5 bash -c '"'"'touch "$1"; sleep 2'"'"' _ "'"${ready_file}"'"
+  ' &
+  LOCK_HOLDER_PID=$!
+
+  while [[ ! -f "${ready_file}" && ${spin} -lt 50 ]]; do
+    sleep 0.1
+    spin=$((spin + 1))
+  done
+
+  [[ -f "${ready_file}" ]]
+}
+
+run_rotation_with_restore_failure() {
+  LAST_ROTATION_OUTPUT=$(
+    TEST_CONFIG_FILE="${TEST_CONFIG_FILE:-}" bash -c '
+      set -euo pipefail
+      source "'"${PROJECT_ROOT}"'/lib/common.sh"
+      source "'"${PROJECT_ROOT}"'/lib/validation.sh"
+      source "'"${PROJECT_ROOT}"'/lib/service.sh"
+      source "'"${PROJECT_ROOT}"'/lib/reality_rotation.sh"
+      restart_invocations_file="'"${TEST_TMP}"'/restart-invocations.count"
+      rotation_restart_impl() {
+        local attempt=0
+        if [[ -f "${restart_invocations_file}" ]]; then
+          attempt=$(cat "${restart_invocations_file}")
+        fi
+        attempt=$((attempt + 1))
+        printf "%s\n" "${attempt}" >"${restart_invocations_file}"
+        if [[ "${attempt}" -eq 1 ]]; then
+          return 1
+        fi
+        return 0
+      }
+      restart_service() {
+        rotation_restart_impl "$@"
+      }
+      _restart_service_impl() {
+        rotation_restart_impl "$@"
+      }
+      _reality_rotation_restore_backups() {
+        printf "restore-failed\n" >>"'"${TEST_TMP}"'/restore-failure.log"
+        return 1
+      }
+      reality_rotate_shortid "$@"
+    ' -- "$@"
+  )
+}
+
+run_restore_with_missing_backup() {
+  local backup_dir="${TEST_TMP}/partial-restore"
+
+  mkdir -p "${backup_dir}"
+  cp -a "${CLIENT_INFO_PATH}" "${backup_dir}/client-info.txt"
+  cp -a "${STATE_FILE_PATH}" "${backup_dir}/state.json"
+
+  bash -c '
+    set -euo pipefail
+    source "'"${PROJECT_ROOT}"'/lib/common.sh"
+    source "'"${PROJECT_ROOT}"'/lib/validation.sh"
+    source "'"${PROJECT_ROOT}"'/lib/service.sh"
+    source "'"${PROJECT_ROOT}"'/lib/reality_rotation.sh"
+    _reality_rotation_restore_backups \
+      "'"${backup_dir}"'" \
+      "'"${CONFIG_FILE_PATH}"'" \
+      "'"${CLIENT_INFO_PATH}"'" \
+      "'"${STATE_FILE_PATH}"'"
+  '
+}
+
+prepare_runtime_restore_scenario() {
+  local backup_dir="${TEST_TMP}/runtime-restore"
+
+  mkdir -p "${backup_dir}"
+  cp -a "${CONFIG_FILE_PATH}" "${backup_dir}/config.json"
+  cp -a "${CLIENT_INFO_PATH}" "${backup_dir}/client-info.txt"
+  cp -a "${STATE_FILE_PATH}" "${backup_dir}/state.json"
+
+  jq '.protocols.reality.short_id = "deadbeef"' "${STATE_FILE_PATH}" >"${STATE_FILE_PATH}.tmp"
+  mv -f "${STATE_FILE_PATH}.tmp" "${STATE_FILE_PATH}"
+  jq '(.inbounds[] | select(.tls.reality) | .tls.reality.short_id) = ["deadbeef"]' \
+    "${CONFIG_FILE_PATH}" >"${CONFIG_FILE_PATH}.tmp"
+  mv -f "${CONFIG_FILE_PATH}.tmp" "${CONFIG_FILE_PATH}"
+  cat >"${CLIENT_INFO_PATH}" <<'EOF'
+UUID="11111111-2222-3333-4444-555555555555"
+SHORT_ID="deadbeef"
+SNI="www.microsoft.com"
+EOF
+
+  printf '%s\n' "${backup_dir}"
+}
+
+run_restore_with_second_copy_failure() {
+  local backup_dir="$1"
+
+  bash -c '
+    set -euo pipefail
+    source "'"${PROJECT_ROOT}"'/lib/common.sh"
+    source "'"${PROJECT_ROOT}"'/lib/validation.sh"
+    source "'"${PROJECT_ROOT}"'/lib/service.sh"
+    source "'"${PROJECT_ROOT}"'/lib/reality_rotation.sh"
+    cp_count=0
+    cp() {
+      cp_count=$((cp_count + 1))
+      if [[ "${cp_count}" -eq 2 ]]; then
+        return 1
+      fi
+      command cp "$@"
+    }
+    _reality_rotation_restore_backups \
+      "'"${backup_dir}"'" \
+      "'"${CONFIG_FILE_PATH}"'" \
+      "'"${CLIENT_INFO_PATH}"'" \
+      "'"${STATE_FILE_PATH}"'"
+  '
+}
+
+prepare_schedule_restore_scenario() {
+  local backup_dir="${TEST_TMP}/schedule-restore"
+  local service_path=''
+  local timer_path=''
+
+  service_path=$(rotation_service_unit_path)
+  timer_path=$(rotation_timer_unit_path)
+  mkdir -p "${backup_dir}"
+
+  cat >"${service_path}" <<'EOF'
+[Unit]
+Description=original service
+EOF
+  cat >"${timer_path}" <<'EOF'
+[Timer]
+OnCalendar=weekly
+EOF
+
+  cp -a "${STATE_FILE_PATH}" "${backup_dir}/state.json"
+  cp -a "${service_path}" "${backup_dir}/sbx-shortid-rotate.service"
+  cp -a "${timer_path}" "${backup_dir}/sbx-shortid-rotate.timer"
+
+  jq '.protocols.reality.short_id_rotation.schedule = "monthly"' "${STATE_FILE_PATH}" \
+    >"${STATE_FILE_PATH}.tmp"
+  mv -f "${STATE_FILE_PATH}.tmp" "${STATE_FILE_PATH}"
+  cat >"${service_path}" <<'EOF'
+[Unit]
+Description=mutated service
+EOF
+  cat >"${timer_path}" <<'EOF'
+[Timer]
+OnCalendar=monthly
+EOF
+
+  printf '%s\n' "${backup_dir}"
+}
+
+run_schedule_restore_with_second_copy_failure() {
+  local backup_dir="$1"
+  local service_path=''
+  local timer_path=''
+
+  service_path=$(rotation_service_unit_path)
+  timer_path=$(rotation_timer_unit_path)
+
+  bash -c '
+    set -euo pipefail
+    source "'"${PROJECT_ROOT}"'/lib/common.sh"
+    source "'"${PROJECT_ROOT}"'/lib/validation.sh"
+    source "'"${PROJECT_ROOT}"'/lib/service.sh"
+    source "'"${PROJECT_ROOT}"'/lib/reality_rotation.sh"
+    cp_count=0
+    cp() {
+      cp_count=$((cp_count + 1))
+      if [[ "${cp_count}" -eq 2 ]]; then
+        return 1
+      fi
+      command cp "$@"
+    }
+    systemctl() {
+      return 0
+    }
+    remove_systemd_unit() {
+      return 0
+    }
+    _rotation_schedule_restore_consistency \
+      "'"${backup_dir}"'/state.json" \
+      "'"${STATE_FILE_PATH}"'" \
+      "'"${backup_dir}"'/sbx-shortid-rotate.service" \
+      "'"${service_path}"'" \
+      "'"${backup_dir}"'/sbx-shortid-rotate.timer" \
+      "'"${timer_path}"'"
   '
 }
 
@@ -394,15 +606,10 @@ test_restart_failure_with_exit_rolls_back_and_restarts_restored_config() {
 }
 
 test_rotation_restart_does_not_inherit_state_lock_file() {
-  local restart_lock_value=''
-
   assert_success "SBX_LOCK_TIMEOUT_SEC=0 run_restart_inside_state_lock" \
     "restart inside rotation succeeds without re-locking the state lock file"
-
-  assert_file_exists "${TEST_TMP}/restart-lock-file.txt" "restart path captures the inherited lock file"
-  restart_lock_value=$(cat "${TEST_TMP}/restart-lock-file.txt")
-  assert_equals "__unset__" "${restart_lock_value}" \
-    "restart inside rotation clears SBX_LOCK_FILE before calling restart_service"
+  assert_file_exists "${TEST_TMP}/restart-impl-called.txt" \
+    "rotation restart helper reaches the unlocked restart implementation"
 }
 
 test_scheduled_run_records_timer_trigger() {
@@ -528,6 +735,108 @@ test_schedule_change_failure_restores_prior_active_schedule() {
     "rollback re-enables timer only after daemon-reload"
 }
 
+test_rotation_respects_global_lock() {
+  local before_state=''
+  local before_client=''
+  local before_config=''
+
+  before_state=$(cat "${STATE_FILE_PATH}")
+  before_client=$(cat "${CLIENT_INFO_PATH}")
+  before_config=$(cat "${CONFIG_FILE_PATH}")
+
+  assert_success "hold_global_lock_in_background" \
+    "test fixture acquires the shared mutation lock"
+  SBX_LOCK_TIMEOUT_SEC=0 assert_failure "run_rotation" \
+    "rotation should fail fast while the shared mutation lock is held"
+
+  assert_equals "${before_state}" "$(cat "${STATE_FILE_PATH}")" \
+    "global lock contention leaves state.json untouched"
+  assert_equals "${before_client}" "$(cat "${CLIENT_INFO_PATH}")" \
+    "global lock contention leaves client-info.txt untouched"
+  assert_equals "${before_config}" "$(cat "${CONFIG_FILE_PATH}")" \
+    "global lock contention leaves config.json untouched"
+}
+
+test_schedule_respects_global_lock() {
+  local before_state=''
+
+  before_state=$(cat "${STATE_FILE_PATH}")
+
+  assert_success "hold_global_lock_in_background" \
+    "test fixture acquires the shared mutation lock for scheduling"
+  SBX_LOCK_TIMEOUT_SEC=0 assert_failure "run_schedule weekly" \
+    "schedule changes should fail fast while the shared mutation lock is held"
+
+  assert_equals "${before_state}" "$(cat "${STATE_FILE_PATH}")" \
+    "global lock contention leaves schedule state untouched"
+  assert_file_not_exists "$(rotation_service_unit_path)" \
+    "global lock contention does not install service unit"
+  assert_file_not_exists "$(rotation_timer_unit_path)" \
+    "global lock contention does not install timer unit"
+}
+
+test_restore_failure_aborts_without_retry_restart() {
+  assert_failure "run_rotation_with_restore_failure" \
+    "rotation should fail when restore of backup files fails"
+  assert_file_exists "${TEST_TMP}/restore-failure.log" \
+    "restore failure path is exercised"
+  assert_file_exists "${TEST_TMP}/restart-invocations.count" \
+    "restart attempts are tracked when restore fails"
+  assert_equals "1" "$(cat "${TEST_TMP}/restart-invocations.count")" \
+    "restore failure aborts without retrying restart on mixed files"
+}
+
+test_restore_requires_complete_backup_set() {
+  assert_failure "run_restore_with_missing_backup" \
+    "restore helper should fail when any required backup file is missing"
+}
+
+test_runtime_restore_is_atomic_on_copy_failure() {
+  local backup_dir=''
+  local before_state=''
+  local before_client=''
+  local before_config=''
+
+  backup_dir=$(prepare_runtime_restore_scenario)
+  before_state=$(cat "${STATE_FILE_PATH}")
+  before_client=$(cat "${CLIENT_INFO_PATH}")
+  before_config=$(cat "${CONFIG_FILE_PATH}")
+
+  assert_failure "run_restore_with_second_copy_failure '${backup_dir}'" \
+    "runtime restore should fail when a staged copy fails"
+  assert_equals "${before_state}" "$(cat "${STATE_FILE_PATH}")" \
+    "failed runtime restore leaves state.json unchanged"
+  assert_equals "${before_client}" "$(cat "${CLIENT_INFO_PATH}")" \
+    "failed runtime restore leaves client-info.txt unchanged"
+  assert_equals "${before_config}" "$(cat "${CONFIG_FILE_PATH}")" \
+    "failed runtime restore leaves config.json unchanged"
+}
+
+test_schedule_restore_is_atomic_on_copy_failure() {
+  local backup_dir=''
+  local service_path=''
+  local timer_path=''
+  local before_state=''
+  local before_service=''
+  local before_timer=''
+
+  backup_dir=$(prepare_schedule_restore_scenario)
+  service_path=$(rotation_service_unit_path)
+  timer_path=$(rotation_timer_unit_path)
+  before_state=$(cat "${STATE_FILE_PATH}")
+  before_service=$(cat "${service_path}")
+  before_timer=$(cat "${timer_path}")
+
+  assert_failure "run_schedule_restore_with_second_copy_failure '${backup_dir}'" \
+    "schedule restore should fail when a staged copy fails"
+  assert_equals "${before_state}" "$(cat "${STATE_FILE_PATH}")" \
+    "failed schedule restore leaves state.json unchanged"
+  assert_equals "${before_service}" "$(cat "${service_path}")" \
+    "failed schedule restore leaves service unit unchanged"
+  assert_equals "${before_timer}" "$(cat "${timer_path}")" \
+    "failed schedule restore leaves timer unit unchanged"
+}
+
 test_history_trimming_keeps_twenty_entries() {
   local history_count=''
 
@@ -578,6 +887,24 @@ main() {
   teardown_fixture
   setup_fixture
   test_history_trimming_keeps_twenty_entries
+  teardown_fixture
+  setup_fixture
+  test_rotation_respects_global_lock
+  teardown_fixture
+  setup_fixture
+  test_schedule_respects_global_lock
+  teardown_fixture
+  setup_fixture
+  test_restore_failure_aborts_without_retry_restart
+  teardown_fixture
+  setup_fixture
+  test_restore_requires_complete_backup_set
+  teardown_fixture
+  setup_fixture
+  test_runtime_restore_is_atomic_on_copy_failure
+  teardown_fixture
+  setup_fixture
+  test_schedule_restore_is_atomic_on_copy_failure
   teardown_fixture
   print_test_summary
 }

--- a/tests/unit/test_reality_rotation.sh
+++ b/tests/unit/test_reality_rotation.sh
@@ -280,6 +280,22 @@ run_schedule() {
   )
 }
 
+run_restart_inside_state_lock() {
+  bash -c '
+    set -euo pipefail
+    source "'"${PROJECT_ROOT}"'/lib/common.sh"
+    source "'"${PROJECT_ROOT}"'/lib/validation.sh"
+    source "'"${PROJECT_ROOT}"'/lib/service.sh"
+    source "'"${PROJECT_ROOT}"'/lib/reality_rotation.sh"
+    restart_lock_file="'"${TEST_TMP}"'/restart-lock-file.txt"
+    restart_service() {
+      printf "%s\n" "${SBX_LOCK_FILE-__unset__}" >"${restart_lock_file}"
+      with_flock "${SBX_LOCK_TIMEOUT_SEC:-30}" true
+    }
+    with_state_lock "${SBX_LOCK_TIMEOUT_SEC:-30}" _reality_rotation_restart_service_safely
+  '
+}
+
 test_manual_rotation_updates_files() {
   local before_state=''
   local before_client=''
@@ -375,6 +391,18 @@ test_restart_failure_with_exit_rolls_back_and_restarts_restored_config() {
     "second restart saw restored config"
   assert_file_not_exists "${TEST_TMP}/subscription-refresh.log" "failed rotation does not refresh subscription cache"
   assert_equals "abcd1234" "$(current_state_short_id)" "non-returning restart failure restores original state short ID"
+}
+
+test_rotation_restart_does_not_inherit_state_lock_file() {
+  local restart_lock_value=''
+
+  assert_success "SBX_LOCK_TIMEOUT_SEC=0 run_restart_inside_state_lock" \
+    "restart inside rotation succeeds without re-locking the state lock file"
+
+  assert_file_exists "${TEST_TMP}/restart-lock-file.txt" "restart path captures the inherited lock file"
+  restart_lock_value=$(cat "${TEST_TMP}/restart-lock-file.txt")
+  assert_equals "__unset__" "${restart_lock_value}" \
+    "restart inside rotation clears SBX_LOCK_FILE before calling restart_service"
 }
 
 test_scheduled_run_records_timer_trigger() {
@@ -526,6 +554,9 @@ main() {
   teardown_fixture
   setup_fixture
   test_restart_failure_with_exit_rolls_back_and_restarts_restored_config
+  teardown_fixture
+  setup_fixture
+  test_rotation_restart_does_not_inherit_state_lock_file
   teardown_fixture
   setup_fixture
   test_scheduled_run_records_timer_trigger

--- a/tests/unit/test_reality_rotation.sh
+++ b/tests/unit/test_reality_rotation.sh
@@ -158,13 +158,29 @@ current_config_short_id() {
 
 run_rotation() {
   LAST_ROTATION_OUTPUT=$(
-    MOCK_RESTART_RESULT="${MOCK_RESTART_RESULT:-0}" bash -c '
+    TEST_CONFIG_FILE="${TEST_CONFIG_FILE:-}" MOCK_RESTART_RESULT="${MOCK_RESTART_RESULT:-0}" MOCK_RESTART_STYLE="${MOCK_RESTART_STYLE:-return}" bash -c '
       set -euo pipefail
       source "'"${PROJECT_ROOT}"'/lib/common.sh"
       source "'"${PROJECT_ROOT}"'/lib/validation.sh"
       source "'"${PROJECT_ROOT}"'/lib/service.sh"
       source "'"${PROJECT_ROOT}"'/lib/reality_rotation.sh"
+      restart_attempts_file="'"${TEST_TMP}"'/restart-attempts.log"
+      restart_invocations_file="'"${TEST_TMP}"'/restart-invocations.count"
+      restart_config_file="${TEST_CONFIG_FILE:-${SB_CONF}}"
       restart_service() {
+        local attempt=0
+        if [[ -f "${restart_invocations_file}" ]]; then
+          attempt=$(cat "${restart_invocations_file}")
+        fi
+        attempt=$((attempt + 1))
+        printf "%s\n" "${attempt}" >"${restart_invocations_file}"
+        jq -r ".inbounds[] | select(.tls.reality) | .tls.reality.short_id[0]" "${restart_config_file}" >>"${restart_attempts_file}"
+        if [[ "${MOCK_RESTART_STYLE:-return}" == "exit" ]]; then
+          if [[ "${attempt}" -eq 1 ]]; then
+            exit 17
+          fi
+          return 0
+        fi
         if [[ "${MOCK_RESTART_RESULT:-0}" != "0" ]]; then
           return 1
         fi
@@ -201,6 +217,8 @@ test_manual_rotation_updates_files() {
     "state.json rotation metadata records the new short ID"
   assert_equals "${old_sid}" "$(jq -r '.protocols.reality.short_id_rotation.previous_short_id' "${STATE_FILE_PATH}")" \
     "state.json rotation metadata records the previous short ID"
+  assert_equals "manual" "$(jq -r '.protocols.reality.short_id_rotation.trigger' "${STATE_FILE_PATH}")" \
+    "manual rotations are labeled manual"
   assert_file_exists "${TEST_TMP}/subscription-refresh.log" "subscription cache refresh is triggered when enabled"
   assert_contains "$(cat "${TEST_TMP}/subscription-refresh.log")" "subscription_refresh_cache" \
     "subscription cache refresh is triggered when enabled"
@@ -247,6 +265,41 @@ test_restart_failure_rolls_back_files() {
   assert_equals "abcd1234" "$(current_config_short_id)" "rollback restores original config short ID"
 }
 
+test_restart_failure_with_exit_rolls_back_and_restarts_restored_config() {
+  local before_state=''
+  local before_client=''
+  local before_config=''
+  before_state=$(cat "${STATE_FILE_PATH}")
+  before_client=$(cat "${CLIENT_INFO_PATH}")
+  before_config=$(cat "${CONFIG_FILE_PATH}")
+
+  MOCK_RESTART_STYLE=exit assert_failure "run_rotation" "non-returning restart failure still triggers rollback"
+
+  assert_equals "${before_state}" "$(cat "${STATE_FILE_PATH}")" "non-returning restart failure rolls back state.json"
+  assert_equals "${before_client}" "$(cat "${CLIENT_INFO_PATH}")" "non-returning restart failure rolls back client-info.txt"
+  assert_equals "${before_config}" "$(cat "${CONFIG_FILE_PATH}")" "non-returning restart failure rolls back config.json"
+  assert_file_exists "${TEST_TMP}/restart-attempts.log" "restart attempts are logged"
+  assert_equals "2" "$(wc -l <"${TEST_TMP}/restart-attempts.log" | tr -d '[:space:]')" \
+    "rotation retries restart after restoring backups"
+  assert_matches "$(sed -n '1p' "${TEST_TMP}/restart-attempts.log")" '^[0-9a-f]{8}$' \
+    "first restart saw a rotated short ID"
+  assert_not_contains "$(sed -n '1p' "${TEST_TMP}/restart-attempts.log")" "abcd1234" \
+    "first restart did not see the original short ID"
+  assert_equals "abcd1234" "$(sed -n '2p' "${TEST_TMP}/restart-attempts.log")" \
+    "second restart saw restored config"
+  assert_file_not_exists "${TEST_TMP}/subscription-refresh.log" "failed rotation does not refresh subscription cache"
+  assert_equals "abcd1234" "$(current_state_short_id)" "non-returning restart failure restores original state short ID"
+}
+
+test_scheduled_run_records_timer_trigger() {
+  run_rotation --scheduled-run
+
+  assert_equals "timer" "$(jq -r '.protocols.reality.short_id_rotation.trigger' "${STATE_FILE_PATH}")" \
+    "scheduled rotations are labeled timer"
+  assert_equals "timer" "$(jq -r '.protocols.reality.short_id_rotation.history[0].trigger' "${STATE_FILE_PATH}")" \
+    "rotation history records timer trigger"
+}
+
 main() {
   set +e
   echo "Running: reality rotation"
@@ -258,6 +311,12 @@ main() {
   teardown_fixture
   setup_fixture
   test_restart_failure_rolls_back_files
+  teardown_fixture
+  setup_fixture
+  test_restart_failure_with_exit_rolls_back_and_restarts_restored_config
+  teardown_fixture
+  setup_fixture
+  test_scheduled_run_records_timer_trigger
   teardown_fixture
   print_test_summary
 }

--- a/tests/unit/test_reality_rotation.sh
+++ b/tests/unit/test_reality_rotation.sh
@@ -245,6 +245,9 @@ run_schedule() {
       source "'"${PROJECT_ROOT}"'/lib/reality_rotation.sh"
       systemctl() {
         printf "systemctl %s\n" "$*" >>"'"${TEST_TMP}"'/systemctl.log"
+        if [[ "${SYSTEMCTL_FAIL_ENABLE_NOW:-0}" == "1" && "${1:-}" == "enable" && "${2:-}" == "--now" ]]; then
+          return 1
+        fi
         return 0
       }
       install_systemd_unit() {
@@ -389,7 +392,19 @@ test_reality_rotation_schedule_weekly_installs_units_and_updates_state() {
 }
 
 test_reality_rotation_schedule_off_removes_units_and_disables_state() {
+  local before_log_lines=0
+  local after_log_lines=0
+  local after_off_log=''
+
+  run_schedule weekly
+
+  assert_file_exists "$(rotation_service_unit_path)" "precondition: service unit exists before disabling"
+  assert_file_exists "$(rotation_timer_unit_path)" "precondition: timer unit exists before disabling"
+  before_log_lines=$(wc -l <"${TEST_TMP}/systemd.log" | tr -d '[:space:]')
+
   run_schedule off
+  after_log_lines=$(wc -l <"${TEST_TMP}/systemd.log" | tr -d '[:space:]')
+  after_off_log=$(sed -n "$((before_log_lines + 1)),${after_log_lines}p" "${TEST_TMP}/systemd.log")
 
   assert_equals "off" "$(jq -r '.protocols.reality.short_id_rotation.schedule' "${STATE_FILE_PATH}")" \
     "state.json records off schedule"
@@ -398,10 +413,45 @@ test_reality_rotation_schedule_off_removes_units_and_disables_state() {
   assert_equals "null" "$(jq -r '.protocols.reality.short_id_rotation.on_calendar' "${STATE_FILE_PATH}")" \
     "state.json clears on-calendar when disabled"
   assert_file_exists "${TEST_TMP}/systemd.log" "off schedule logs unit removal"
-  assert_not_contains "$(cat "${TEST_TMP}/systemd.log")" "install_systemd_unit" \
+  assert_not_contains "${after_off_log}" "install_systemd_unit" \
     "off schedule does not render units"
-  assert_contains "$(cat "${TEST_TMP}/systemd.log")" "remove_systemd_unit" \
+  assert_contains "${after_off_log}" "remove_systemd_unit" \
     "off schedule exercises unit removal"
+  assert_file_not_exists "$(rotation_service_unit_path)" "service unit is removed"
+  assert_file_not_exists "$(rotation_timer_unit_path)" "timer unit is removed"
+}
+
+test_invalid_schedule_leaves_state_and_units_untouched() {
+  local before_state=''
+  local before_service=''
+  local before_timer=''
+
+  run_schedule weekly
+  before_state=$(cat "${STATE_FILE_PATH}")
+  before_service=$(cat "$(rotation_service_unit_path)")
+  before_timer=$(cat "$(rotation_timer_unit_path)")
+
+  assert_failure "run_schedule hourly" "invalid schedule should fail"
+
+  assert_equals "${before_state}" "$(cat "${STATE_FILE_PATH}")" "invalid schedule leaves state.json untouched"
+  assert_equals "${before_service}" "$(cat "$(rotation_service_unit_path)")" "invalid schedule leaves service unit untouched"
+  assert_equals "${before_timer}" "$(cat "$(rotation_timer_unit_path)")" "invalid schedule leaves timer unit untouched"
+}
+
+test_schedule_enable_failure_rolls_back_state_and_units() {
+  local before_state=''
+
+  before_state=$(cat "${STATE_FILE_PATH}")
+
+  SYSTEMCTL_FAIL_ENABLE_NOW=1 assert_failure "run_schedule weekly" "failed timer activation should fail"
+
+  assert_equals "${before_state}" "$(cat "${STATE_FILE_PATH}")" "failed activation leaves state.json untouched"
+  assert_equals "[]" "$(jq -c '.protocols.reality.short_id_rotation.history' "${STATE_FILE_PATH}")" \
+    "failed activation keeps history unchanged"
+  assert_file_not_exists "$(rotation_service_unit_path)" "failed activation rolls back service unit"
+  assert_file_not_exists "$(rotation_timer_unit_path)" "failed activation rolls back timer unit"
+  assert_contains "$(cat "${TEST_TMP}/systemd.log")" "remove_systemd_unit" \
+    "failed activation exercises rollback removal"
 }
 
 test_history_trimming_keeps_twenty_entries() {
@@ -439,6 +489,12 @@ main() {
   teardown_fixture
   setup_fixture
   test_reality_rotation_schedule_off_removes_units_and_disables_state
+  teardown_fixture
+  setup_fixture
+  test_invalid_schedule_leaves_state_and_units_untouched
+  teardown_fixture
+  setup_fixture
+  test_schedule_enable_failure_rolls_back_state_and_units
   teardown_fixture
   setup_fixture
   test_history_trimming_keeps_twenty_entries

--- a/tests/unit/test_reality_rotation.sh
+++ b/tests/unit/test_reality_rotation.sh
@@ -701,6 +701,23 @@ test_schedule_enable_failure_rolls_back_state_and_units() {
     "failed activation exercises rollback removal"
 }
 
+test_schedule_unit_write_failure_rolls_back_state_and_units() {
+  local before_state=''
+
+  before_state=$(cat "${STATE_FILE_PATH}")
+  rm -rf "${SYSTEMD_DIR_PATH}"
+
+  assert_failure "run_schedule weekly" \
+    "failed unit writes should make schedule changes fail"
+
+  assert_equals "${before_state}" "$(cat "${STATE_FILE_PATH}")" \
+    "failed unit writes leave state.json untouched"
+  assert_file_not_exists "$(rotation_service_unit_path)" \
+    "failed unit writes leave the service unit absent"
+  assert_file_not_exists "$(rotation_timer_unit_path)" \
+    "failed unit writes leave the timer unit absent"
+}
+
 test_schedule_change_failure_restores_prior_active_schedule() {
   local before_state=''
   local before_service=''
@@ -881,6 +898,9 @@ main() {
   teardown_fixture
   setup_fixture
   test_schedule_enable_failure_rolls_back_state_and_units
+  teardown_fixture
+  setup_fixture
+  test_schedule_unit_write_failure_rolls_back_state_and_units
   teardown_fixture
   setup_fixture
   test_schedule_change_failure_restores_prior_active_schedule

--- a/tests/unit/test_reality_rotation_installation.sh
+++ b/tests/unit/test_reality_rotation_installation.sh
@@ -15,7 +15,6 @@ noop() {
 
 test_reality_rotation_installation() {
   local install_sh="${PROJECT_ROOT}/install.sh"
-  local rotation_sh="${PROJECT_ROOT}/lib/reality_rotation.sh"
   local module_line=''
   local contract_line=''
   local timer_line=''
@@ -25,14 +24,14 @@ test_reality_rotation_installation() {
   module_line=$(grep -F 'subscription reality_rotation stats' "${install_sh}" || true)
   contract_line=$(grep -F '["reality_rotation"]="reality_rotate_shortid reality_rotation_schedule reality_rotation_remove_units"' "${install_sh}" || true)
   helper_call_line=$(grep -F 'if declare -f reality_rotation_remove_units' "${install_sh}" || true)
-  timer_line=$(grep -F 'sbx-shortid-rotate.timer' "${rotation_sh}" || true)
-  service_line=$(grep -F 'sbx-shortid-rotate.service' "${rotation_sh}" || true)
+  timer_line=$(grep -F 'rm -f "/etc/systemd/system/${ROTATION_TIMER_NAME}"' "${install_sh}" || true)
+  service_line=$(grep -F 'rm -f "/etc/systemd/system/${ROTATION_SERVICE_NAME}"' "${install_sh}" || true)
 
   assert_not_empty "${module_line}" "install.sh module list includes reality_rotation after subscription and before stats"
   assert_not_empty "${contract_line}" "install.sh API contract includes reality_rotation"
   assert_not_empty "${helper_call_line}" "uninstall_flow calls reality_rotation_remove_units when available"
-  assert_not_empty "${timer_line}" "reality_rotation_remove_units targets sbx-shortid-rotate.timer"
-  assert_not_empty "${service_line}" "reality_rotation_remove_units targets sbx-shortid-rotate.service"
+  assert_not_empty "${timer_line}" "install.sh uninstall flow removes sbx-shortid-rotate.timer"
+  assert_not_empty "${service_line}" "install.sh uninstall flow removes sbx-shortid-rotate.service"
 }
 
 main() {

--- a/tests/unit/test_reality_rotation_installation.sh
+++ b/tests/unit/test_reality_rotation_installation.sh
@@ -24,8 +24,8 @@ test_reality_rotation_installation() {
   module_line=$(grep -F 'subscription reality_rotation stats' "${install_sh}" || true)
   contract_line=$(grep -F '["reality_rotation"]="reality_rotate_shortid reality_rotation_schedule reality_rotation_remove_units"' "${install_sh}" || true)
   helper_call_line=$(grep -F 'if declare -f reality_rotation_remove_units' "${install_sh}" || true)
-  timer_line=$(grep -F 'rm -f "/etc/systemd/system/${ROTATION_TIMER_NAME}"' "${install_sh}" || true)
-  service_line=$(grep -F 'rm -f "/etc/systemd/system/${ROTATION_SERVICE_NAME}"' "${install_sh}" || true)
+  timer_line=$(grep -F 'remove_systemd_unit "sbx-shortid-rotate.timer" "/etc/systemd/system/sbx-shortid-rotate.timer" "best_effort"' "${install_sh}" || true)
+  service_line=$(grep -F 'remove_systemd_unit "sbx-shortid-rotate.service" "/etc/systemd/system/sbx-shortid-rotate.service" "best_effort"' "${install_sh}" || true)
 
   assert_not_empty "${module_line}" "install.sh module list includes reality_rotation after subscription and before stats"
   assert_not_empty "${contract_line}" "install.sh API contract includes reality_rotation"

--- a/tests/unit/test_reality_rotation_installation.sh
+++ b/tests/unit/test_reality_rotation_installation.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# tests/unit/test_reality_rotation_installation.sh - Validate reality rotation registration in install.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../test_framework.sh"
+
+noop() {
+  :
+}
+
+test_reality_rotation_installation() {
+  local install_sh="${PROJECT_ROOT}/install.sh"
+  local rotation_sh="${PROJECT_ROOT}/lib/reality_rotation.sh"
+  local module_line=''
+  local contract_line=''
+  local timer_line=''
+  local service_line=''
+  local helper_call_line=''
+
+  module_line=$(grep -F 'subscription reality_rotation stats' "${install_sh}" || true)
+  contract_line=$(grep -F '["reality_rotation"]="reality_rotate_shortid reality_rotation_schedule reality_rotation_remove_units"' "${install_sh}" || true)
+  helper_call_line=$(grep -F 'if declare -f reality_rotation_remove_units' "${install_sh}" || true)
+  timer_line=$(grep -F 'sbx-shortid-rotate.timer' "${rotation_sh}" || true)
+  service_line=$(grep -F 'sbx-shortid-rotate.service' "${rotation_sh}" || true)
+
+  assert_not_empty "${module_line}" "install.sh module list includes reality_rotation after subscription and before stats"
+  assert_not_empty "${contract_line}" "install.sh API contract includes reality_rotation"
+  assert_not_empty "${helper_call_line}" "uninstall_flow calls reality_rotation_remove_units when available"
+  assert_not_empty "${timer_line}" "reality_rotation_remove_units targets sbx-shortid-rotate.timer"
+  assert_not_empty "${service_line}" "reality_rotation_remove_units targets sbx-shortid-rotate.service"
+}
+
+main() {
+  set +e
+  run_test_suite "reality rotation install registration" noop test_reality_rotation_installation noop
+  print_test_summary
+}
+
+main "$@"

--- a/tests/unit/test_sbx_manager_rotate_shortid.sh
+++ b/tests/unit/test_sbx_manager_rotate_shortid.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# tests/unit/test_sbx_manager_rotate_shortid.sh - Validate sbx-manager rotate-shortid routing
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../test_framework.sh"
+
+setup_manager_rotate_shortid_mock() {
+  TEST_TMP_DIR="$(mktemp -d /tmp/sbx-manager-rotate-shortid.XXXXXX)"
+  STUB_LIB="${TEST_TMP_DIR}/lib"
+  INVOCATION_LOG="${TEST_TMP_DIR}/invocations.log"
+
+  mkdir -p "${STUB_LIB}"
+  : >"${INVOCATION_LOG}"
+
+  cat >"${STUB_LIB}/common.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+need_root() { echo "need_root" >>"${INVOCATION_LOG}"; return 0; }
+EOF
+
+  cat >"${STUB_LIB}/reality_rotation.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+reality_rotate_shortid() { echo "reality_rotate_shortid $*" >>"${INVOCATION_LOG}"; }
+reality_rotation_schedule() { echo "reality_rotation_schedule $*" >>"${INVOCATION_LOG}"; }
+EOF
+}
+
+teardown_manager_rotate_shortid_mock() {
+  [[ -n "${TEST_TMP_DIR:-}" && -d "${TEST_TMP_DIR}" ]] && rm -rf "${TEST_TMP_DIR}"
+}
+
+test_help_lists_rotate_shortid_commands() {
+  echo "Testing sbx-manager help includes rotate-shortid commands..."
+
+  local output=""
+  output="$(LIB_DIR="${STUB_LIB}" INVOCATION_LOG="${INVOCATION_LOG}" \
+    bash "${PROJECT_ROOT}/bin/sbx-manager.sh" help 2>&1)"
+
+  assert_contains "${output}" "Reality Rotation" "help output lists Reality Rotation section"
+  assert_contains "${output}" "rotate-shortid [--dry-run]" "help output shows rotate-shortid dry-run usage"
+  assert_contains "${output}" "rotate-shortid --schedule <daily|weekly|monthly|off>" \
+    "help output shows rotate-shortid schedule usage"
+}
+
+test_rotate_shortid_dry_run_routes_to_module() {
+  echo "Testing sbx-manager rotate-shortid dry-run routing..."
+
+  : >"${INVOCATION_LOG}"
+  local rc=0
+  LIB_DIR="${STUB_LIB}" INVOCATION_LOG="${INVOCATION_LOG}" \
+    bash "${PROJECT_ROOT}/bin/sbx-manager.sh" rotate-shortid --dry-run >/dev/null 2>&1 || rc=$?
+
+  assert_equals "0" "${rc}" "rotate-shortid --dry-run exits successfully"
+
+  local -a invocation_lines=()
+  mapfile -t invocation_lines <"${INVOCATION_LOG}"
+  assert_equals "2" "${#invocation_lines[@]}" "rotate-shortid --dry-run logs need_root and module invocation"
+  assert_equals "need_root" "${invocation_lines[0]}" "rotate-shortid --dry-run calls need_root first"
+  assert_equals "reality_rotate_shortid --dry-run" "${invocation_lines[1]}" \
+    "rotate-shortid --dry-run dispatches to reality_rotate_shortid with only module args"
+}
+
+test_rotate_shortid_schedule_weekly_routes_to_module() {
+  echo "Testing sbx-manager rotate-shortid schedule routing..."
+
+  : >"${INVOCATION_LOG}"
+  local rc=0
+  LIB_DIR="${STUB_LIB}" INVOCATION_LOG="${INVOCATION_LOG}" \
+    bash "${PROJECT_ROOT}/bin/sbx-manager.sh" rotate-shortid --schedule weekly >/dev/null 2>&1 || rc=$?
+
+  assert_equals "0" "${rc}" "rotate-shortid --schedule weekly exits successfully"
+
+  local -a invocation_lines=()
+  mapfile -t invocation_lines <"${INVOCATION_LOG}"
+  assert_equals "2" "${#invocation_lines[@]}" "rotate-shortid --schedule weekly logs need_root and schedule invocation"
+  assert_equals "need_root" "${invocation_lines[0]}" "rotate-shortid --schedule weekly calls need_root first"
+  assert_equals "reality_rotation_schedule weekly" "${invocation_lines[1]}" \
+    "rotate-shortid --schedule weekly dispatches to reality_rotation_schedule"
+}
+
+test_rotate_shortid_invalid_flag_combination_fails() {
+  echo "Testing sbx-manager rotate-shortid invalid flag combination..."
+
+  : >"${INVOCATION_LOG}"
+  local rc=0
+  local output=""
+  output="$(LIB_DIR="${STUB_LIB}" INVOCATION_LOG="${INVOCATION_LOG}" \
+    bash "${PROJECT_ROOT}/bin/sbx-manager.sh" rotate-shortid --dry-run --schedule weekly 2>&1)" || rc=$?
+
+  assert_equals "1" "${rc}" "rotate-shortid --dry-run --schedule weekly exits non-zero"
+  assert_contains "${output}" "--schedule cannot be combined with other flags" \
+    "rotate-shortid rejects combined --schedule and --dry-run flags"
+  assert_equals "" "$(cat "${INVOCATION_LOG}")" "invalid flag combinations should not reach need_root or modules"
+}
+
+main() {
+  set +e
+  run_test_suite \
+    "sbx-manager rotate-shortid command routing" \
+    setup_manager_rotate_shortid_mock \
+    test_help_lists_rotate_shortid_commands \
+    test_rotate_shortid_dry_run_routes_to_module \
+    test_rotate_shortid_schedule_weekly_routes_to_module \
+    test_rotate_shortid_invalid_flag_combination_fails \
+    teardown_manager_rotate_shortid_mock
+  print_test_summary
+}
+
+main "$@"

--- a/tests/unit/test_sbx_manager_rotate_shortid.sh
+++ b/tests/unit/test_sbx_manager_rotate_shortid.sh
@@ -102,11 +102,23 @@ test_rotate_shortid_invalid_flag_combination_fails() {
 main() {
   set +e
   run_test_suite \
-    "sbx-manager rotate-shortid command routing" \
+    "sbx-manager rotate-shortid help" \
     setup_manager_rotate_shortid_mock \
     test_help_lists_rotate_shortid_commands \
+    teardown_manager_rotate_shortid_mock
+  run_test_suite \
+    "sbx-manager rotate-shortid dry-run" \
+    setup_manager_rotate_shortid_mock \
     test_rotate_shortid_dry_run_routes_to_module \
+    teardown_manager_rotate_shortid_mock
+  run_test_suite \
+    "sbx-manager rotate-shortid schedule" \
+    setup_manager_rotate_shortid_mock \
     test_rotate_shortid_schedule_weekly_routes_to_module \
+    teardown_manager_rotate_shortid_mock
+  run_test_suite \
+    "sbx-manager rotate-shortid invalid flags" \
+    setup_manager_rotate_shortid_mock \
     test_rotate_shortid_invalid_flag_combination_fails \
     teardown_manager_rotate_shortid_mock
   print_test_summary


### PR DESCRIPTION
## Summary
- add `sbx rotate-shortid` with `--dry-run`, `--schedule`, timer-driven execution, audit history, and install/uninstall integration for Reality short ID rotation
- harden runtime mutation safety by serializing rotation with the shared mutation lock, using staged multi-file restore paths, and covering the lock/rollback edge cases with regression tests
- record the lock-order and staged-restore lessons in `.claude/CODING_STANDARDS.md` so future runtime mutators follow the same discipline

## Test Plan
- `bash tests/test-runner.sh unit`
- `bash -u install.sh --help`
- on the AWS VM: `bash tests/unit/test_reality_rotation.sh`
- on the AWS VM: `sudo env AUTO_INSTALL=1 bash install.sh`
- on the AWS VM: `sudo sbx rotate-shortid --dry-run`
- on the AWS VM: `sudo sbx rotate-shortid`
- on the AWS VM: `sudo sbx rotate-shortid --schedule weekly`
- on the AWS VM: `sudo systemctl start sbx-shortid-rotate.service`
- on the AWS VM: `sudo sbx rotate-shortid --schedule off`
- on the AWS VM: `bash scripts/e2e/install-lifecycle-smoke.sh`

Closes #107.