### PR TITLE
fix: resolve issue #135 and harden protocol lifecycle paths

### DIFF
--- a/bin/sbx-manager.sh
+++ b/bin/sbx-manager.sh
@@ -193,7 +193,10 @@ validate_state_info_file() {
   local resolved owner perm
   resolved=$(readlink -f "$state_file") || error_exit "Failed to resolve state file path: $state_file"
   perm=$(stat -c '%a' "$resolved" 2>/dev/null || stat -f '%Lp' "$resolved" 2>/dev/null) || error_exit "Unable to read state file permissions."
-  [[ "$perm" == "600" ]] || error_exit "State file permissions must be 600 (found $perm)."
+  case "$perm" in
+    600 | 640) ;;
+    *) error_exit "State file permissions must be 600 or 640 (found $perm)." ;;
+  esac
   [[ -s "$resolved" ]] || error_exit "State file is empty."
 
   if [[ -z "${TEST_STATE_FILE:-}" ]]; then
@@ -243,22 +246,34 @@ parse_client_info_file() {
     printf -v "$key" '%s' "${client_info_map[$key]}"
   done
 
-  if [[ -v client_info_map[WS_PORT] ]]; then
+  if [[ -n "${REALITY_PORT:-}" ]]; then
+    REALITY_ENABLED="true"
+  else
+    REALITY_ENABLED="false"
+  fi
+
+  if [[ -n "${WS_PORT:-}" ]]; then
     WS_ENABLED="true"
   else
     WS_ENABLED="false"
   fi
 
-  if [[ -v client_info_map[HY2_PORT] || -v client_info_map[HY2_PASS] ]]; then
+  if [[ -n "${HY2_PORT:-}" || -n "${HY2_PASS:-}" ]]; then
     HY2_ENABLED="true"
   else
     HY2_ENABLED="false"
   fi
 
-  if [[ -v client_info_map[TUIC_PORT] || -v client_info_map[TUIC_PASS] ]]; then
+  if [[ -n "${TUIC_PORT:-}" || -n "${TUIC_PASS:-}" ]]; then
     TUIC_ENABLED="true"
   else
     TUIC_ENABLED="false"
+  fi
+
+  if [[ -n "${TROJAN_PORT:-}" || -n "${TROJAN_PASS:-}" ]]; then
+    TROJAN_ENABLED="true"
+  else
+    TROJAN_ENABLED="false"
   fi
 
   # Set defaults for missing variables
@@ -267,17 +282,46 @@ parse_client_info_file() {
   local default_ws="${WS_PORT_DEFAULT:-8444}"
   local default_hy2="${HY2_PORT_DEFAULT:-8443}"
   local default_tuic="${TUIC_PORT_DEFAULT:-8445}"
+  local default_trojan="${TROJAN_PORT_DEFAULT:-8446}"
 
-  REALITY_PORT="${REALITY_PORT:-$default_reality}"
-  SNI="${SNI:-$default_sni}"
-  WS_PORT="${WS_PORT:-$default_ws}"
-  HY2_PORT="${HY2_PORT:-$default_hy2}"
-  TUIC_PORT="${TUIC_PORT:-$default_tuic}"
+  if [[ "${REALITY_ENABLED}" == "true" ]]; then
+    REALITY_PORT="${REALITY_PORT:-$default_reality}"
+    SNI="${SNI:-$default_sni}"
+  else
+    REALITY_PORT=""
+  fi
+
+  if [[ "${WS_ENABLED}" == "true" ]]; then
+    WS_PORT="${WS_PORT:-$default_ws}"
+  else
+    WS_PORT=""
+  fi
+
+  if [[ "${HY2_ENABLED}" == "true" ]]; then
+    HY2_PORT="${HY2_PORT:-$default_hy2}"
+  else
+    HY2_PORT=""
+    HY2_PASS=""
+  fi
+
+  if [[ "${TUIC_ENABLED}" == "true" ]]; then
+    TUIC_PORT="${TUIC_PORT:-$default_tuic}"
+  else
+    TUIC_PORT=""
+    TUIC_PASS=""
+  fi
+
+  if [[ "${TROJAN_ENABLED}" == "true" ]]; then
+    TROJAN_PORT="${TROJAN_PORT:-$default_trojan}"
+  else
+    TROJAN_PORT=""
+    TROJAN_PASS=""
+  fi
 }
 
 parse_state_info_file() {
   local file="$1"
-  local ws_enabled_raw='' hy2_enabled_raw='' tuic_enabled_raw=''
+  local reality_enabled_raw='' ws_enabled_raw='' hy2_enabled_raw='' tuic_enabled_raw='' trojan_enabled_raw=''
 
   DOMAIN=$(jq -r '.server.domain // .server.ip // empty' "$file")
   UUID=$(jq -r '.protocols.reality.uuid // empty' "$file")
@@ -290,11 +334,23 @@ parse_state_info_file() {
   HY2_PASS=$(jq -r '.protocols.hysteria2.password // empty' "$file")
   TUIC_PORT=$(jq -r '.protocols.tuic.port // empty' "$file")
   TUIC_PASS=$(jq -r '.protocols.tuic.password // empty' "$file")
+  TROJAN_PORT=$(jq -r '.protocols.trojan.port // empty' "$file")
+  TROJAN_PASS=$(jq -r '.protocols.trojan.password // empty' "$file")
   CERT_FULLCHAIN=$(jq -r '.protocols.ws_tls.certificate // empty' "$file")
   CERT_KEY=$(jq -r '.protocols.ws_tls.key // empty' "$file")
+  reality_enabled_raw=$(jq -r '.protocols.reality.enabled // empty' "$file")
   ws_enabled_raw=$(jq -r '.protocols.ws_tls.enabled // empty' "$file")
   hy2_enabled_raw=$(jq -r '.protocols.hysteria2.enabled // empty' "$file")
   tuic_enabled_raw=$(jq -r '.protocols.tuic.enabled // empty' "$file")
+  trojan_enabled_raw=$(jq -r '.protocols.trojan.enabled // empty' "$file")
+
+  case "${reality_enabled_raw}" in
+    true | 1 | yes | on) REALITY_ENABLED="true" ;;
+    false | 0 | no | off) REALITY_ENABLED="false" ;;
+    *)
+      [[ -n "${REALITY_PORT:-}" ]] && REALITY_ENABLED="true" || REALITY_ENABLED="false"
+      ;;
+  esac
 
   case "${ws_enabled_raw}" in
     true | 1 | yes | on) WS_ENABLED="true" ;;
@@ -320,17 +376,54 @@ parse_state_info_file() {
       ;;
   esac
 
+  case "${trojan_enabled_raw}" in
+    true | 1 | yes | on) TROJAN_ENABLED="true" ;;
+    false | 0 | no | off) TROJAN_ENABLED="false" ;;
+    *)
+      [[ -n "${TROJAN_PORT:-}" || -n "${TROJAN_PASS:-}" ]] && TROJAN_ENABLED="true" || TROJAN_ENABLED="false"
+      ;;
+  esac
+
   local default_reality="${REALITY_PORT_DEFAULT:-443}"
   local default_sni="${SNI_DEFAULT:-www.microsoft.com}"
   local default_ws="${WS_PORT_DEFAULT:-8444}"
   local default_hy2="${HY2_PORT_DEFAULT:-8443}"
   local default_tuic="${TUIC_PORT_DEFAULT:-8445}"
+  local default_trojan="${TROJAN_PORT_DEFAULT:-8446}"
 
-  REALITY_PORT="${REALITY_PORT:-$default_reality}"
-  SNI="${SNI:-$default_sni}"
-  WS_PORT="${WS_PORT:-$default_ws}"
-  HY2_PORT="${HY2_PORT:-$default_hy2}"
-  TUIC_PORT="${TUIC_PORT:-$default_tuic}"
+  if [[ "${REALITY_ENABLED}" == "true" ]]; then
+    REALITY_PORT="${REALITY_PORT:-$default_reality}"
+    SNI="${SNI:-$default_sni}"
+  else
+    REALITY_PORT=""
+  fi
+
+  if [[ "${WS_ENABLED}" == "true" ]]; then
+    WS_PORT="${WS_PORT:-$default_ws}"
+  else
+    WS_PORT=""
+  fi
+
+  if [[ "${HY2_ENABLED}" == "true" ]]; then
+    HY2_PORT="${HY2_PORT:-$default_hy2}"
+  else
+    HY2_PORT=""
+    HY2_PASS=""
+  fi
+
+  if [[ "${TUIC_ENABLED}" == "true" ]]; then
+    TUIC_PORT="${TUIC_PORT:-$default_tuic}"
+  else
+    TUIC_PORT=""
+    TUIC_PASS=""
+  fi
+
+  if [[ "${TROJAN_ENABLED}" == "true" ]]; then
+    TROJAN_PORT="${TROJAN_PORT:-$default_trojan}"
+  else
+    TROJAN_PORT=""
+    TROJAN_PASS=""
+  fi
 }
 
 fallback_load_client_info() {
@@ -625,17 +718,21 @@ output_info_json() {
   local missing_fields=()
   local warnings_text=''
   local warnings_json='[]'
+  local has_reality=false
   local has_ws=false
   local has_hy2=false
   local has_tuic=false
-  local tuic_port_out='' tuic_pass_out=''
-  local uri_real='' uri_ws='' uri_hy2='' uri_tuic=''
+  local has_trojan=false
+  local tuic_port_out='' tuic_pass_out='' trojan_port_out='' trojan_pass_out=''
+  local uri_real='' uri_ws='' uri_hy2='' uri_tuic='' uri_trojan=''
 
   ensure_client_info_loaded
 
-  [[ -z "${PUBLIC_KEY:-}" ]] && missing_fields+=("PUBLIC_KEY")
-  [[ -z "${UUID:-}" ]] && missing_fields+=("UUID")
-  [[ -z "${SHORT_ID:-}" ]] && missing_fields+=("SHORT_ID")
+  if [[ "${REALITY_ENABLED:-false}" == "true" ]]; then
+    [[ -z "${PUBLIC_KEY:-}" ]] && missing_fields+=("PUBLIC_KEY")
+    [[ -z "${UUID:-}" ]] && missing_fields+=("UUID")
+    [[ -z "${SHORT_ID:-}" ]] && missing_fields+=("SHORT_ID")
+  fi
   [[ -z "${DOMAIN:-}" ]] && missing_fields+=("DOMAIN")
 
   local field
@@ -643,28 +740,29 @@ output_info_json() {
     warnings_text+="Missing required field: ${field}"$'\n'
   done
 
-  REALITY_PORT="${REALITY_PORT:-443}"
-  SNI="${SNI:-www.microsoft.com}"
-  WS_PORT="${WS_PORT:-8444}"
-  HY2_PORT="${HY2_PORT:-8443}"
-  HY2_PASS="${HY2_PASS:-}"
+  if [[ "${REALITY_ENABLED:-false}" == "true" ]]; then
+    has_reality=true
+    REALITY_PORT="${REALITY_PORT:-443}"
+    SNI="${SNI:-www.microsoft.com}"
+  fi
 
   if [[ "${WS_ENABLED:-false}" == "true" ]]; then
     has_ws=true
-  elif [[ -n "${CERT_FULLCHAIN:-}" && -n "${CERT_KEY:-}" ]]; then
-    has_ws=true
+    WS_PORT="${WS_PORT:-8444}"
   fi
 
   if [[ "${HY2_ENABLED:-false}" == "true" ]]; then
     has_hy2=true
-  elif [[ -n "${CERT_FULLCHAIN:-}" && -n "${CERT_KEY:-}" ]]; then
-    has_hy2=true
+    HY2_PORT="${HY2_PORT:-8443}"
+    HY2_PASS="${HY2_PASS:-}"
   fi
 
   if [[ "${TUIC_ENABLED:-false}" == "true" ]]; then
     [[ -n "${TUIC_PASS:-}" ]] && has_tuic=true
-  elif [[ -n "${TUIC_PORT:-}" && -n "${TUIC_PASS:-}" ]]; then
-    has_tuic=true
+  fi
+
+  if [[ "${TROJAN_ENABLED:-false}" == "true" ]]; then
+    [[ -n "${TROJAN_PASS:-}" ]] && has_trojan=true
   fi
 
   if [[ "${has_tuic}" == "true" ]]; then
@@ -672,23 +770,46 @@ output_info_json() {
     tuic_pass_out="${TUIC_PASS:-}"
   fi
 
+  if [[ "${has_trojan}" == "true" ]]; then
+    trojan_port_out="${TROJAN_PORT:-8446}"
+    trojan_pass_out="${TROJAN_PASS:-}"
+  fi
+
   if command -v export_uri >/dev/null 2>&1; then
-    uri_real=$(export_uri reality)
-    uri_ws=$(export_uri ws 2>/dev/null || true)
-    uri_hy2=$(export_uri hy2 2>/dev/null || true)
+    if [[ "${has_reality}" == "true" ]]; then
+      uri_real=$(export_uri reality)
+    fi
+    if [[ "${has_ws}" == "true" ]]; then
+      uri_ws=$(export_uri ws)
+    fi
+    if [[ "${has_hy2}" == "true" ]]; then
+      uri_hy2=$(export_uri hy2)
+    fi
     if [[ "${has_tuic}" == "true" ]]; then
       uri_tuic=$(export_uri tuic)
     fi
+    if [[ "${has_trojan}" == "true" ]]; then
+      uri_trojan=$(export_uri trojan)
+    fi
   else
-    uri_real="vless://${UUID:-}@${DOMAIN:-}:${REALITY_PORT}?encryption=none&security=reality&flow=xtls-rprx-vision&sni=${SNI}&pbk=${PUBLIC_KEY:-}&sid=${SHORT_ID:-}&type=tcp&fp=chrome#Reality-${DOMAIN:-}"
-    uri_ws="vless://${UUID:-}@${DOMAIN:-}:${WS_PORT}?encryption=none&security=tls&type=ws&host=${DOMAIN:-}&path=/ws&sni=${DOMAIN:-}&fp=chrome#WS-TLS-${DOMAIN:-}"
-    uri_hy2="hysteria2://${HY2_PASS}@${DOMAIN:-}:${HY2_PORT}/?sni=${DOMAIN:-}&alpn=h3&insecure=0#Hysteria2-${DOMAIN:-}"
+    if [[ "${has_reality}" == "true" ]]; then
+      uri_real="vless://${UUID:-}@${DOMAIN:-}:${REALITY_PORT}?encryption=none&security=reality&flow=xtls-rprx-vision&sni=${SNI}&pbk=${PUBLIC_KEY:-}&sid=${SHORT_ID:-}&type=tcp&fp=chrome#Reality-${DOMAIN:-}"
+    fi
+    if [[ "${has_ws}" == "true" ]]; then
+      uri_ws="vless://${UUID:-}@${DOMAIN:-}:${WS_PORT}?encryption=none&security=tls&type=ws&host=${DOMAIN:-}&path=/ws&sni=${DOMAIN:-}&fp=chrome#WS-TLS-${DOMAIN:-}"
+    fi
+    if [[ "${has_hy2}" == "true" ]]; then
+      uri_hy2="hysteria2://${HY2_PASS}@${DOMAIN:-}:${HY2_PORT}/?sni=${DOMAIN:-}&alpn=h3&insecure=0#Hysteria2-${DOMAIN:-}"
+    fi
     if [[ "${has_tuic}" == "true" ]]; then
       uri_tuic="tuic://${UUID:-}:${tuic_pass_out}@${DOMAIN:-}:${tuic_port_out}?congestion_control=bbr&alpn=h3&sni=${DOMAIN:-}&udp_relay_mode=native#TUIC-${DOMAIN:-}"
     fi
+    if [[ "${has_trojan}" == "true" ]]; then
+      uri_trojan="trojan://${trojan_pass_out}@${DOMAIN:-}:${trojan_port_out}?sni=${DOMAIN:-}&security=tls&type=tcp&fp=chrome#Trojan-${DOMAIN:-}"
+    fi
   fi
 
-  if echo "${uri_real}" | grep -qE 'pbk=&|pbk=$|@:|//:'; then
+  if [[ "${has_reality}" == "true" ]] && echo "${uri_real}" | grep -qE 'pbk=&|pbk=$|@:|//:'; then
     warnings_text+="Reality URI has empty parameters"$'\n'
   fi
 
@@ -704,22 +825,27 @@ output_info_json() {
     --arg uuid "${UUID:-}" \
     --arg public_key "${PUBLIC_KEY:-}" \
     --arg short_id "${SHORT_ID:-}" \
-    --arg sni "${SNI}" \
-    --arg reality_port "${REALITY_PORT}" \
+    --arg sni "${SNI:-}" \
+    --arg reality_port "${REALITY_PORT:-}" \
     --arg uri_real "${uri_real}" \
-    --arg ws_port "${WS_PORT}" \
+    --arg ws_port "${WS_PORT:-}" \
     --arg uri_ws "${uri_ws}" \
-    --arg hy2_port "${HY2_PORT}" \
-    --arg hy2_pass "${HY2_PASS}" \
+    --arg hy2_port "${HY2_PORT:-}" \
+    --arg hy2_pass "${HY2_PASS:-}" \
     --arg uri_hy2 "${uri_hy2}" \
     --arg tuic_port "${tuic_port_out}" \
     --arg tuic_pass "${tuic_pass_out}" \
     --arg uri_tuic "${uri_tuic}" \
+    --arg trojan_port "${trojan_port_out}" \
+    --arg trojan_pass "${trojan_pass_out}" \
+    --arg uri_trojan "${uri_trojan}" \
     --arg cert_fullchain "${CERT_FULLCHAIN:-}" \
     --arg cert_key "${CERT_KEY:-}" \
+    --argjson reality_enabled "${has_reality}" \
     --argjson ws_enabled "${has_ws}" \
     --argjson hy2_enabled "${has_hy2}" \
     --argjson tuic_enabled "${has_tuic}" \
+    --argjson trojan_enabled "${has_trojan}" \
     --argjson warnings "${warnings_json}" \
     '{
         command: $command,
@@ -729,13 +855,13 @@ output_info_json() {
         warnings: $warnings,
         protocols: {
           reality: {
-            enabled: true,
+            enabled: $reality_enabled,
             port: ($reality_port | tonumber? // null),
             uuid: (if $uuid == "" then null else $uuid end),
             public_key: (if $public_key == "" then null else $public_key end),
             short_id: (if $short_id == "" then null else $short_id end),
             sni: (if $sni == "" then null else $sni end),
-            uri: $uri_real
+            uri: (if $reality_enabled then $uri_real else null end)
           },
           ws_tls: {
             enabled: $ws_enabled,
@@ -754,6 +880,12 @@ output_info_json() {
             port: ($tuic_port | tonumber? // null),
             password: (if $tuic_enabled and $tuic_pass != "" then $tuic_pass else null end),
             uri: (if $tuic_enabled then $uri_tuic else null end)
+          },
+          trojan: {
+            enabled: $trojan_enabled,
+            port: ($trojan_port | tonumber? // null),
+            password: (if $trojan_enabled and $trojan_pass != "" then $trojan_pass else null end),
+            uri: (if $trojan_enabled then $uri_trojan else null end)
           }
         }
       }'
@@ -839,9 +971,11 @@ case "${1:-}" in
     # Validate required fields
     missing_fields=()
     has_warnings=0
-    [[ -z "${PUBLIC_KEY:-}" ]] && missing_fields+=("PUBLIC_KEY") && has_warnings=1
-    [[ -z "${UUID:-}" ]] && missing_fields+=("UUID") && has_warnings=1
-    [[ -z "${SHORT_ID:-}" ]] && missing_fields+=("SHORT_ID") && has_warnings=1
+    if [[ "${REALITY_ENABLED:-false}" == "true" ]]; then
+      [[ -z "${PUBLIC_KEY:-}" ]] && missing_fields+=("PUBLIC_KEY") && has_warnings=1
+      [[ -z "${UUID:-}" ]] && missing_fields+=("UUID") && has_warnings=1
+      [[ -z "${SHORT_ID:-}" ]] && missing_fields+=("SHORT_ID") && has_warnings=1
+    fi
     [[ -z "${DOMAIN:-}" ]] && missing_fields+=("DOMAIN") && has_warnings=1
 
     echo
@@ -866,59 +1000,62 @@ case "${1:-}" in
     echo "Service   : systemctl status sing-box"
     echo
 
-    # Reality (use defaults if not set)
-    REALITY_PORT="${REALITY_PORT:-443}"
-    SNI="${SNI:-www.microsoft.com}"
-    echo "INBOUND   : VLESS-REALITY  ${REALITY_PORT}/tcp"
-    echo "  PublicKey = ${PUBLIC_KEY:-[MISSING]}"
-    echo "  Short ID  = ${SHORT_ID:-[MISSING]}"
-    echo "  UUID      = ${UUID:-[MISSING]}"
-    # Use export_uri() if available (DRY), otherwise generate inline
-    if command -v export_uri >/dev/null 2>&1; then
-      URI_REAL=$(export_uri reality)
-    else
-      URI_REAL="vless://${UUID:-}@${DOMAIN:-}:${REALITY_PORT}?encryption=none&security=reality&flow=xtls-rprx-vision&sni=${SNI}&pbk=${PUBLIC_KEY:-}&sid=${SHORT_ID:-}&type=tcp&fp=chrome#Reality-${DOMAIN:-}"
-    fi
-    echo "  URI       = ${URI_REAL}"
-
-    # Warn if URI has empty parameters
-    if echo "$URI_REAL" | grep -qE 'pbk=&|pbk=$|@:|//:'; then
-      echo -e "  ${R}⚠ WARNING:${N} URI has empty parameters and cannot be used"
-    fi
-
+    has_reality_in_info=false
     has_ws_in_info=false
     has_hy2_in_info=false
     has_tuic_in_info=false
+    has_trojan_in_info=false
     cert_label=''
+
+    if [[ "${REALITY_ENABLED:-false}" == "true" ]]; then
+      has_reality_in_info=true
+      REALITY_PORT="${REALITY_PORT:-443}"
+      SNI="${SNI:-www.microsoft.com}"
+    fi
 
     if [[ "${WS_ENABLED:-false}" == "true" ]]; then
       has_ws_in_info=true
-    elif [[ -n "${CERT_FULLCHAIN:-}" && -n "${CERT_KEY:-}" ]]; then
-      has_ws_in_info=true
+      WS_PORT="${WS_PORT:-8444}"
     fi
 
     if [[ "${HY2_ENABLED:-false}" == "true" ]]; then
       has_hy2_in_info=true
-    elif [[ -n "${CERT_FULLCHAIN:-}" && -n "${CERT_KEY:-}" ]]; then
-      has_hy2_in_info=true
+      HY2_PORT="${HY2_PORT:-8443}"
+      HY2_PASS="${HY2_PASS:-}"
     fi
 
     if [[ "${TUIC_ENABLED:-false}" == "true" ]]; then
       [[ -n "${TUIC_PASS:-}" ]] && has_tuic_in_info=true
-    elif [[ -n "${TUIC_PORT:-}" && -n "${TUIC_PASS:-}" ]]; then
-      has_tuic_in_info=true
+    fi
+
+    if [[ "${TROJAN_ENABLED:-false}" == "true" ]]; then
+      [[ -n "${TROJAN_PASS:-}" ]] && has_trojan_in_info=true
+    fi
+
+    if [[ "${has_reality_in_info}" == "true" ]]; then
+      echo "INBOUND   : VLESS-REALITY  ${REALITY_PORT}/tcp"
+      echo "  PublicKey = ${PUBLIC_KEY:-[MISSING]}"
+      echo "  Short ID  = ${SHORT_ID:-[MISSING]}"
+      echo "  UUID      = ${UUID:-[MISSING]}"
+      if command -v export_uri >/dev/null 2>&1; then
+        URI_REAL=$(export_uri reality)
+      else
+        URI_REAL="vless://${UUID:-}@${DOMAIN:-}:${REALITY_PORT}?encryption=none&security=reality&flow=xtls-rprx-vision&sni=${SNI}&pbk=${PUBLIC_KEY:-}&sid=${SHORT_ID:-}&type=tcp&fp=chrome#Reality-${DOMAIN:-}"
+      fi
+      echo "  URI       = ${URI_REAL}"
+
+      if echo "$URI_REAL" | grep -qE 'pbk=&|pbk=$|@:|//:'; then
+        echo -e "  ${R}⚠ WARNING:${N} URI has empty parameters and cannot be used"
+      fi
     fi
 
     if [[ -n "${CERT_FULLCHAIN:-}" && -n "${CERT_KEY:-}" ]]; then
       cert_label="${CERT_FULLCHAIN}"
-    elif [[ "${has_ws_in_info}" == "true" || "${has_hy2_in_info}" == "true" || "${has_tuic_in_info}" == "true" ]]; then
+    elif [[ "${has_ws_in_info}" == "true" || "${has_hy2_in_info}" == "true" || "${has_tuic_in_info}" == "true" || "${has_trojan_in_info}" == "true" ]]; then
       cert_label="ACME-managed"
     fi
 
-    if [[ "${has_ws_in_info}" == "true" || "${has_hy2_in_info}" == "true" || "${has_tuic_in_info}" == "true" ]]; then
-      WS_PORT="${WS_PORT:-8444}"
-      HY2_PORT="${HY2_PORT:-8443}"
-      HY2_PASS="${HY2_PASS:-}"
+    if [[ "${has_ws_in_info}" == "true" || "${has_hy2_in_info}" == "true" || "${has_tuic_in_info}" == "true" || "${has_trojan_in_info}" == "true" ]]; then
       echo
       if [[ "${has_ws_in_info}" == "true" ]]; then
         echo "INBOUND   : VLESS-WS-TLS   ${WS_PORT}/tcp"
@@ -961,9 +1098,23 @@ case "${1:-}" in
         fi
         echo "  URI      = ${URI_TUIC}"
       fi
+
+      if [[ "${has_trojan_in_info}" == "true" ]]; then
+        trojan_port_info="${TROJAN_PORT:-8446}"
+        trojan_pass_info="${TROJAN_PASS:-}"
+        echo
+        echo "INBOUND   : Trojan         ${trojan_port_info}/tcp"
+        echo "  CERT     = ${cert_label}"
+        if command -v export_uri >/dev/null 2>&1; then
+          URI_TROJAN=$(export_uri trojan)
+        else
+          URI_TROJAN="trojan://${trojan_pass_info}@${DOMAIN:-}:${trojan_port_info}?sni=${DOMAIN:-}&security=tls&type=tcp&fp=chrome#Trojan-${DOMAIN:-}"
+        fi
+        echo "  URI      = ${URI_TROJAN}"
+      fi
     fi
     echo
-    echo -e "${Y}Notes${N}: Reality/Hy2/TUIC suggest gray cloud; WS-TLS can use gray/orange cloud."
+    echo -e "${Y}Notes${N}: Reality/Hy2/TUIC/Trojan suggest gray cloud; WS-TLS can use gray/orange cloud."
 
     # Optional: Generate QR codes
     if command -v qrencode >/dev/null 2>&1; then
@@ -985,7 +1136,7 @@ case "${1:-}" in
     echo -e "${B}=== Configuration QR Codes ===${N}"
 
     # Generate Reality QR code
-    if [[ -n "$UUID" && -n "$DOMAIN" && -n "$PUBLIC_KEY" && -n "$SHORT_ID" ]]; then
+    if [[ "${REALITY_ENABLED:-false}" == "true" && -n "$UUID" && -n "$DOMAIN" && -n "$PUBLIC_KEY" && -n "$SHORT_ID" ]]; then
       echo
       echo -e "${G}VLESS-REALITY:${N}"
       echo "┌─────────────────────────────────────┐"
@@ -1000,8 +1151,7 @@ case "${1:-}" in
       echo "└─────────────────────────────────────┘"
     fi
 
-    # Generate WS-TLS QR code if certificates exist
-    if [[ -n "$CERT_FULLCHAIN" && -n "$CERT_KEY" && -n "$UUID" && -n "$DOMAIN" ]]; then
+    if [[ "${WS_ENABLED:-false}" == "true" && -n "$UUID" && -n "$DOMAIN" ]]; then
       echo
       echo -e "${G}VLESS-WS-TLS:${N}"
       echo "┌─────────────────────────────────────┐"
@@ -1012,7 +1162,9 @@ case "${1:-}" in
       fi
       qrencode -t UTF8 -m 0 "$URI_WS" 2>/dev/null || echo "QR code generation failed"
       echo "└─────────────────────────────────────┘"
+    fi
 
+    if [[ "${HY2_ENABLED:-false}" == "true" && -n "$DOMAIN" ]]; then
       echo
       echo -e "${G}Hysteria2:${N}"
       echo "┌─────────────────────────────────────┐"
@@ -1169,21 +1321,20 @@ case "${1:-}" in
       exit 1
     fi
 
-    # Paths
-    SB_BIN="/usr/local/bin/sing-box"
-    SB_CONF_DIR="/etc/sing-box"
-    SB_CONF="${SB_CONF_DIR}/config.json"
-    SB_SVC="/etc/systemd/system/sing-box.service"
-    CERT_DIR_BASE="/etc/ssl/sbx"
+    uninstall_sb_bin="${SB_BIN:-/usr/local/bin/sing-box}"
+    uninstall_sb_conf_dir="${SB_CONF_DIR:-/etc/sing-box}"
+    uninstall_sb_conf="${SB_CONF:-${uninstall_sb_conf_dir}/config.json}"
+    uninstall_sb_svc="${SB_SVC:-/etc/systemd/system/sing-box.service}"
+    uninstall_cert_dir="${CERT_DIR_BASE:-/etc/ssl/sbx}"
 
     echo
     echo -e "${Y}[!]${N} The following will be completely removed:"
-    [[ -x "$SB_BIN" ]] && echo "  - Binary: $SB_BIN"
-    [[ -f "$SB_CONF" ]] && echo "  - Config: $SB_CONF"
-    [[ -d "$SB_CONF_DIR" ]] && echo "  - Config directory: $SB_CONF_DIR"
-    [[ -f "$SB_SVC" ]] && echo "  - Service: $SB_SVC"
+    [[ -x "$uninstall_sb_bin" ]] && echo "  - Binary: $uninstall_sb_bin"
+    [[ -f "$uninstall_sb_conf" ]] && echo "  - Config: $uninstall_sb_conf"
+    [[ -d "$uninstall_sb_conf_dir" ]] && echo "  - Config directory: $uninstall_sb_conf_dir"
+    [[ -f "$uninstall_sb_svc" ]] && echo "  - Service: $uninstall_sb_svc"
     [[ -x "/usr/local/bin/sbx-manager" ]] && echo "  - Management commands: sbx-manager, sbx"
-    [[ -d "$CERT_DIR_BASE" ]] && echo "  - Certificates: $CERT_DIR_BASE"
+    [[ -d "$uninstall_cert_dir" ]] && echo "  - Certificates: $uninstall_cert_dir"
     [[ -d "$LIB_DIR" ]] && echo "  - Library modules: $LIB_DIR"
 
     echo
@@ -1212,10 +1363,10 @@ case "${1:-}" in
     done
 
     echo -e "${G}[*]${N} Removing files..."
-    rm -f "$SB_BIN" "$SB_SVC" "/usr/local/bin/sbx-manager" "/usr/local/bin/sbx" \
+    rm -f "$uninstall_sb_bin" "$uninstall_sb_svc" "/usr/local/bin/sbx-manager" "/usr/local/bin/sbx" \
       "/usr/local/bin/sbx-telegram-bot" "/etc/sing-box/telegram.env"
     rm -rf "/var/lib/sbx-telegram-bot"
-    rm -rf "$SB_CONF_DIR" "$CERT_DIR_BASE" "$LIB_DIR"
+    rm -rf "$uninstall_sb_conf_dir" "$uninstall_cert_dir" "$LIB_DIR"
 
     systemctl daemon-reload
 

--- a/install.sh
+++ b/install.sh
@@ -1545,6 +1545,7 @@ save_state_info() {
   local server_ip=''
   local ws_enabled=false
   local hy2_enabled=false
+  local reality_enabled=false
   local cert_path=''
   local cert_key=''
   local ws_port=''
@@ -1554,6 +1555,7 @@ save_state_info() {
   [[ "${REALITY_ONLY_MODE:-0}" == "1" ]] && mode="reality_only"
   installed_at=$(date -Iseconds 2>/dev/null || date)
   resolved_version=$(get_installed_version 2>/dev/null || echo "")
+  [[ "${ENABLE_REALITY:-1}" == "1" ]] && reality_enabled=true
 
   if validate_ip_address "${DOMAIN}" >/dev/null 2>&1; then
     server_ip="${DOMAIN}"
@@ -1616,6 +1618,7 @@ save_state_info() {
     --arg reality_public_key "${PUB}" \
     --arg reality_short_id "${SID}" \
     --arg reality_sni "${SNI:-${SNI_DEFAULT}}" \
+    --argjson reality_enabled "${reality_enabled}" \
     --argjson reality_port "${REALITY_PORT_CHOSEN:-0}" \
     --arg default_user_name "default" \
     --argjson ws_enabled "${ws_enabled}" \
@@ -1650,8 +1653,8 @@ save_state_info() {
       },
       protocols: {
         reality: {
-          enabled: true,
-          port: (if $reality_port == 0 then null else $reality_port end),
+          enabled: $reality_enabled,
+          port: (if $reality_enabled and $reality_port != 0 then $reality_port else null end),
           uuid: $reality_uuid,
           users: [{name: $default_user_name, uuid: $reality_uuid, created_at: $installed_at}],
           public_key: $reality_public_key,

--- a/lib/cloudflare_tunnel.sh
+++ b/lib/cloudflare_tunnel.sh
@@ -259,7 +259,7 @@ ingress:
       noTLSVerify: true
   - service: http_status:404
 EOF
-  chmod 600 "${CLOUDFLARED_CONFIG}"
+  chmod 644 "${CLOUDFLARED_CONFIG}"
 }
 
 # cloudflared_write_service_file <mode>
@@ -272,7 +272,7 @@ cloudflared_write_service_file() {
     token)
       # The token is pulled from EnvironmentFile at start-time so it never
       # appears on the command line (and therefore not in `ps`/journal).
-      exec_line='ExecStart=/usr/local/bin/cloudflared --no-autoupdate tunnel run --token ${TUNNEL_TOKEN}'
+      exec_line="ExecStart=/usr/local/bin/cloudflared --config ${CLOUDFLARED_CONFIG} --no-autoupdate tunnel run --token \${TUNNEL_TOKEN}"
       ;;
     quick)
       local quick_port=""

--- a/lib/cloudflare_tunnel.sh
+++ b/lib/cloudflare_tunnel.sh
@@ -235,7 +235,10 @@ cloudflared_write_env_file() {
 }
 
 # cloudflared_write_config_yml <hostname> [upstream_port]
-# Writes a minimal named-tunnel config.yml routing <hostname> -> local WS.
+# Writes a minimal named-tunnel config.yml routing <hostname> -> local WS-TLS.
+# sing-box terminates TLS on the WS inbound, so cloudflared must speak HTTPS to
+# the local origin. We disable origin verification because sbx commonly uses a
+# self-signed or domain-mismatched cert on loopback.
 cloudflared_write_config_yml() {
   local hostname="$1"
   local upstream_port="${2:-$(cloudflared_resolve_upstream_port)}"
@@ -251,7 +254,9 @@ cloudflared_write_config_yml() {
 # Routes public hostname traffic to the local sing-box WebSocket inbound.
 ingress:
   - hostname: ${hostname}
-    service: http://127.0.0.1:${upstream_port}
+    service: https://127.0.0.1:${upstream_port}
+    originRequest:
+      noTLSVerify: true
   - service: http_status:404
 EOF
   chmod 600 "${CLOUDFLARED_CONFIG}"
@@ -272,7 +277,7 @@ cloudflared_write_service_file() {
     quick)
       local quick_port=""
       quick_port=$(cloudflared_resolve_upstream_port)
-      exec_line="ExecStart=/usr/local/bin/cloudflared --no-autoupdate tunnel --url http://127.0.0.1:${quick_port}"
+      exec_line="ExecStart=/usr/local/bin/cloudflared --no-autoupdate tunnel --url https://127.0.0.1:${quick_port} --no-tls-verify"
       ;;
     *)
       err "cloudflared_write_service_file: unknown mode '${mode}'"

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -191,7 +191,7 @@ create_reality_inbound() {
   # Build sing-box users array: keep only uuid + flow fields
   local sb_users=''
   sb_users=$(echo "${users_json}" | jq --arg flow "${REALITY_FLOW_VISION}" \
-    '[.[] | {uuid: .uuid, flow: $flow}]') || {
+    '[.[] | ({uuid: .uuid, flow: $flow} + (if (.name // "") != "" then {name: .name} else {} end))]') || {
     err "Failed to build Reality users array from input"
     return 1
   }
@@ -368,7 +368,8 @@ create_ws_inbound() {
 
   # Build sing-box users array (uuid only, no flow for WS-TLS)
   local sb_users=''
-  sb_users=$(echo "${users_json}" | jq '[.[] | {uuid: .uuid}]') || {
+  sb_users=$(echo "${users_json}" | jq \
+    '[.[] | ({uuid: .uuid} + (if (.name // "") != "" then {name: .name} else {} end))]') || {
     err "Failed to build WS-TLS users array from input"
     return 1
   }
@@ -754,7 +755,7 @@ _create_all_inbounds() {
   # wrapping the positional uuid argument in a single-element array.
   local users_json="${USERS_JSON:-}"
   if [[ -z "${users_json}" ]]; then
-    users_json=$(jq -n --arg uuid "${uuid}" '[{uuid: $uuid}]')
+    users_json=$(jq -n --arg uuid "${uuid}" '[{name: "default", uuid: $uuid}]')
   fi
 
   # Add Reality inbound (if enabled and port is set)

--- a/lib/export.sh
+++ b/lib/export.sh
@@ -39,7 +39,7 @@ _export_die() {
 # Load client info from saved configuration with strict validation
 load_client_info() {
   local client_info_file='' state_file='' resolved='' owner='' perm='' invalid_line=''
-  local ws_enabled_raw='' hy2_enabled_raw='' tuic_enabled_raw='' trojan_enabled_raw=''
+  local reality_enabled_raw='' ws_enabled_raw='' hy2_enabled_raw='' tuic_enabled_raw='' trojan_enabled_raw=''
   local -a state_fields=()
   local allowed_keys_regex="^(DOMAIN|UUID|PUBLIC_KEY|SHORT_ID|SNI|REALITY_PORT|WS_PORT|HY2_PORT|HY2_PASS|TUIC_PORT|TUIC_PASS|TROJAN_PORT|TROJAN_PASS|CERT_FULLCHAIN|CERT_KEY|TUNNEL_ENABLED|TUNNEL_HOSTNAME|TUNNEL_MODE)$"
 
@@ -53,9 +53,14 @@ load_client_info() {
       "Ensure state path exists and is readable."
     perm=$(stat -c '%a' "${resolved}" 2>/dev/null || stat -f '%Lp' "${resolved}" 2>/dev/null) || _export_die "SBX-EXPORT-003" "Unable to read state file permissions" \
       "Check file permissions and stat command availability."
-    [[ "${perm}" == "600" ]] || _export_die "SBX-EXPORT-004" "State file permissions must be 600 (found ${perm})" \
-      "Restrict state file permissions to owner read/write only." \
-      "chmod 600 /etc/sing-box/state.json"
+    case "${perm}" in
+      600 | 640) ;;
+      *)
+        _export_die "SBX-EXPORT-004" "State file permissions must be 600 or 640 (found ${perm})" \
+          "Restrict state file permissions to owner read/write, with optional group-read for subscription." \
+          "chmod 600 /etc/sing-box/state.json"
+        ;;
+    esac
     [[ -s "${resolved}" ]] || _export_die "SBX-EXPORT-005" "State file is empty" \
       "Re-run install or restore state.json from backup."
 
@@ -100,6 +105,7 @@ load_client_info() {
           (.tunnel.enabled // false | tostring),
           (.tunnel.hostname // ""),
           (.tunnel.mode // ""),
+          (.protocols.reality.enabled | if . == null then "" else tostring end),
           (.protocols.ws_tls.enabled | if . == null then "" else tostring end),
           (.protocols.hysteria2.enabled | if . == null then "" else tostring end),
           (.protocols.tuic.enabled | if . == null then "" else tostring end),
@@ -110,7 +116,7 @@ load_client_info() {
     ) || _export_die "SBX-EXPORT-010" "Failed to extract client info from state file" \
       "Repair or regenerate state.json."
 
-    [[ "${#state_fields[@]}" -eq 28 ]] || _export_die "SBX-EXPORT-011" "Unexpected state data shape while loading client info" \
+    [[ "${#state_fields[@]}" -eq 29 ]] || _export_die "SBX-EXPORT-011" "Unexpected state data shape while loading client info" \
       "Repair or regenerate state.json."
 
     DOMAIN="${state_fields[0]}"
@@ -137,10 +143,19 @@ load_client_info() {
     TUNNEL_ENABLED="${state_fields[21]}"
     TUNNEL_HOSTNAME="${state_fields[22]}"
     TUNNEL_MODE="${state_fields[23]}"
-    ws_enabled_raw="${state_fields[24]}"
-    hy2_enabled_raw="${state_fields[25]}"
-    tuic_enabled_raw="${state_fields[26]}"
-    trojan_enabled_raw="${state_fields[27]}"
+    reality_enabled_raw="${state_fields[24]}"
+    ws_enabled_raw="${state_fields[25]}"
+    hy2_enabled_raw="${state_fields[26]}"
+    tuic_enabled_raw="${state_fields[27]}"
+    trojan_enabled_raw="${state_fields[28]}"
+
+    case "${reality_enabled_raw}" in
+      true | 1 | yes | on) REALITY_ENABLED="true" ;;
+      false | 0 | no | off) REALITY_ENABLED="false" ;;
+      *)
+        [[ -n "${REALITY_PORT:-}" ]] && REALITY_ENABLED="true" || REALITY_ENABLED="false"
+        ;;
+    esac
 
     case "${ws_enabled_raw}" in
       true | 1 | yes | on) WS_ENABLED="true" ;;
@@ -174,12 +189,40 @@ load_client_info() {
         ;;
     esac
 
-    REALITY_PORT="${REALITY_PORT:-${REALITY_PORT_DEFAULT:-443}}"
-    SNI="${SNI:-${SNI_DEFAULT:-www.microsoft.com}}"
-    WS_PORT="${WS_PORT:-${WS_PORT_DEFAULT:-8444}}"
-    HY2_PORT="${HY2_PORT:-${HY2_PORT_DEFAULT:-8443}}"
-    TUIC_PORT="${TUIC_PORT:-${TUIC_PORT_DEFAULT:-8445}}"
-    TROJAN_PORT="${TROJAN_PORT:-${TROJAN_PORT_DEFAULT:-8446}}"
+    if [[ "${REALITY_ENABLED}" == "true" ]]; then
+      REALITY_PORT="${REALITY_PORT:-${REALITY_PORT_DEFAULT:-443}}"
+      SNI="${SNI:-${SNI_DEFAULT:-www.microsoft.com}}"
+    else
+      REALITY_PORT=''
+    fi
+
+    if [[ "${WS_ENABLED}" == "true" ]]; then
+      WS_PORT="${WS_PORT:-${WS_PORT_DEFAULT:-8444}}"
+    else
+      WS_PORT=''
+    fi
+
+    if [[ "${HY2_ENABLED}" == "true" ]]; then
+      HY2_PORT="${HY2_PORT:-${HY2_PORT_DEFAULT:-8443}}"
+    else
+      HY2_PORT=''
+      HY2_PASS=''
+      HY2_PORT_RANGE=''
+    fi
+
+    if [[ "${TUIC_ENABLED}" == "true" ]]; then
+      TUIC_PORT="${TUIC_PORT:-${TUIC_PORT_DEFAULT:-8445}}"
+    else
+      TUIC_PORT=''
+      TUIC_PASS=''
+    fi
+
+    if [[ "${TROJAN_ENABLED}" == "true" ]]; then
+      TROJAN_PORT="${TROJAN_PORT:-${TROJAN_PORT_DEFAULT:-8446}}"
+    else
+      TROJAN_PORT=''
+      TROJAN_PASS=''
+    fi
     return 0
   fi
 
@@ -254,37 +297,70 @@ load_client_info() {
     printf -v "${key}" '%s' "${client_info_map[${key}]}"
   done
 
-  if [[ -v client_info_map[WS_PORT] ]]; then
+  if [[ -n "${REALITY_PORT:-}" ]]; then
+    REALITY_ENABLED="true"
+  else
+    REALITY_ENABLED="false"
+  fi
+
+  if [[ -n "${WS_PORT:-}" ]]; then
     WS_ENABLED="true"
   else
     WS_ENABLED="false"
   fi
 
-  if [[ -v client_info_map[HY2_PORT] || -v client_info_map[HY2_PASS] ]]; then
+  if [[ -n "${HY2_PORT:-}" || -n "${HY2_PASS:-}" ]]; then
     HY2_ENABLED="true"
   else
     HY2_ENABLED="false"
   fi
 
-  if [[ -v client_info_map[TUIC_PORT] || -v client_info_map[TUIC_PASS] ]]; then
+  if [[ -n "${TUIC_PORT:-}" || -n "${TUIC_PASS:-}" ]]; then
     TUIC_ENABLED="true"
   else
     TUIC_ENABLED="false"
   fi
 
-  if [[ -v client_info_map[TROJAN_PORT] || -v client_info_map[TROJAN_PASS] ]]; then
+  if [[ -n "${TROJAN_PORT:-}" || -n "${TROJAN_PASS:-}" ]]; then
     TROJAN_ENABLED="true"
   else
     TROJAN_ENABLED="false"
   fi
 
-  # Set defaults for missing variables to ensure valid URIs
-  REALITY_PORT="${REALITY_PORT:-${REALITY_PORT_DEFAULT:-443}}"
-  SNI="${SNI:-${SNI_DEFAULT:-www.microsoft.com}}"
-  WS_PORT="${WS_PORT:-${WS_PORT_DEFAULT:-8444}}"
-  HY2_PORT="${HY2_PORT:-${HY2_PORT_DEFAULT:-8443}}"
-  TUIC_PORT="${TUIC_PORT:-${TUIC_PORT_DEFAULT:-8445}}"
-  TROJAN_PORT="${TROJAN_PORT:-${TROJAN_PORT_DEFAULT:-8446}}"
+  if [[ "${REALITY_ENABLED}" == "true" ]]; then
+    REALITY_PORT="${REALITY_PORT:-${REALITY_PORT_DEFAULT:-443}}"
+    SNI="${SNI:-${SNI_DEFAULT:-www.microsoft.com}}"
+  else
+    REALITY_PORT=''
+  fi
+
+  if [[ "${WS_ENABLED}" == "true" ]]; then
+    WS_PORT="${WS_PORT:-${WS_PORT_DEFAULT:-8444}}"
+  else
+    WS_PORT=''
+  fi
+
+  if [[ "${HY2_ENABLED}" == "true" ]]; then
+    HY2_PORT="${HY2_PORT:-${HY2_PORT_DEFAULT:-8443}}"
+  else
+    HY2_PORT=''
+    HY2_PASS=''
+    HY2_PORT_RANGE=''
+  fi
+
+  if [[ "${TUIC_ENABLED}" == "true" ]]; then
+    TUIC_PORT="${TUIC_PORT:-${TUIC_PORT_DEFAULT:-8445}}"
+  else
+    TUIC_PORT=''
+    TUIC_PASS=''
+  fi
+
+  if [[ "${TROJAN_ENABLED}" == "true" ]]; then
+    TROJAN_PORT="${TROJAN_PORT:-${TROJAN_PORT_DEFAULT:-8446}}"
+  else
+    TROJAN_PORT=''
+    TROJAN_PASS=''
+  fi
 }
 
 #==============================================================================
@@ -299,6 +375,8 @@ export_v2rayn_json() {
   local config=""
   case "${protocol}" in
     reality)
+      [[ "${REALITY_ENABLED:-false}" == "true" && -n "${REALITY_PORT:-}" ]] || _export_die "SBX-EXPORT-039" "Reality not configured" \
+        "Enable Reality during install or export another protocol."
       config=$(
         cat <<EOF
 {
@@ -337,7 +415,7 @@ EOF
       )
       ;;
     ws)
-      [[ -n "${WS_PORT}" ]] || _export_die "SBX-EXPORT-040" "WS-TLS not configured" \
+      [[ "${WS_ENABLED:-false}" == "true" && -n "${WS_PORT:-}" ]] || _export_die "SBX-EXPORT-040" "WS-TLS not configured" \
         "Enable WS during install or export Reality only."
       local ws_host="" ws_port=""
       ws_host=$(_effective_ws_host)
@@ -396,9 +474,13 @@ EOF
 # Generate Clash/Clash Meta YAML configuration
 export_clash_yaml() {
   load_client_info
+  local ws_host='' ws_port='' proxy_name=''
+  local -a proxy_names=()
 
-  cat <<EOF
-proxies:
+  echo "proxies:"
+
+  if [[ "${REALITY_ENABLED:-false}" == "true" && -n "${REALITY_PORT:-}" ]]; then
+    cat <<EOF
   - name: "sbx-reality-${DOMAIN}"
     type: vless
     server: ${DOMAIN}
@@ -413,11 +495,10 @@ proxies:
     client-fingerprint: ${REALITY_FINGERPRINT_DEFAULT}
     servername: ${SNI}
 EOF
+    proxy_names+=("\"sbx-reality-${DOMAIN}\"")
+  fi
 
-  # WS-TLS proxy: rendered when WS is configured and either a local cert
-  # exists (direct mode) or Cloudflare Tunnel terminates TLS at the edge.
-  if [[ -n "${WS_PORT}" && (-n "${CERT_FULLCHAIN}" || "${TUNNEL_ENABLED:-false}" == "true") ]]; then
-    local ws_host="" ws_port=""
+  if [[ "${WS_ENABLED:-false}" == "true" && -n "${WS_PORT:-}" ]]; then
     ws_host=$(_effective_ws_host)
     ws_port=$(_effective_ws_port)
     cat <<EOF
@@ -436,9 +517,10 @@ EOF
     servername: ${ws_host}
     client-fingerprint: ${REALITY_FINGERPRINT_DEFAULT}
 EOF
+    proxy_names+=("\"sbx-ws-${DOMAIN}\"")
   fi
 
-  if [[ -n "${WS_PORT}" && -n "${CERT_FULLCHAIN}" ]]; then
+  if [[ "${HY2_ENABLED:-false}" == "true" && -n "${HY2_PORT:-}" && -n "${HY2_PASS:-}" ]]; then
     cat <<EOF
 
   - name: "sbx-hysteria2-${DOMAIN}"
@@ -454,6 +536,7 @@ EOF
     ports: ${HY2_PORT_RANGE}
 EOF
     fi
+    proxy_names+=("\"sbx-hysteria2-${DOMAIN}\"")
   fi
 
   if [[ "${TUIC_ENABLED:-false}" == "true" && -n "${TUIC_PORT:-}" && -n "${TUIC_PASS:-}" ]]; then
@@ -471,6 +554,7 @@ EOF
     sni: ${DOMAIN}
     skip-cert-verify: false
 EOF
+    proxy_names+=("\"sbx-tuic-${DOMAIN}\"")
   fi
 
   if [[ "${TROJAN_ENABLED:-false}" == "true" && -n "${TROJAN_PORT:-}" && -n "${TROJAN_PASS:-}" ]]; then
@@ -485,6 +569,7 @@ EOF
     skip-cert-verify: false
     client-fingerprint: ${REALITY_FINGERPRINT_DEFAULT}
 EOF
+    proxy_names+=("\"sbx-trojan-${DOMAIN}\"")
   fi
 
   cat <<EOF
@@ -493,31 +578,11 @@ proxy-groups:
   - name: "sbx-lite"
     type: select
     proxies:
-      - "sbx-reality-${DOMAIN}"
 EOF
 
-  if [[ -n "${WS_PORT}" && (-n "${CERT_FULLCHAIN}" || "${TUNNEL_ENABLED:-false}" == "true") ]]; then
-    cat <<EOF
-      - "sbx-ws-${DOMAIN}"
-EOF
-  fi
-  if [[ -n "${WS_PORT}" && -n "${CERT_FULLCHAIN}" ]]; then
-    cat <<EOF
-      - "sbx-hysteria2-${DOMAIN}"
-EOF
-  fi
-
-  if [[ "${TUIC_ENABLED:-false}" == "true" ]]; then
-    cat <<EOF
-      - "sbx-tuic-${DOMAIN}"
-EOF
-  fi
-
-  if [[ "${TROJAN_ENABLED:-false}" == "true" ]]; then
-    cat <<EOF
-      - "sbx-trojan-${DOMAIN}"
-EOF
-  fi
+  for proxy_name in "${proxy_names[@]}"; do
+    echo "      - ${proxy_name}"
+  done
 }
 
 #==============================================================================
@@ -554,15 +619,17 @@ export_uri() {
 
   case "${protocol}" in
     reality)
+      [[ "${REALITY_ENABLED:-false}" == "true" && -n "${REALITY_PORT:-}" ]] || _export_die "SBX-EXPORT-039" "Reality not configured" \
+        "Enable Reality during install or export another protocol."
       echo "vless://${UUID}@${DOMAIN}:${REALITY_PORT}?encryption=none&security=reality&flow=${REALITY_FLOW_VISION}&sni=${SNI}&pbk=${PUBLIC_KEY}&sid=${SHORT_ID}&type=tcp&fp=${REALITY_FINGERPRINT_DEFAULT}#Reality-${DOMAIN}"
       ;;
     ws)
-      [[ -n "${WS_PORT}" ]] || _export_die "SBX-EXPORT-040" "WS-TLS not configured" \
+      [[ "${WS_ENABLED:-false}" == "true" && -n "${WS_PORT:-}" ]] || _export_die "SBX-EXPORT-040" "WS-TLS not configured" \
         "Enable WS during install or export Reality only."
       echo "vless://${UUID}@${ws_host}:${ws_port}?encryption=none&security=tls&type=ws&host=${ws_host}&path=/ws&sni=${ws_host}&fp=${REALITY_FINGERPRINT_DEFAULT}#WS-TLS-${ws_host}"
       ;;
     hysteria2 | hy2)
-      [[ -n "${HY2_PORT}" ]] || _export_die "SBX-EXPORT-042" "Hysteria2 not configured" \
+      [[ "${HY2_ENABLED:-false}" == "true" && -n "${HY2_PORT:-}" && -n "${HY2_PASS:-}" ]] || _export_die "SBX-EXPORT-042" "Hysteria2 not configured" \
         "Enable Hysteria2 during install or export Reality only."
       local hy2_uri="hysteria2://${HY2_PASS}@${DOMAIN}:${HY2_PORT}/?sni=${DOMAIN}&alpn=h3&insecure=0"
       [[ -n "${HY2_PORT_RANGE:-}" ]] && hy2_uri+="&mport=${HY2_PORT_RANGE}"
@@ -580,11 +647,21 @@ export_uri() {
       echo "trojan://${TROJAN_PASS}@${DOMAIN}:${TROJAN_PORT}?sni=${DOMAIN}&security=tls&type=tcp&fp=${REALITY_FINGERPRINT_DEFAULT}#Trojan-${DOMAIN}"
       ;;
     all)
-      export_uri reality
-      [[ -n "${WS_PORT}" ]] && export_uri ws
-      [[ -n "${HY2_PORT}" ]] && export_uri hy2
-      [[ "${TUIC_ENABLED:-false}" == "true" ]] && export_uri tuic
-      [[ "${TROJAN_ENABLED:-false}" == "true" ]] && export_uri trojan
+      if [[ "${REALITY_ENABLED:-false}" == "true" ]]; then
+        export_uri reality
+      fi
+      if [[ "${WS_ENABLED:-false}" == "true" ]]; then
+        export_uri ws
+      fi
+      if [[ "${HY2_ENABLED:-false}" == "true" ]]; then
+        export_uri hy2
+      fi
+      if [[ "${TUIC_ENABLED:-false}" == "true" ]]; then
+        export_uri tuic
+      fi
+      if [[ "${TROJAN_ENABLED:-false}" == "true" ]]; then
+        export_uri trojan
+      fi
       ;;
     *)
       _export_die "SBX-EXPORT-043" "Invalid protocol: ${protocol} (use: reality, ws, hy2, tuic, trojan, all)" \
@@ -609,19 +686,20 @@ export_qr_codes() {
 
   mkdir -p "${output_dir}"
 
-  # Reality QR
-  reality_uri=$(export_uri reality)
-  qrencode -t PNG -o "${output_dir}/reality-qr.png" "${reality_uri}"
-  qrencode -t UTF8 -o "${output_dir}/reality-qr.txt" "${reality_uri}"
-  success "  ✓ Reality QR code: ${output_dir}/reality-qr.png"
+  if [[ "${REALITY_ENABLED:-false}" == "true" ]]; then
+    reality_uri=$(export_uri reality)
+    qrencode -t PNG -o "${output_dir}/reality-qr.png" "${reality_uri}"
+    qrencode -t UTF8 -o "${output_dir}/reality-qr.txt" "${reality_uri}"
+    success "  ✓ Reality QR code: ${output_dir}/reality-qr.png"
+  fi
 
-  if [[ -n "${WS_PORT}" ]]; then
-    # WS-TLS QR
+  if [[ "${WS_ENABLED:-false}" == "true" ]]; then
     ws_uri=$(export_uri ws)
     qrencode -t PNG -o "${output_dir}/ws-qr.png" "${ws_uri}"
     success "  ✓ WS-TLS QR code: ${output_dir}/ws-qr.png"
+  fi
 
-    # Hysteria2 QR
+  if [[ "${HY2_ENABLED:-false}" == "true" ]]; then
     hy2_uri=$(export_uri hy2)
     qrencode -t PNG -o "${output_dir}/hy2-qr.png" "${hy2_uri}"
     success "  ✓ Hysteria2 QR code: ${output_dir}/hy2-qr.png"
@@ -649,26 +727,10 @@ export_qr_codes() {
 # Generate subscription link (Base64 encoded URIs)
 export_subscription() {
   local output_file="${1:-/var/www/html/sub.txt}"
-  local subscription='' sub_url=''
+  local subscription='' sub_url='' uris=''
   load_client_info
 
-  local uris=""
-
-  # Reality URI
-  uris+=$(export_uri reality)
-
-  if [[ -n "${WS_PORT}" ]]; then
-    uris+=$'\n'$(export_uri ws)
-    uris+=$'\n'$(export_uri hy2)
-  fi
-
-  if [[ "${TUIC_ENABLED:-false}" == "true" ]]; then
-    uris+=$'\n'$(export_uri tuic)
-  fi
-
-  if [[ "${TROJAN_ENABLED:-false}" == "true" ]]; then
-    uris+=$'\n'$(export_uri trojan)
-  fi
+  uris=$(export_uri all)
 
   # Base64 encode
   subscription=$(echo -n "${uris}" | base64 -w 0)

--- a/lib/stats.sh
+++ b/lib/stats.sh
@@ -88,8 +88,12 @@ _stats_single_reality_user_name() {
 
   jq -r '
     (.protocols.reality.users // null) as $users
-    | if ($users | type) == "array" and ($users | length) == 1 and (($users[0].name // "") != "") then
-        $users[0].name
+    | if ($users | type) == "array" then
+        if ($users | length) == 1 and (($users[0].name // "") != "") then
+          $users[0].name
+        else
+          ""
+        end
       elif (.protocols.reality.uuid // empty) != "" then
         "default"
       else

--- a/lib/stats.sh
+++ b/lib/stats.sh
@@ -74,6 +74,56 @@ _stats_secret() {
   _stats_state_get secret
 }
 
+_stats_single_reality_user_name() {
+  local state_file=''
+  state_file=$(_stats_state_file)
+  [[ -f "${state_file}" ]] || {
+    echo ""
+    return 0
+  }
+  have jq || {
+    echo ""
+    return 0
+  }
+
+  jq -r '
+    (.protocols.reality.users // null) as $users
+    | if ($users | type) == "array" and ($users | length) == 1 and (($users[0].name // "") != "") then
+        $users[0].name
+      elif (.protocols.reality.uuid // empty) != "" then
+        "default"
+      else
+        ""
+      end
+  ' "${state_file}" 2>/dev/null || echo ""
+}
+
+_stats_connections_with_resolved_user_json() {
+  local conns_json="$1"
+  local fallback_reality_user=''
+  fallback_reality_user=$(_stats_single_reality_user_name)
+
+  echo "${conns_json}" | jq --arg fallback_reality_user "${fallback_reality_user}" '
+    def resolved_user:
+      (.metadata.user // "") as $user
+      | if $user != "" then
+          $user
+        elif $fallback_reality_user != "" and (
+          (.metadata.type // "") == "vless/in-reality" or
+          (.metadata.type // "") == "vless/in-ws" or
+          (.metadata.inboundTag // "") == "in-reality" or
+          (.metadata.inboundTag // "") == "in-ws" or
+          (.metadata.inboundName // "") == "in-reality" or
+          (.metadata.inboundName // "") == "in-ws"
+        ) then
+          $fallback_reality_user
+        else
+          "unknown"
+        end;
+    .connections = ((.connections // []) | map(. + {resolved_user: resolved_user}))
+  '
+}
+
 stats_api_base() {
   local bind='' port=''
   bind=$(_stats_bind)
@@ -246,11 +296,12 @@ _stats_human_duration() {
 # in metadata.user for Reality/WS inbounds.
 _stats_group_by_user_json() {
   local conns_json="$1"
+  conns_json=$(_stats_connections_with_resolved_user_json "${conns_json}")
   echo "${conns_json}" | jq '
     (.connections // [])
-    | group_by(.metadata.user // "")
+    | group_by(.resolved_user // "unknown")
     | map({
-        user: (.[0].metadata.user // "unknown"),
+        user: (.[0].resolved_user // "unknown"),
         count: length,
         upload: (map(.upload // 0) | add // 0),
         download: (map(.download // 0) | add // 0)
@@ -364,6 +415,7 @@ stats_connections_pretty() {
   }
   local conns=''
   conns=$(_stats_connections_snapshot)
+  conns=$(_stats_connections_with_resolved_user_json "${conns}")
 
   local count=0
   count=$(echo "${conns}" | jq -r '(.connections // []) | length')
@@ -399,7 +451,7 @@ stats_connections_pretty() {
         ((.metadata.host // .metadata.destinationIP // "") + ":" + (.metadata.destinationPort // "")),
         (.rule // ""),
         (.metadata.inboundName // .metadata.inboundTag // .metadata.type // ""),
-        (.metadata.user // ""),
+        (.resolved_user // .metadata.user // ""),
         (.upload // 0),
         (.download // 0),
         (.start // "")
@@ -418,6 +470,7 @@ stats_connections_json() {
   fi
   local conns=''
   conns=$(_stats_connections_snapshot)
+  conns=$(_stats_connections_with_resolved_user_json "${conns}")
   echo "${conns}" | jq '{
     enabled: true,
     count: ((.connections // []) | length),

--- a/lib/subscription.sh
+++ b/lib/subscription.sh
@@ -235,12 +235,16 @@ _subscription_state_get() {
 # Widens mode from 600 to 640 and sets group to the service user.
 _subscription_grant_state_read() {
   local state_file=''
+  local state_dir=''
   local user="${SUB_SYSTEM_USER_OVERRIDE:-${SUBSCRIPTION_SYSTEM_USER}}"
   state_file=$(_subscription_state_file)
   [[ -f "${state_file}" ]] || return 0
+  state_dir=$(dirname "${state_file}")
   # Only touch permissions when running as root on a real system
   if [[ -z "${SUB_CACHE_DIR_OVERRIDE:-}" ]] && [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
     if id -u "${user}" >/dev/null 2>&1; then
+      chgrp "${user}" "${state_dir}" 2>/dev/null || true
+      chmod 750 "${state_dir}" 2>/dev/null || true
       chgrp "${user}" "${state_file}" 2>/dev/null || true
       chmod 640 "${state_file}" 2>/dev/null || true
     fi

--- a/lib/telegram_bot.sh
+++ b/lib/telegram_bot.sh
@@ -277,10 +277,9 @@ _tg_get_updates() {
       --data-urlencode "offset=${offset}" \
       --data-urlencode "timeout=${SBX_TG_POLL_TIMEOUT}" \
       --config - \
-      2>/dev/null <<EOF
+      2>/dev/null <<EOF; then
 url = "${SBX_TG_API_BASE}/bot${BOT_TOKEN}/getUpdates"
 EOF
-    then
       return 0
     fi
 
@@ -320,18 +319,19 @@ _tg_send_message() {
   while [[ ${attempts} -lt ${max_attempts} ]]; do
     attempts=$((attempts + 1))
     local http_code=""
-    http_code=$("${curl_cmd}" -sS \
-      -o "${body_file}" \
-      -w '%{http_code}' \
-      --max-time 30 \
-      --connect-timeout 10 \
-      --data-urlencode "chat_id=${chat_id}" \
-      --data-urlencode "text=${text}" \
-      --config - \
-      2>/dev/null <<EOF
+    http_code=$(
+      "${curl_cmd}" -sS \
+        -o "${body_file}" \
+        -w '%{http_code}' \
+        --max-time 30 \
+        --connect-timeout 10 \
+        --data-urlencode "chat_id=${chat_id}" \
+        --data-urlencode "text=${text}" \
+        --config - \
+        2>/dev/null <<EOF
 url = "${SBX_TG_API_BASE}/bot${BOT_TOKEN}/sendMessage"
 EOF
-) || http_code="000"
+    ) || http_code="000"
 
     if [[ "${http_code}" == "200" ]]; then
       return 0

--- a/lib/telegram_bot.sh
+++ b/lib/telegram_bot.sh
@@ -276,8 +276,11 @@ _tg_get_updates() {
       -o "${output_file}" \
       --data-urlencode "offset=${offset}" \
       --data-urlencode "timeout=${SBX_TG_POLL_TIMEOUT}" \
-      "${SBX_TG_API_BASE}/bot${BOT_TOKEN}/getUpdates" \
-      2>/dev/null; then
+      --config - \
+      2>/dev/null <<EOF
+url = "${SBX_TG_API_BASE}/bot${BOT_TOKEN}/getUpdates"
+EOF
+    then
       return 0
     fi
 
@@ -324,8 +327,11 @@ _tg_send_message() {
       --connect-timeout 10 \
       --data-urlencode "chat_id=${chat_id}" \
       --data-urlencode "text=${text}" \
-      "${SBX_TG_API_BASE}/bot${BOT_TOKEN}/sendMessage" \
-      2>/dev/null) || http_code="000"
+      --config - \
+      2>/dev/null <<EOF
+url = "${SBX_TG_API_BASE}/bot${BOT_TOKEN}/sendMessage"
+EOF
+) || http_code="000"
 
     if [[ "${http_code}" == "200" ]]; then
       return 0

--- a/tests/unit/test_cloudflare_tunnel.sh
+++ b/tests/unit/test_cloudflare_tunnel.sh
@@ -117,7 +117,7 @@ assert_contains "config.yml disables origin TLS verification" "noTLSVerify: true
 assert_contains "config.yml has 404 catch-all" "service: http_status:404" "${yml_content}"
 
 perm=$(stat -c '%a' "${CLOUDFLARED_CONFIG}" 2>/dev/null || stat -f '%Lp' "${CLOUDFLARED_CONFIG}" 2>/dev/null)
-assert_eq "config.yml is mode 600" "600" "${perm}"
+assert_eq "config.yml is mode 644" "644" "${perm}"
 
 #==============================================================================
 # Upstream port resolution (issue #121)
@@ -217,6 +217,7 @@ assert_contains "unit has [Unit]" "[Unit]" "${unit_content}"
 assert_contains "unit has [Service]" "[Service]" "${unit_content}"
 assert_contains "unit has [Install]" "[Install]" "${unit_content}"
 assert_contains "unit references EnvironmentFile" "EnvironmentFile=-${CLOUDFLARED_ENV_FILE}" "${unit_content}"
+assert_contains "token mode ExecStart pins config path" "--config ${CLOUDFLARED_CONFIG}" "${unit_content}"
 assert_contains "unit ExecStart uses tunnel run --token" 'tunnel run --token ${TUNNEL_TOKEN}' "${unit_content}"
 assert_contains "unit hardened with NoNewPrivileges" "NoNewPrivileges=true" "${unit_content}"
 assert_contains "unit hardened with ProtectSystem" "ProtectSystem=strict" "${unit_content}"

--- a/tests/unit/test_cloudflare_tunnel.sh
+++ b/tests/unit/test_cloudflare_tunnel.sh
@@ -16,6 +16,8 @@ export CLOUDFLARED_SVC="${TEST_TMP_DIR}/cloudflared.service"
 export CLOUDFLARED_CONF_DIR="${TEST_TMP_DIR}/etc-cloudflared"
 export CLOUDFLARED_CONFIG="${CLOUDFLARED_CONF_DIR}/config.yml"
 export CLOUDFLARED_ENV_FILE="${CLOUDFLARED_CONF_DIR}/tunnel.env"
+export SBX_LOCK_FILE="${TEST_TMP_DIR}/sbx.lock"
+export SBX_STATE_LOCK_FILE="${TEST_TMP_DIR}/sbx-state.lock"
 mkdir -p "${CLOUDFLARED_CONF_DIR}"
 
 # Source modules. Each re-enables strict mode and may install its own EXIT trap;
@@ -238,6 +240,11 @@ fi
 echo ""
 echo "Testing cloudflared_update_state..."
 
+assert_eq "test overrides general lock file" \
+  "${TEST_TMP_DIR}/sbx.lock" "${SBX_LOCK_FILE:-}"
+assert_eq "test overrides state lock file" \
+  "${TEST_TMP_DIR}/sbx-state.lock" "${SBX_STATE_LOCK_FILE:-}"
+
 if command -v jq >/dev/null 2>&1; then
   state_file="${TEST_TMP_DIR}/state.json"
   cat >"${state_file}" <<'JSON'
@@ -256,6 +263,11 @@ JSON
   assert_eq "state.tunnel.mode" "token" "${mode}"
   assert_eq "state.tunnel.hostname" "abc.example.com" "${hostname}"
   assert_eq "state.tunnel.upstream_port" "8444" "${upstream}"
+  if [[ -f "${SBX_STATE_LOCK_FILE}" ]]; then
+    test_result "state update uses test state lock file" "pass"
+  else
+    test_result "state update uses test state lock file" "fail"
+  fi
 
   # Disable path: nulls out hostname/mode but keeps file valid JSON
   TEST_STATE_FILE="${state_file}" cloudflared_update_state "false" "" "" 0 >/dev/null 2>&1

--- a/tests/unit/test_cloudflare_tunnel.sh
+++ b/tests/unit/test_cloudflare_tunnel.sh
@@ -112,7 +112,8 @@ cloudflared_write_config_yml "h.example.com" 8444 >/dev/null 2>&1
 yml_content=""
 [[ -f "${CLOUDFLARED_CONFIG}" ]] && yml_content=$(cat "${CLOUDFLARED_CONFIG}")
 assert_contains "config.yml has hostname" "hostname: h.example.com" "${yml_content}"
-assert_contains "config.yml has localhost upstream" "service: http://127.0.0.1:8444" "${yml_content}"
+assert_contains "config.yml has localhost upstream" "service: https://127.0.0.1:8444" "${yml_content}"
+assert_contains "config.yml disables origin TLS verification" "noTLSVerify: true" "${yml_content}"
 assert_contains "config.yml has 404 catch-all" "service: http_status:404" "${yml_content}"
 
 perm=$(stat -c '%a' "${CLOUDFLARED_CONFIG}" 2>/dev/null || stat -f '%Lp' "${CLOUDFLARED_CONFIG}" 2>/dev/null)
@@ -144,7 +145,7 @@ JSON
   yml_state=""
   [[ -f "${CLOUDFLARED_CONFIG}" ]] && yml_state=$(cat "${CLOUDFLARED_CONFIG}")
   assert_contains "config.yml default uses state.json port" \
-    "service: http://127.0.0.1:9443" "${yml_state}"
+    "service: https://127.0.0.1:9443" "${yml_state}"
 
   # Quick-mode unit must also honor state.json.
   TEST_STATE_FILE="${resolve_state_file}" \
@@ -152,7 +153,7 @@ JSON
   unit_state=""
   [[ -f "${CLOUDFLARED_SVC}" ]] && unit_state=$(cat "${CLOUDFLARED_SVC}")
   assert_contains "quick-mode unit uses state.json port" \
-    "tunnel --url http://127.0.0.1:9443" "${unit_state}"
+    "tunnel --url https://127.0.0.1:9443 --no-tls-verify" "${unit_state}"
 
   # Explicit CLI override must still win.
   TEST_STATE_FILE="${resolve_state_file}" \
@@ -160,7 +161,7 @@ JSON
   yml_override=""
   [[ -f "${CLOUDFLARED_CONFIG}" ]] && yml_override=$(cat "${CLOUDFLARED_CONFIG}")
   assert_contains "explicit port overrides state.json" \
-    "service: http://127.0.0.1:7777" "${yml_override}"
+    "service: https://127.0.0.1:7777" "${yml_override}"
 
   # Missing state file falls back to WS_PORT_DEFAULT (compile-time default).
   # WS_PORT_DEFAULT is readonly after bootstrap; read it instead of overriding.
@@ -223,7 +224,8 @@ assert_contains "unit hardened with ProtectSystem" "ProtectSystem=strict" "${uni
 cloudflared_write_service_file "quick" >/dev/null 2>&1
 unit_quick=""
 [[ -f "${CLOUDFLARED_SVC}" ]] && unit_quick=$(cat "${CLOUDFLARED_SVC}")
-assert_contains "quick mode ExecStart uses --url" "tunnel --url http://127.0.0.1:" "${unit_quick}"
+assert_contains "quick mode ExecStart uses https origin" "tunnel --url https://127.0.0.1:" "${unit_quick}"
+assert_contains "quick mode ExecStart disables origin TLS verification" "--no-tls-verify" "${unit_quick}"
 
 # Negative: bogus mode
 out=$(cloudflared_write_service_file "bogus" 2>&1)

--- a/tests/unit/test_config_generation.sh
+++ b/tests/unit/test_config_generation.sh
@@ -261,6 +261,19 @@ test_create_reality_inbound_basic() {
   fi
 }
 
+test_create_reality_inbound_preserves_user_name() {
+  echo ""
+  echo "Testing create_reality_inbound() - User Name Preservation"
+  echo "---------------------------------------------------------"
+
+  local users_json='[{"name":"default","uuid":"123e4567-e89b-12d3-a456-426614174000"}]'
+  local reality_config
+  reality_config=$(create_reality_inbound "${users_json}" "443" "::" \
+    "www.microsoft.com" "EKlZxErkrHGkRKTyR7oiQ4jF-eO8w9BNYQ_MfB8BAnk" "abcdef12" 2>/dev/null)
+
+  assert_json_value_equals "Reality user name is preserved" "$reality_config" ".users[0].name" "default"
+}
+
 test_create_reality_inbound_security() {
   echo ""
   echo "Testing create_reality_inbound() - Security Features"
@@ -624,6 +637,24 @@ test_create_ws_inbound_basic() {
   assert_json_value_equals "TLS enabled" "$ws_config" ".tls.enabled" "true"
   assert_json_has_key "TLS has ACME block" "$ws_config" ".tls.acme"
   assert_json_value_equals "ACME domain correct" "$ws_config" ".tls.acme.domain[0]" "${test_domain}"
+}
+
+test_create_ws_inbound_preserves_user_name() {
+  echo ""
+  echo "Testing create_ws_inbound() - User Name Preservation"
+  echo "----------------------------------------------------"
+
+  local test_domain="ws.example.com"
+  local tls_json
+  tls_json=$(_build_tls_block "${test_domain}" '["h2","http/1.1"]' \
+    "" "" "acme" "" 2>/dev/null)
+
+  local users_json='[{"name":"default","uuid":"123e4567-e89b-12d3-a456-426614174000"}]'
+  local ws_config
+  ws_config=$(create_ws_inbound "${users_json}" "8444" "::" \
+    "${test_domain}" "${tls_json}" 2>/dev/null)
+
+  assert_json_value_equals "WS-TLS user name is preserved" "$ws_config" ".users[0].name" "default"
 }
 
 test_create_ws_inbound_manual_cert() {
@@ -990,6 +1021,7 @@ main() {
   test_create_base_config_dual_stack
   test_create_base_config_log_levels
   test_create_reality_inbound_basic
+  test_create_reality_inbound_preserves_user_name
   test_create_reality_inbound_security
   test_json_structure_compliance
   test_deprecated_fields_not_present
@@ -1003,6 +1035,7 @@ main() {
 
   # Run test suites — WS + Hysteria2 inbounds
   test_create_ws_inbound_basic
+  test_create_ws_inbound_preserves_user_name
   test_create_ws_inbound_manual_cert
   test_create_hysteria2_inbound_basic
   test_create_hysteria2_inbound_dns01

--- a/tests/unit/test_error_codes.sh
+++ b/tests/unit/test_error_codes.sh
@@ -137,6 +137,8 @@ test_backup_restore_uses_structured_code() {
     local output=''
     set +e
     output=$(bash -c '
+      tmp=$(mktemp -d /tmp/sbx-test-error-codes.XXXXXX)
+      export SBX_LOCK_FILE="${tmp}/sbx.lock"
       source "'"${PROJECT_ROOT}"'/lib/backup.sh" >/dev/null 2>&1
       trap - EXIT INT TERM HUP QUIT ERR RETURN
       backup_restore /tmp/sbx-missing-backup.tar.gz

--- a/tests/unit/test_install_state_persistence.sh
+++ b/tests/unit/test_install_state_persistence.sh
@@ -10,9 +10,13 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 source "$SCRIPT_DIR/../test_framework.sh"
 
 TEST_TMP=""
+LOCK_FILE_PATH=""
+STATE_LOCK_FILE_PATH=""
 
 setup_state_persistence_fixture() {
     TEST_TMP=$(mktemp -d /tmp/sbx-install-state.XXXXXX)
+    LOCK_FILE_PATH="${TEST_TMP}/sbx.lock"
+    STATE_LOCK_FILE_PATH="${TEST_TMP}/sbx-state.lock"
 }
 
 teardown_state_persistence_fixture() {
@@ -57,6 +61,8 @@ test_save_state_info_writes_json() {
       source "'"${PROJECT_ROOT}"'/install.sh" >/dev/null 2>&1
       trap - EXIT INT TERM HUP QUIT ERR RETURN
       export TEST_STATE_FILE="'"${TEST_TMP}"'/state.json"
+      export SBX_LOCK_FILE="'"${LOCK_FILE_PATH}"'"
+      export SBX_STATE_LOCK_FILE="'"${STATE_LOCK_FILE_PATH}"'"
       export DOMAIN="example.com"
       export REALITY_ONLY_MODE=0
       export UUID="11111111-2222-3333-4444-555555555555"
@@ -76,6 +82,7 @@ test_save_state_info_writes_json() {
 
     assert_equals "0" "${rc}" "save_state_info command succeeds"
     assert_file_exists "${TEST_TMP}/state.json" "state.json is created"
+    assert_file_exists "${STATE_LOCK_FILE_PATH}" "save_state_info uses test state lock file"
     assert_contains "${output}" "pubkey123" "state.json stores reality public key"
 }
 
@@ -86,6 +93,8 @@ test_save_state_info_acme_marks_ws_hy2_enabled() {
       source "'"${PROJECT_ROOT}"'/install.sh" >/dev/null 2>&1
       trap - EXIT INT TERM HUP QUIT ERR RETURN
       export TEST_STATE_FILE="'"${TEST_TMP}"'/state-acme.json"
+      export SBX_LOCK_FILE="'"${LOCK_FILE_PATH}"'"
+      export SBX_STATE_LOCK_FILE="'"${STATE_LOCK_FILE_PATH}"'"
       export DOMAIN="example.com"
       export REALITY_ONLY_MODE=0
       export ENABLE_WS=1
@@ -107,6 +116,7 @@ test_save_state_info_acme_marks_ws_hy2_enabled() {
 
     assert_equals "0" "${rc}" "save_state_info ACME scenario succeeds"
     assert_file_exists "${TEST_TMP}/state-acme.json" "ACME state.json is created"
+    assert_file_exists "${STATE_LOCK_FILE_PATH}" "ACME save_state_info uses test state lock file"
     assert_contains "${output}" $'true\n8444\ntrue\n8443' "ACME state marks ws/hy2 enabled with ports"
 }
 

--- a/tests/unit/test_install_state_persistence.sh
+++ b/tests/unit/test_install_state_persistence.sh
@@ -120,11 +120,55 @@ test_save_state_info_acme_marks_ws_hy2_enabled() {
     assert_contains "${output}" $'true\n8444\ntrue\n8443' "ACME state marks ws/hy2 enabled with ports"
 }
 
+test_save_state_info_cf_mode_disables_non_ws_protocols() {
+    local output='' rc=0
+    set +e
+    output=$(bash -c '
+      source "'"${PROJECT_ROOT}"'/install.sh" >/dev/null 2>&1
+      trap - EXIT INT TERM HUP QUIT ERR RETURN
+      export TEST_STATE_FILE="'"${TEST_TMP}"'/state-cf-mode.json"
+      export SBX_LOCK_FILE="'"${LOCK_FILE_PATH}"'"
+      export SBX_STATE_LOCK_FILE="'"${STATE_LOCK_FILE_PATH}"'"
+      export DOMAIN="x.950288.xyz"
+      export CF_MODE=1
+      export REALITY_ONLY_MODE=0
+      export ENABLE_REALITY=0
+      export ENABLE_WS=1
+      export ENABLE_HY2=0
+      export ENABLE_TUIC=0
+      export ENABLE_TROJAN=0
+      export UUID="11111111-2222-3333-4444-555555555555"
+      export PUB="pubkey123"
+      export SID="abcd1234"
+      export SNI="www.microsoft.com"
+      export REALITY_PORT_CHOSEN=""
+      export WS_PORT_CHOSEN=443
+      export HY2_PORT_CHOSEN=""
+      export HY2_PASS=""
+      export CERT_FULLCHAIN="/tmp/fake-fullchain.pem"
+      export CERT_KEY="/tmp/fake-key.pem"
+      save_state_info
+      jq -r ".protocols.reality.enabled,
+              (.protocols.reality.port | tostring),
+              .protocols.ws_tls.enabled,
+              .protocols.ws_tls.port,
+              .protocols.hysteria2.enabled,
+              (.protocols.hysteria2.port | tostring)" "${TEST_STATE_FILE}"
+    ' 2>&1)
+    rc=$?
+
+    assert_equals "0" "${rc}" "save_state_info CF_MODE scenario succeeds"
+    assert_file_exists "${TEST_TMP}/state-cf-mode.json" "CF_MODE state.json is created"
+    assert_contains "${output}" $'false\nnull\ntrue\n443\nfalse\nnull' \
+      "CF_MODE state disables reality and hysteria2 while keeping WS enabled"
+}
+
 main() {
     set +e
     run_test_suite "install client info persistence" setup_state_persistence_fixture test_save_client_info_creates_parent_dir teardown_state_persistence_fixture
     run_test_suite "install state persistence" setup_state_persistence_fixture test_save_state_info_writes_json teardown_state_persistence_fixture
     run_test_suite "install state persistence (acme ws/hy2)" setup_state_persistence_fixture test_save_state_info_acme_marks_ws_hy2_enabled teardown_state_persistence_fixture
+    run_test_suite "install state persistence (cf mode ws-only)" setup_state_persistence_fixture test_save_state_info_cf_mode_disables_non_ws_protocols teardown_state_persistence_fixture
     print_test_summary
 }
 

--- a/tests/unit/test_sbx_manager_json.sh
+++ b/tests/unit/test_sbx_manager_json.sh
@@ -31,6 +31,8 @@ HY2_PORT="8443"
 HY2_PASS="hy2pass123"
 TUIC_PORT="8445"
 TUIC_PASS="tuicpass123"
+TROJAN_PORT="8446"
+TROJAN_PASS="trojanpass123"
 CERT_FULLCHAIN="/tmp/fake-fullchain.pem"
 CERT_KEY="/tmp/fake-key.pem"
 EOF
@@ -58,28 +60,49 @@ cat >"${LIB_DIR_STUB}/export.sh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 load_client_info() {
-  unset WS_ENABLED HY2_ENABLED TUIC_ENABLED WS_PORT HY2_PORT HY2_PASS TUIC_PORT TUIC_PASS CERT_FULLCHAIN CERT_KEY
+  unset REALITY_ENABLED WS_ENABLED HY2_ENABLED TUIC_ENABLED TROJAN_ENABLED WS_PORT HY2_PORT HY2_PASS TUIC_PORT TUIC_PASS TROJAN_PORT TROJAN_PASS CERT_FULLCHAIN CERT_KEY
   source "${TEST_CLIENT_INFO:?}"
-  if [[ -n "${WS_PORT+x}" ]]; then
+  if [[ -n "${REALITY_PORT:-}" ]]; then
+    REALITY_ENABLED="true"
+  else
+    REALITY_ENABLED="false"
+  fi
+  if [[ -n "${WS_PORT:-}" ]]; then
     WS_ENABLED="true"
   else
     WS_ENABLED="false"
   fi
-  if [[ -n "${HY2_PORT+x}" || -n "${HY2_PASS+x}" ]]; then
+  if [[ -n "${HY2_PORT:-}" || -n "${HY2_PASS:-}" ]]; then
     HY2_ENABLED="true"
   else
     HY2_ENABLED="false"
   fi
-  if [[ -n "${TUIC_PORT+x}" || -n "${TUIC_PASS+x}" ]]; then
+  if [[ -n "${TUIC_PORT:-}" || -n "${TUIC_PASS:-}" ]]; then
     TUIC_ENABLED="true"
   else
     TUIC_ENABLED="false"
   fi
-  REALITY_PORT="${REALITY_PORT:-443}"
-  SNI="${SNI:-www.microsoft.com}"
-  WS_PORT="${WS_PORT:-8444}"
-  HY2_PORT="${HY2_PORT:-8443}"
-  TUIC_PORT="${TUIC_PORT:-8445}"
+  if [[ -n "${TROJAN_PORT:-}" || -n "${TROJAN_PASS:-}" ]]; then
+    TROJAN_ENABLED="true"
+  else
+    TROJAN_ENABLED="false"
+  fi
+  if [[ "${REALITY_ENABLED}" == "true" ]]; then
+    REALITY_PORT="${REALITY_PORT:-443}"
+    SNI="${SNI:-www.microsoft.com}"
+  fi
+  if [[ "${WS_ENABLED}" == "true" ]]; then
+    WS_PORT="${WS_PORT:-8444}"
+  fi
+  if [[ "${HY2_ENABLED}" == "true" ]]; then
+    HY2_PORT="${HY2_PORT:-8443}"
+  fi
+  if [[ "${TUIC_ENABLED}" == "true" ]]; then
+    TUIC_PORT="${TUIC_PORT:-8445}"
+  fi
+  if [[ "${TROJAN_ENABLED}" == "true" ]]; then
+    TROJAN_PORT="${TROJAN_PORT:-8446}"
+  fi
 }
 export_uri() {
   case "${1:-all}" in
@@ -89,6 +112,10 @@ export_uri() {
     tuic)
       [[ -n "${TUIC_PORT:-}" && -n "${TUIC_PASS:-}" ]] || return 46
       echo "tuic://tuic-uri"
+      ;;
+    trojan)
+      [[ -n "${TROJAN_PORT:-}" && -n "${TROJAN_PASS:-}" ]] || return 47
+      echo "trojan://trojan-uri"
       ;;
     *) echo "vless://all-uri" ;;
   esac
@@ -202,6 +229,10 @@ test_json_output_commands() {
     assert_equals "8445" "$(echo "$info_json" | jq -r '.protocols.tuic.port')" "info --json includes tuic port"
     assert_equals "tuicpass123" "$(echo "$info_json" | jq -r '.protocols.tuic.password')" "info --json includes tuic password"
     assert_equals "tuic://tuic-uri" "$(echo "$info_json" | jq -r '.protocols.tuic.uri')" "info --json includes tuic URI"
+    assert_equals "true" "$(echo "$info_json" | jq -r '.protocols.trojan.enabled')" "info --json marks trojan enabled"
+    assert_equals "8446" "$(echo "$info_json" | jq -r '.protocols.trojan.port')" "info --json includes trojan port"
+    assert_equals "trojanpass123" "$(echo "$info_json" | jq -r '.protocols.trojan.password')" "info --json includes trojan password"
+    assert_equals "trojan://trojan-uri" "$(echo "$info_json" | jq -r '.protocols.trojan.uri')" "info --json includes trojan URI"
 
     # --json status (global flag form)
     status_json=$(run_sbx_json --json status 2>/dev/null)
@@ -250,6 +281,10 @@ EOF
     assert_equals "null" "$(echo "$info_json_acme" | jq -r '.protocols.tuic.port')" "info --json ACME omits tuic port"
     assert_equals "null" "$(echo "$info_json_acme" | jq -r '.protocols.tuic.password')" "info --json ACME omits tuic password"
     assert_equals "null" "$(echo "$info_json_acme" | jq -r '.protocols.tuic.uri')" "info --json ACME omits tuic URI"
+    assert_equals "false" "$(echo "$info_json_acme" | jq -r '.protocols.trojan.enabled')" "info --json ACME marks trojan disabled"
+    assert_equals "null" "$(echo "$info_json_acme" | jq -r '.protocols.trojan.port')" "info --json ACME omits trojan port"
+    assert_equals "null" "$(echo "$info_json_acme" | jq -r '.protocols.trojan.password')" "info --json ACME omits trojan password"
+    assert_equals "null" "$(echo "$info_json_acme" | jq -r '.protocols.trojan.uri')" "info --json ACME omits trojan URI"
 }
 
 main() {

--- a/tests/unit/test_sbx_manager_uninstall.sh
+++ b/tests/unit/test_sbx_manager_uninstall.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# tests/unit/test_sbx_manager_uninstall.sh - Validate sbx-manager uninstall path
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../test_framework.sh"
+
+test_uninstall_does_not_reassign_readonly_bootstrap_paths() {
+  echo "Testing sbx-manager uninstall source does not reassign readonly bootstrap paths..."
+
+  local matches=""
+  matches=$(rg -n '^[[:space:]]+(SB_BIN|SB_CONF_DIR|SB_CONF|SB_SVC|CERT_DIR_BASE)=' \
+    "${PROJECT_ROOT}/bin/sbx-manager.sh" 2>/dev/null || true)
+
+  assert_not_contains "${matches}" "1173:" "uninstall must not reassign SB_BIN"
+  assert_not_contains "${matches}" "1174:" "uninstall must not reassign SB_CONF_DIR"
+  assert_not_contains "${matches}" "1175:" "uninstall must not reassign SB_CONF"
+  assert_not_contains "${matches}" "1176:" "uninstall must not reassign SB_SVC"
+  assert_not_contains "${matches}" "1177:" "uninstall must not reassign CERT_DIR_BASE"
+}
+
+main() {
+  set +e
+  run_test_suite \
+    "sbx-manager uninstall path" \
+    true \
+    test_uninstall_does_not_reassign_readonly_bootstrap_paths \
+    true
+  print_test_summary
+}
+
+main "$@"

--- a/tests/unit/test_sbx_manager_uri.sh
+++ b/tests/unit/test_sbx_manager_uri.sh
@@ -49,6 +49,8 @@ HY2_PORT="8443"
 HY2_PASS="pass123"
 TUIC_PORT="8445"
 TUIC_PASS="tuicpass123"
+TROJAN_PORT="8446"
+TROJAN_PASS="trojanpass123"
 CERT_FULLCHAIN="/tmp/fullchain.pem"
 CERT_KEY="/tmp/key.pem"
 EOF
@@ -73,6 +75,10 @@ export_uri() {
       [[ -n "${TUIC_PORT:-}" && -n "${TUIC_PASS:-}" ]] || return 46
       echo "stub-tuic"
       ;;
+    trojan)
+      [[ -n "${TROJAN_PORT:-}" && -n "${TROJAN_PASS:-}" ]] || return 47
+      echo "stub-trojan"
+      ;;
     *)
       echo "stub-${1:-all}"
       ;;
@@ -80,10 +86,36 @@ export_uri() {
 }
 load_client_info() {
   source "${TEST_CLIENT_INFO:?}"
-  REALITY_PORT="${REALITY_PORT:-443}"
-  SNI="${SNI:-www.microsoft.com}"
-  WS_PORT="${WS_PORT:-8444}"
-  HY2_PORT="${HY2_PORT:-8443}"
+  if [[ -n "${REALITY_PORT:-}" ]]; then
+    REALITY_ENABLED="true"
+    REALITY_PORT="${REALITY_PORT:-443}"
+    SNI="${SNI:-www.microsoft.com}"
+  else
+    REALITY_ENABLED="false"
+  fi
+  if [[ -n "${WS_PORT:-}" ]]; then
+    WS_ENABLED="true"
+    WS_PORT="${WS_PORT:-8444}"
+  else
+    WS_ENABLED="false"
+  fi
+  if [[ -n "${HY2_PORT:-}" || -n "${HY2_PASS:-}" ]]; then
+    HY2_ENABLED="true"
+    HY2_PORT="${HY2_PORT:-8443}"
+  else
+    HY2_ENABLED="false"
+  fi
+  if [[ -n "${TUIC_PORT:-}" || -n "${TUIC_PASS:-}" ]]; then
+    TUIC_ENABLED="true"
+  else
+    TUIC_ENABLED="false"
+  fi
+  if [[ -n "${TROJAN_PORT:-}" || -n "${TROJAN_PASS:-}" ]]; then
+    TROJAN_ENABLED="true"
+    TROJAN_PORT="${TROJAN_PORT:-8446}"
+  else
+    TROJAN_ENABLED="false"
+  fi
 }
 EOF
 }
@@ -127,6 +159,45 @@ EOF
   chmod 600 "$path"
 }
 
+create_state_info() {
+  local path="$1"
+  cat > "$path" << 'EOF'
+{
+  "version": "1.0",
+  "installed_at": "2026-04-01T00:00:00Z",
+  "mode": "multi_protocol",
+  "server": {"domain": "example.com", "ip": null},
+  "protocols": {
+    "reality": {
+      "enabled": true,
+      "port": 443,
+      "uuid": "11111111-2222-3333-4444-555555555555",
+      "public_key": "pubkey123",
+      "short_id": "abcd1234",
+      "sni": "www.microsoft.com"
+    },
+    "ws_tls": {"enabled": true, "port": 8444, "certificate": null, "key": null},
+    "hysteria2": {
+      "enabled": true,
+      "port": 8443,
+      "password": "pass123",
+      "port_range": null
+    },
+    "tuic": {"enabled": false, "port": null, "password": null},
+    "trojan": {"enabled": false, "port": null, "password": null}
+  },
+  "subscription": {
+    "enabled": true,
+    "port": 8838,
+    "bind": "127.0.0.1",
+    "token": "deadbeefdeadbeefdeadbeefdeadbeef",
+    "path": "/sub",
+    "created_at": "2026-04-01T00:00:00Z"
+  }
+}
+EOF
+}
+
 test_stubbed_export_uri_used_in_info_and_qr() {
   echo ""
   echo "Test: sbx-manager uses export_uri hook"
@@ -158,6 +229,12 @@ EOF
     pass "info command prints TUIC URI when configured"
   else
     fail "info command should print TUIC URI" "$info_output"
+  fi
+
+  if echo "$info_output" | grep -q "stub-trojan"; then
+    pass "info command prints Trojan URI when configured"
+  else
+    fail "info command should print Trojan URI" "$info_output"
   fi
 
   LIB_DIR="$stub_lib" TEST_CLIENT_INFO="$client_info" PATH="$TEST_TMP_DIR/bin:$PATH" bash "$PROJECT_ROOT/bin/sbx-manager.sh" qr > /dev/null 2>&1 || true
@@ -305,6 +382,40 @@ test_hy2_uri_mport_param() {
   fi
 }
 
+test_info_accepts_group_readable_state_without_export_module() {
+  echo ""
+  echo "Test: sbx-manager info accepts 640 state.json without export module"
+
+  local state_file="$TEST_TMP_DIR/state-info.json"
+  create_state_info "$state_file"
+  chmod 640 "$state_file"
+
+  local stub_lib="$TEST_TMP_DIR/lib-fallback"
+  mkdir -p "$stub_lib"
+  cat > "${stub_lib}/common.sh" << EOF
+#!/usr/bin/env bash
+set -euo pipefail
+source "${PROJECT_ROOT}/lib/common.sh"
+EOF
+  chmod +x "${stub_lib}/common.sh"
+
+  local output=""
+  output=$(LIB_DIR="$stub_lib" TEST_STATE_FILE="$state_file" bash "$PROJECT_ROOT/bin/sbx-manager.sh" info 2>&1)
+  local rc=$?
+
+  if [[ "$rc" -eq 0 ]]; then
+    pass "info command accepts 640 state.json in fallback path"
+  else
+    fail "info command should accept 640 state.json in fallback path" "$output"
+  fi
+
+  if echo "$output" | grep -q "example.com"; then
+    pass "info command renders state-derived domain with 640 state.json"
+  else
+    fail "info command should render state-derived domain" "$output"
+  fi
+}
+
 echo ""
 echo "=========================================="
 echo "Running test suite: sbx-manager URI paths"
@@ -316,6 +427,7 @@ test_info_skips_tuic_when_not_configured
 test_info_prints_acme_managed_protocols
 test_cli_uri_matches_export_module
 test_hy2_uri_mport_param
+test_info_accepts_group_readable_state_without_export_module
 
 echo ""
 echo "=========================================="

--- a/tests/unit/test_state_json_compat.sh
+++ b/tests/unit/test_state_json_compat.sh
@@ -78,6 +78,53 @@ teardown_state_fixture() {
   [[ -n "${TEST_TMP:-}" && -d "${TEST_TMP}" ]] && rm -rf "${TEST_TMP}"
 }
 
+write_cf_ws_only_state() {
+  cat > "${STATE_FILE}" << 'EOF'
+{
+  "version": "1.0",
+  "installed_at": "2026-04-19T00:00:00Z",
+  "mode": "multi_protocol",
+  "server": {
+    "domain": "x.950288.xyz",
+    "ip": null
+  },
+  "protocols": {
+    "reality": {
+      "enabled": false,
+      "port": null,
+      "uuid": "11111111-2222-3333-4444-555555555555",
+      "public_key": "pubkey123",
+      "short_id": "abcd1234",
+      "sni": "www.microsoft.com"
+    },
+    "ws_tls": {
+      "enabled": true,
+      "port": 443,
+      "certificate": "/tmp/fake-fullchain.pem",
+      "key": "/tmp/fake-key.pem"
+    },
+    "hysteria2": {
+      "enabled": false,
+      "port": null,
+      "password": null,
+      "port_range": null
+    },
+    "tuic": {
+      "enabled": false,
+      "port": null,
+      "password": null
+    },
+    "trojan": {
+      "enabled": false,
+      "port": null,
+      "password": null
+    }
+  }
+}
+EOF
+  chmod 600 "${STATE_FILE}"
+}
+
 test_sbx_manager_reads_state_json() {
   local output=''
   set +e
@@ -118,10 +165,42 @@ test_export_reads_state_json() {
   assert_equals "20000-40000" "${port_range_val}" "state.json port_range field is readable"
 }
 
+test_sbx_manager_skips_disabled_protocols_from_state_json() {
+  local output=''
+  write_cf_ws_only_state
+
+  set +e
+  output=$(LIB_DIR="${LIB_STUB}" TEST_STATE_FILE="${STATE_FILE}" TEST_CLIENT_INFO="${TEST_TMP}/missing-client-info.txt" \
+    bash "${PROJECT_ROOT}/bin/sbx-manager.sh" info 2>&1)
+  local rc=$?
+
+  assert_equals "0" "${rc}" "sbx-manager info works with ws-only CF state"
+  assert_contains "${output}" "INBOUND   : VLESS-WS-TLS   443/tcp" "ws-only CF state still prints WS inbound"
+  assert_not_contains "${output}" "INBOUND   : VLESS-REALITY" "ws-only CF state hides disabled reality inbound"
+  assert_not_contains "${output}" "INBOUND   : Hysteria2" "ws-only CF state hides disabled hysteria2 inbound"
+}
+
+test_export_skips_disabled_protocols_from_state_json() {
+  local uri_list=''
+  write_cf_ws_only_state
+
+  set +e
+  uri_list=$(TEST_STATE_FILE="${STATE_FILE}" TEST_CLIENT_INFO="${TEST_TMP}/missing-client-info.txt" \
+    bash -c "source \"${PROJECT_ROOT}/lib/export.sh\"; export_uri all" 2>&1)
+  local rc=$?
+
+  assert_equals "0" "${rc}" "export_uri all works with ws-only CF state"
+  assert_contains "${uri_list}" "WS-TLS-x.950288.xyz" "ws-only CF state still exports WS URI"
+  assert_not_contains "${uri_list}" "Reality-x.950288.xyz" "ws-only CF state skips disabled reality URI"
+  assert_not_contains "${uri_list}" "Hysteria2-x.950288.xyz" "ws-only CF state skips disabled hysteria2 URI"
+}
+
 main() {
   set +e
   run_test_suite "state.json compatibility" setup_state_fixture test_sbx_manager_reads_state_json teardown_state_fixture
   run_test_suite "state.json export compatibility" setup_state_fixture test_export_reads_state_json teardown_state_fixture
+  run_test_suite "state.json ws-only CF compatibility" setup_state_fixture test_sbx_manager_skips_disabled_protocols_from_state_json teardown_state_fixture
+  run_test_suite "state.json ws-only CF export compatibility" setup_state_fixture test_export_skips_disabled_protocols_from_state_json teardown_state_fixture
   print_test_summary
 }
 

--- a/tests/unit/test_state_json_locking.sh
+++ b/tests/unit/test_state_json_locking.sh
@@ -12,10 +12,14 @@ source "${SCRIPT_DIR}/../test_framework.sh"
 
 TEST_TMP=""
 STATE_FILE_PATH=""
+LOCK_FILE_PATH=""
+STATE_LOCK_FILE_PATH=""
 
 setup_fixture() {
   TEST_TMP=$(mktemp -d /tmp/sbx-state-locking.XXXXXX)
   STATE_FILE_PATH="${TEST_TMP}/state.json"
+  LOCK_FILE_PATH="${TEST_TMP}/sbx.lock"
+  STATE_LOCK_FILE_PATH="${TEST_TMP}/sbx-state.lock"
   cat >"${STATE_FILE_PATH}" <<'EOF'
 {
   "subscription": {
@@ -59,6 +63,8 @@ teardown_fixture() {
 
 test_state_json_apply_updates_fixture() {
   TEST_STATE_FILE="${STATE_FILE_PATH}" \
+  SBX_LOCK_FILE="${LOCK_FILE_PATH}" \
+  SBX_STATE_LOCK_FILE="${STATE_LOCK_FILE_PATH}" \
     bash -c "
       source '${PROJECT_ROOT}/lib/common.sh'
       state_json_apply '${STATE_FILE_PATH}' '.subscription.enabled = true'
@@ -66,6 +72,8 @@ test_state_json_apply_updates_fixture() {
 
   assert_success "jq -e '.subscription.enabled == true' '${STATE_FILE_PATH}' >/dev/null" \
     "state_json_apply updates the target file"
+  assert_success "test -f '${STATE_LOCK_FILE_PATH}'" \
+    "state_json_apply uses the test state lock file"
   local perm=''
   perm=$(stat -c '%a' "${STATE_FILE_PATH}" 2>/dev/null || stat -f '%Lp' "${STATE_FILE_PATH}" 2>/dev/null)
   assert_equals "600" "${perm}" "state_json_apply preserves secure permissions"

--- a/tests/unit/test_stats.sh
+++ b/tests/unit/test_stats.sh
@@ -48,6 +48,7 @@ source "${PROJECT_ROOT}/lib/stats.sh"
 
 _SECRET_FIXTURE="deadbeef0123456789abcdef0123456789abcdef0123456789abcdef0123dead"
 _TMP_STATE=""
+STATS_CONNECTIONS_FIXTURE="default"
 
 _setup_state() {
   local enabled="$1"
@@ -98,7 +99,21 @@ curl() {
       echo '{"inuse":10485760,"oslimit":0}'
       ;;
     */connections)
-      cat <<'EOF'
+      case "${STATS_CONNECTIONS_FIXTURE:-default}" in
+        no_metadata_user_reality)
+          cat <<'EOF'
+{
+  "downloadTotal": 4096,
+  "uploadTotal":    1024,
+  "connections": [
+    {"upload": 100, "download": 200, "start": "2024-01-01T00:00:00Z", "rule": "",
+     "metadata": {"host": "fallback.example", "destinationPort": "443", "type": "vless/in-reality"}}
+  ]
+}
+EOF
+          ;;
+        *)
+          cat <<'EOF'
 {
   "downloadTotal": 1048576,
   "uploadTotal":    524288,
@@ -112,6 +127,8 @@ curl() {
   ]
 }
 EOF
+          ;;
+      esac
       ;;
     *)
       return 22
@@ -197,6 +214,35 @@ test_per_user_grouping() {
   assert_jq "bob grouped count" "${out}" '[.users[] | select(.user=="bob")][0].count' "1"
   assert_jq "sorted by total traffic" "${out}" '.users[0].user' "alice"
 
+  _teardown_state
+}
+
+test_single_user_fallback_from_state() {
+  echo ""
+  echo "Testing single-user fallback when metadata.user is absent"
+  echo "--------------------------------------------------------"
+  _setup_state true
+  STATS_CONNECTIONS_FIXTURE="no_metadata_user_reality"
+
+  local tmp_state=""
+  tmp_state=$(mktemp)
+  jq '.protocols.reality.users = [{name: "default", uuid: "uuid-default"}]' \
+    "${_TMP_STATE}" >"${tmp_state}"
+  mv -f "${tmp_state}" "${_TMP_STATE}"
+
+  local out=""
+  out=$(stats_users_json)
+  assert_jq "fallback users payload valid" "${out}" '.enabled' "true"
+  assert_jq "fallback user count" "${out}" '.users | length' "1"
+  assert_jq "fallback user resolved from state" "${out}" '.users[0].user' "default"
+  assert_jq "fallback upload sum" "${out}" '.users[0].upload' "100"
+  assert_jq "fallback download sum" "${out}" '.users[0].download' "200"
+
+  out=$(stats_connections_json)
+  assert_jq "connections json exposes resolved_user" "${out}" \
+    '.connections[0].resolved_user' "default"
+
+  STATS_CONNECTIONS_FIXTURE="default"
   _teardown_state
 }
 
@@ -325,6 +371,7 @@ main() {
   test_disabled_path
   test_overview_json_structure
   test_per_user_grouping
+  test_single_user_fallback_from_state
   test_bearer_token_sent
   test_secret_never_printed
   test_curl_failure_handled

--- a/tests/unit/test_stats.sh
+++ b/tests/unit/test_stats.sh
@@ -246,6 +246,39 @@ test_single_user_fallback_from_state() {
   _teardown_state
 }
 
+test_multi_user_missing_metadata_stays_unknown() {
+  echo ""
+  echo "Testing multi-user installs do not fall back to default"
+  echo "------------------------------------------------------"
+  _setup_state true
+  STATS_CONNECTIONS_FIXTURE="no_metadata_user_reality"
+
+  local tmp_state=""
+  tmp_state=$(mktemp)
+  jq '.protocols.reality = {
+        uuid: "uuid-default",
+        users: [
+          {name: "default", uuid: "uuid-default"},
+          {name: "alice", uuid: "uuid-alice"}
+        ]
+      }' "${_TMP_STATE}" >"${tmp_state}"
+  mv -f "${tmp_state}" "${_TMP_STATE}"
+
+  local out=""
+  out=$(stats_users_json)
+  assert_jq "multi-user payload valid" "${out}" '.enabled' "true"
+  assert_jq "multi-user fallback keeps unknown bucket" "${out}" '.users[0].user' "unknown"
+  assert_jq "multi-user upload stays on unknown bucket" "${out}" '.users[0].upload' "100"
+  assert_jq "multi-user download stays on unknown bucket" "${out}" '.users[0].download' "200"
+
+  out=$(stats_connections_json)
+  assert_jq "multi-user connections keep resolved_user unknown" "${out}" \
+    '.connections[0].resolved_user' "unknown"
+
+  STATS_CONNECTIONS_FIXTURE="default"
+  _teardown_state
+}
+
 test_bearer_token_sent() {
   echo ""
   echo "Testing Bearer token is attached to requests"
@@ -372,6 +405,7 @@ main() {
   test_overview_json_structure
   test_per_user_grouping
   test_single_user_fallback_from_state
+  test_multi_user_missing_metadata_stays_unknown
   test_bearer_token_sent
   test_secret_never_printed
   test_curl_failure_handled

--- a/tests/unit/test_subscription_state_schema.sh
+++ b/tests/unit/test_subscription_state_schema.sh
@@ -16,6 +16,8 @@ source "${SCRIPT_DIR}/../test_framework.sh"
 
 TEST_TMP=""
 STATE_FILE_PATH=""
+LOCK_FILE_PATH=""
+STATE_LOCK_FILE_PATH=""
 
 # A minimal legacy state.json: no `subscription` key at all.
 _write_legacy_state() {
@@ -82,6 +84,8 @@ EOF
 setup_fixture() {
   TEST_TMP=$(mktemp -d /tmp/sbx-sub-schema.XXXXXX)
   STATE_FILE_PATH="${TEST_TMP}/state.json"
+  LOCK_FILE_PATH="${TEST_TMP}/sbx.lock"
+  STATE_LOCK_FILE_PATH="${TEST_TMP}/sbx-state.lock"
 }
 
 teardown_fixture() {
@@ -137,6 +141,8 @@ test_ensure_block_adds_defaults_when_missing() {
   _write_legacy_state
 
   TEST_STATE_FILE="${STATE_FILE_PATH}" \
+    SBX_LOCK_FILE="${LOCK_FILE_PATH}" \
+    SBX_STATE_LOCK_FILE="${STATE_LOCK_FILE_PATH}" \
     bash -c "
       source '${PROJECT_ROOT}/lib/common.sh'
       source '${PROJECT_ROOT}/lib/subscription.sh'
@@ -145,6 +151,8 @@ test_ensure_block_adds_defaults_when_missing() {
 
   assert_success "jq -e '.subscription | type == \"object\"' '${STATE_FILE_PATH}' >/dev/null" \
     "subscription block is added to legacy state.json"
+  assert_success "test -f '${STATE_LOCK_FILE_PATH}'" \
+    "subscription_ensure_state_block uses test state lock file"
   assert_equals "false" "$(jq -r '.subscription.enabled' "${STATE_FILE_PATH}")" \
     "default enabled=false"
   assert_equals "8838" "$(jq -r '.subscription.port' "${STATE_FILE_PATH}")" \
@@ -163,6 +171,8 @@ test_ensure_block_is_idempotent() {
   before=$(jq -c '.subscription' "${STATE_FILE_PATH}")
 
   TEST_STATE_FILE="${STATE_FILE_PATH}" \
+    SBX_LOCK_FILE="${LOCK_FILE_PATH}" \
+    SBX_STATE_LOCK_FILE="${STATE_LOCK_FILE_PATH}" \
     bash -c "
       source '${PROJECT_ROOT}/lib/common.sh'
       source '${PROJECT_ROOT}/lib/subscription.sh'

--- a/tests/unit/test_subscription_state_schema.sh
+++ b/tests/unit/test_subscription_state_schema.sh
@@ -205,6 +205,29 @@ test_load_client_info_exposes_sub_vars() {
   assert_contains "${out}" "SUB_PATH=/sub" "SUB_PATH populated"
 }
 
+test_load_client_info_accepts_group_readable_state() {
+  _write_state_with_subscription
+  chmod 640 "${STATE_FILE_PATH}"
+
+  local out=''
+  out=$(
+    TEST_STATE_FILE="${STATE_FILE_PATH}" \
+      TEST_CLIENT_INFO="${TEST_TMP}/nope" \
+      bash -c "
+        source '${PROJECT_ROOT}/lib/export.sh'
+        load_client_info >/dev/null
+        printf 'SUB_ENABLED=%s\nSUB_TOKEN=%s\n' \
+          \"\${SUB_ENABLED:-}\" \"\${SUB_TOKEN:-}\"
+      "
+  )
+  local rc=$?
+
+  assert_equals "0" "${rc}" "group-readable state.json remains loadable for subscription"
+  assert_contains "${out}" "SUB_ENABLED=true" "SUB_ENABLED loads from 640 state.json"
+  assert_contains "${out}" "SUB_TOKEN=deadbeefdeadbeefdeadbeefdeadbeef" \
+    "SUB_TOKEN loads from 640 state.json"
+}
+
 main() {
   set +e
   setup_fixture
@@ -212,6 +235,7 @@ main() {
   test_ensure_block_adds_defaults_when_missing
   test_ensure_block_is_idempotent
   test_load_client_info_exposes_sub_vars
+  test_load_client_info_accepts_group_readable_state
   test_load_client_info_batches_state_reads
   teardown_fixture
   print_test_summary

--- a/tests/unit/test_subscription_token.sh
+++ b/tests/unit/test_subscription_token.sh
@@ -135,6 +135,14 @@ test_disable_clears_enabled_and_cache() {
   assert_file_not_exists "${CACHE_DIR}/uri.txt" "cache uri.txt removed"
 }
 
+test_state_read_grant_covers_parent_directory() {
+  local source=''
+  source=$(sed -n '/_subscription_grant_state_read()/,/^}/p' "${PROJECT_ROOT}/lib/subscription.sh")
+
+  assert_contains "${source}" "dirname" "_subscription_grant_state_read derives the state directory"
+  assert_contains "${source}" "chmod 750" "_subscription_grant_state_read grants group traverse on the state directory"
+}
+
 main() {
   set +e
   setup_fixture
@@ -143,6 +151,7 @@ main() {
   test_url_prints_current_token
   test_rotate_changes_token_but_keeps_enabled
   test_disable_clears_enabled_and_cache
+  test_state_read_grant_covers_parent_directory
   teardown_fixture
   print_test_summary
 }

--- a/tests/unit/test_subscription_token.sh
+++ b/tests/unit/test_subscription_token.sh
@@ -14,11 +14,15 @@ source "${SCRIPT_DIR}/../test_framework.sh"
 TEST_TMP=""
 STATE_FILE_PATH=""
 CACHE_DIR=""
+LOCK_FILE_PATH=""
+STATE_LOCK_FILE_PATH=""
 
 setup_fixture() {
   TEST_TMP=$(mktemp -d /tmp/sbx-sub-token.XXXXXX)
   STATE_FILE_PATH="${TEST_TMP}/state.json"
   CACHE_DIR="${TEST_TMP}/cache"
+  LOCK_FILE_PATH="${TEST_TMP}/sbx.lock"
+  STATE_LOCK_FILE_PATH="${TEST_TMP}/sbx-state.lock"
   mkdir -p "${CACHE_DIR}"
 
   cat >"${STATE_FILE_PATH}" <<'EOF'
@@ -64,6 +68,8 @@ teardown_fixture() {
 _run_subscription() {
   local cmd="$1"
   TEST_STATE_FILE="${STATE_FILE_PATH}" \
+    SBX_LOCK_FILE="${LOCK_FILE_PATH}" \
+    SBX_STATE_LOCK_FILE="${STATE_LOCK_FILE_PATH}" \
     TEST_CLIENT_INFO="${TEST_TMP}/nope" \
     SUB_UNIT_DRY_RUN=1 \
     SUB_CACHE_DIR_OVERRIDE="${CACHE_DIR}" \
@@ -82,6 +88,7 @@ test_enable_generates_token_and_sets_enabled() {
   local token=''
   token=$(jq -r '.subscription.token' "${STATE_FILE_PATH}")
   assert_matches "${token}" '^[a-f0-9]{32}$' "token is 32 hex chars"
+  assert_file_exists "${STATE_LOCK_FILE_PATH}" "subscription_enable uses test state lock file"
   assert_contains "${output}" "http://127.0.0.1:8838/sub/${token}" "url is printed with token"
 }
 

--- a/tests/unit/test_telegram_bot.sh
+++ b/tests/unit/test_telegram_bot.sh
@@ -293,6 +293,7 @@ echo "Testing _tg_get_updates..."
 # Counters live in files so subshells don't lose them.
 GU_CALLS_FILE="${TEST_TMP_DIR}/gu_calls"
 GU_SLEEPS_FILE="${TEST_TMP_DIR}/gu_sleeps"
+GU_ARGV_FILE="${TEST_TMP_DIR}/gu_argv"
 
 # Stub curl: writes a fixture body and succeeds. Detects the -o argument
 # anywhere in argv (the lib uses curl -o <file>).
@@ -309,6 +310,11 @@ mock_curl_get_success() {
   echo '{"ok":true,"result":[]}' >"${out_file}"
   echo "ok" >>"${GU_CALLS_FILE}"
   return 0
+}
+
+mock_curl_get_success_record_argv() {
+  printf '%s\n' "$*" >"${GU_ARGV_FILE}"
+  mock_curl_get_success "$@"
 }
 
 # Stub curl: always fails (simulates network error / 5xx).
@@ -357,6 +363,20 @@ assert_eq "no sleep on success" "0" "${sleeps}"
 [[ -s "${TEST_TMP_DIR}/gu.out" ]] && test_result "output file populated" "pass" ||
   test_result "output file populated" "fail"
 
+# Case 3b: token must not appear in curl argv.
+: >"${GU_CALLS_FILE}"
+: >"${GU_SLEEPS_FILE}"
+: >"${GU_ARGV_FILE}"
+SBX_TG_CURL_CMD=mock_curl_get_success_record_argv \
+  _tg_get_updates 42 "${TEST_TMP_DIR}/gu.out"
+assert_zero "get_updates argv capture returns 0" "$?"
+if grep -qF "${BOT_TOKEN}" "${GU_ARGV_FILE}"; then
+  test_result "get_updates keeps token out of curl argv" "fail"
+  echo "      argv: $(cat "${GU_ARGV_FILE}")"
+else
+  test_result "get_updates keeps token out of curl argv" "pass"
+fi
+
 # Case 4: persistent failure with attempt cap → rc=1, exact attempt count,
 # backoff sequence is 1, 2, 4 (no sleep after the final failed attempt).
 : >"${GU_CALLS_FILE}"
@@ -387,6 +407,7 @@ echo "Testing _tg_send_message..."
 
 SM_CALLS_FILE="${TEST_TMP_DIR}/sm_calls"
 SM_SLEEPS_FILE="${TEST_TMP_DIR}/sm_sleeps"
+SM_ARGV_FILE="${TEST_TMP_DIR}/sm_argv"
 
 # Stub curl for send: writes body to -o file, prints HTTP code via -w.
 mock_curl_send_200() {
@@ -402,6 +423,11 @@ mock_curl_send_200() {
   echo '{"ok":true,"result":{"message_id":1}}' >"${out_file}"
   echo "200" >>"${SM_CALLS_FILE}"
   printf '200'
+}
+
+mock_curl_send_200_record_argv() {
+  printf '%s\n' "$*" >"${SM_ARGV_FILE}"
+  mock_curl_send_200 "$@"
 }
 
 mock_curl_send_500() {
@@ -481,6 +507,19 @@ calls=$(wc -l <"${SM_CALLS_FILE}" | tr -d ' ')
 sleeps=$(wc -l <"${SM_SLEEPS_FILE}" | tr -d ' ')
 assert_eq "send: exactly one curl call on 200" "1" "${calls}"
 assert_eq "send: no sleep on 200" "0" "${sleeps}"
+
+# Case 3b: token must not appear in curl argv.
+: >"${SM_CALLS_FILE}"
+: >"${SM_SLEEPS_FILE}"
+: >"${SM_ARGV_FILE}"
+SBX_TG_CURL_CMD=mock_curl_send_200_record_argv _tg_send_message 12345 "hello world"
+assert_zero "send argv capture returns 0" "$?"
+if grep -qF "${BOT_TOKEN}" "${SM_ARGV_FILE}"; then
+  test_result "send_message keeps token out of curl argv" "fail"
+  echo "      argv: $(cat "${SM_ARGV_FILE}")"
+else
+  test_result "send_message keeps token out of curl argv" "pass"
+fi
 
 # Case 4: 500 → fail immediately, no retry.
 : >"${SM_CALLS_FILE}"

--- a/tests/unit/test_telegram_bot.sh
+++ b/tests/unit/test_telegram_bot.sh
@@ -21,6 +21,8 @@ export SBX_TG_ENV_FILE="${TEST_TMP_DIR}/telegram.env"
 export SBX_TG_SVC="${TEST_TMP_DIR}/sbx-telegram-bot.service"
 export SBX_TG_BIN="${TEST_TMP_DIR}/sbx-telegram-bot"
 export TEST_STATE_FILE="${TEST_TMP_DIR}/state.json"
+export SBX_LOCK_FILE="${TEST_TMP_DIR}/sbx.lock"
+export SBX_STATE_LOCK_FILE="${TEST_TMP_DIR}/sbx-state.lock"
 
 source "${PROJECT_ROOT}/lib/common.sh" 2>/dev/null || {
   echo "ERROR: Failed to load lib/common.sh"

--- a/tests/unit/test_user_management.sh
+++ b/tests/unit/test_user_management.sh
@@ -5,6 +5,9 @@
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+LOCK_TMP_DIR="$(mktemp -d /tmp/sbx-user-mgmt-locks.XXXXXX)"
+export SBX_LOCK_FILE="${LOCK_TMP_DIR}/sbx.lock"
+export SBX_STATE_LOCK_FILE="${LOCK_TMP_DIR}/sbx-state.lock"
 
 # Disable strict mode so individual test failures don't abort the suite
 set +e
@@ -24,6 +27,7 @@ source "${PROJECT_ROOT}/lib/users.sh" 2>/dev/null || {
 
 # Disable traps after loading modules
 trap - EXIT INT TERM
+trap 'rm -rf "${LOCK_TMP_DIR}"' EXIT
 set +e
 
 # Test counters


### PR DESCRIPTION
## Summary
- fix issue #135 test isolation and state/lock handling regressions
- harden `sbx-manager`/export/state compatibility for WS-only CF mode and Trojan visibility
- fix stats user resolution fallback, Telegram token argv leakage, and Cloudflare tunnel HTTPS-origin handling
- extend unit coverage for uninstall, CF mode, stats, Telegram, manager JSON/text output, and tunnel config

## Verification
- local: `bash tests/unit/test_cloudflare_tunnel.sh`
- local: `bash tests/unit/test_sbx_manager_json.sh`
- local: `bash tests/unit/test_sbx_manager_uri.sh`
- local: `bash tests/unit/test_stats.sh`
- local: `bash tests/unit/test_telegram_bot.sh`
- VM: `bash tests/test-runner.sh unit`
- VM: multi-protocol real install on `x.950288.xyz` with Reality/WS-TLS/Hysteria2/TUIC/Trojan all connected successfully
- VM: `subscription` real fetch verified for base64, Clash, and URI modes
- VM: `stats` real traffic verified for multi-protocol and CF-mode WS-only installs
- VM: `telegram` real setup/enable/send verified and `status` no longer exposed the bot token
- VM: CF_MODE ws-only real install/export/connectivity/subscription verified with manual certs

Closes #135.